### PR TITLE
gomod: remove duplicates poy/kontext

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmorie/go-open-service-broker-client v0.0.0-20181213160916-6988c0983446/go.mod h1:6d5FSWVMC68G2RoLKixGVhkoNlgoEC/phmruM0yHdjQ=
 github.com/poy/knative-pkg v99.0.0+incompatible h1:onvjBYN3yXNLGESi51Sajk70NBU7i5LISPor5ANJ59M=
 github.com/poy/knative-pkg v99.0.0+incompatible/go.mod h1:+LGy4PaS4RL2Ii5I2Ow8OGR9dMhJZ9+LCKUdwtDgyUU=
-github.com/poy/kontext v0.0.0-20190322194304-59ced15e96b1 h1:Dx1hnQtcUttU5Kovao73XH5OvJxpEPCSoB9BJVqlvqM=
-github.com/poy/kontext v0.0.0-20190322194304-59ced15e96b1/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
 github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e h1:HZPqpLefwCMwGfEwjvY0ZcS8biQDaMBzsunN6TqgL+0=
 github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
 github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c h1:5tVj7ImrbnEHf8FNnasPiDBDuSaFRVq8r2ilMLfukzA=


### PR DESCRIPTION
A duplicate poy/kontext was introduced to go.sum recently. This change
removes that, leaving a single reference that points to the desired
version of the dependency.