### PR TITLE
go: use latest github.com/poy/kontext

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
-	github.com/poy/kontext v0.0.0-20190322194304-59ced15e96b1
+	github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e
 	github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c
 	github.com/segmentio/textio v1.2.0
 	github.com/sirupsen/logrus v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -253,6 +253,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmorie/go-open-service-broker-client v0.0.0-20181213160916-6988c0983446/go.mod h1:6d5FSWVMC68G2RoLKixGVhkoNlgoEC/phmruM0yHdjQ=
 github.com/poy/kontext v0.0.0-20190322194304-59ced15e96b1 h1:Dx1hnQtcUttU5Kovao73XH5OvJxpEPCSoB9BJVqlvqM=
 github.com/poy/kontext v0.0.0-20190322194304-59ced15e96b1/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
+github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e h1:HZPqpLefwCMwGfEwjvY0ZcS8biQDaMBzsunN6TqgL+0=
+github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
 github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c h1:5tVj7ImrbnEHf8FNnasPiDBDuSaFRVq8r2ilMLfukzA=
 github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c/go.mod h1:D3X0fYjTImKyVV+A+FaU7e5xIDbU2VOdejI7m5KL0CA=
 github.com/prometheus/client_golang v0.0.0-20170531130054-e7e903064f5e/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -34,11 +34,11 @@ type SrcImageBuilder interface {
 }
 
 // SrcImageBuilderFunc converts a func into a SrcImageBuilder.
-type SrcImageBuilderFunc func(dir, srcImage string) error
+type SrcImageBuilderFunc func(dir, srcImage string, rebase bool) error
 
 // BuildSrcImage implements SrcImageBuilder.
 func (f SrcImageBuilderFunc) BuildSrcImage(dir, srcImage string) error {
-	return f(dir, srcImage)
+	return f(dir, srcImage, false)
 }
 
 // NewPushCommand creates a push command.

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -61,7 +61,7 @@ func TestPushCommand(t *testing.T) {
 			envVars:           []string{"env1=val1", "env2=val2"},
 			wantEnvMap:        map[string]string{"env1": "val1", "env2": "val2"},
 			wantImagePrefix:   "some-reg.io/src-some-namespace-app-name",
-			srcImageBuilder: func(dir, srcImage string) error {
+			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
 				testutil.AssertEqual(t, "path", true, strings.Contains(dir, "some-path"))
 				testutil.AssertEqual(t, "path is abs", true, filepath.IsAbs(dir))
 				return nil
@@ -71,7 +71,7 @@ func TestPushCommand(t *testing.T) {
 			args:              []string{"app-name"},
 			containerRegistry: "some-reg.io",
 			path:              "",
-			srcImageBuilder: func(dir, srcImage string) error {
+			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
 				cwd, err := os.Getwd()
 				testutil.AssertNil(t, "cwd err", err)
 				testutil.AssertEqual(t, "path", cwd, dir)
@@ -109,7 +109,7 @@ func TestPushCommand(t *testing.T) {
 			args:              []string{"app-name"},
 			containerRegistry: "some-reg.io",
 			wantErr:           errors.New("some error"),
-			srcImageBuilder: func(dir, srcImage string) error {
+			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
 				return errors.New("some error")
 			},
 		},
@@ -128,7 +128,7 @@ func TestPushCommand(t *testing.T) {
 			}
 
 			if tc.srcImageBuilder == nil {
-				tc.srcImageBuilder = func(dir, srcImage string) error { return nil }
+				tc.srcImageBuilder = func(dir, srcImage string, rebase bool) error { return nil }
 			}
 
 			ctrl := gomock.NewController(t)


### PR DESCRIPTION
This change updates to a version of Kontext that preserves file
permissions when creating an image. It also updates method signatures
where necessary to accomodate the ability to rebase introduced in this
version of Kontext. Where that is done, rebasing is disabled to preserve
existing behavior.