### PR TITLE
fix push being slow

### DIFF
--- a/pkg/kf/push.go
+++ b/pkg/kf/push.go
@@ -175,7 +175,7 @@ func (p *pusher) buildSpec(
 		return "", err
 	}
 
-	if _, err := p.buildClient.Status(buildName); err != nil {
+	if _, err := p.buildClient.Status(buildName, builds.WithStatusNamespace(namespace)); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
This fixes slow pushes, the issue was that pushes would wait until the watcher timed out before. Now we check the `Ready` field of the service and note any condition there. This has the benefit of reducing duplicated messages at the end of the log.

I found an additional bug in push where the namespace wasn't passed along with the client so even if the build succeeded it could seem like it didn't.

Fixes #227 

Logs now look like this:

```
[deploy-revision] Starting app: test
[deploy-revision] Updated state to: Configuration "test" is waiting for a Revision to become ready.
[deploy-revision] Updated state to: Configuration "test" is waiting for a Revision to become ready.
[deploy-revision] Updated state to: Configuration "test" is waiting for a Revision to become ready.
[deploy-revision] Started in 7.44 seconds
```