### PR TITLE
added app validation webhook and basic validation

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -103,6 +103,7 @@ func main() {
 		Options: options,
 		Handlers: map[schema.GroupVersionKind]webhook.GenericCRD{
 			v1alpha1.SchemeGroupVersion.WithKind("Space"): &v1alpha1.Space{},
+			v1alpha1.SchemeGroupVersion.WithKind("App"):   &v1alpha1.App{},
 		},
 		Logger:                logger,
 		DisallowUnknownFields: true,

--- a/pkg/apis/kf/v1alpha1/app_types_test.go
+++ b/pkg/apis/kf/v1alpha1/app_types_test.go
@@ -131,6 +131,15 @@ func TestAppSpecInstances_ScalingAnnotations(t *testing.T) {
 			instances: AppSpecInstances{},
 			expected:  map[string]string{},
 		},
+		"exactly takes precidence": {
+			// If the webhook fails somehow and exactly gets defined alongside min and
+			// max, then exactly takes precedence.
+			instances: AppSpecInstances{Exactly: intPtr(4), Min: intPtr(3), Max: intPtr(5)},
+			expected: map[string]string{
+				autoscaling.MinScaleAnnotationKey: "4",
+				autoscaling.MaxScaleAnnotationKey: "4",
+			},
+		},
 	}
 
 	for tn, tc := range cases {

--- a/pkg/apis/kf/v1alpha1/app_types_test.go
+++ b/pkg/apis/kf/v1alpha1/app_types_test.go
@@ -1,0 +1,143 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/google/kf/pkg/kf/testutil"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+)
+
+func intPtr(val int) *int {
+	return &val
+}
+
+func TestAppSpecInstances_MinAnnotationValue(t *testing.T) {
+	cases := map[string]struct {
+		instances AppSpecInstances
+		expected  string
+	}{
+		"stopped": {
+			instances: AppSpecInstances{Stopped: true},
+			expected:  "0",
+		},
+		"min defined": {
+			instances: AppSpecInstances{Min: intPtr(3)},
+			expected:  "3",
+		},
+		"exactly defined": {
+			instances: AppSpecInstances{Exactly: intPtr(33)},
+			expected:  "33",
+		},
+		"empty": {
+			instances: AppSpecInstances{},
+			expected:  "",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.instances.MinAnnotationValue()
+
+			testutil.AssertEqual(t, "annotation", tc.expected, actual)
+		})
+	}
+}
+
+func TestAppSpecInstances_MaxAnnotationValue(t *testing.T) {
+	cases := map[string]struct {
+		instances AppSpecInstances
+		expected  string
+	}{
+		"stopped": {
+			instances: AppSpecInstances{Stopped: true},
+			expected:  "0",
+		},
+		"max defined": {
+			instances: AppSpecInstances{Max: intPtr(3)},
+			expected:  "3",
+		},
+		"exactly defined": {
+			instances: AppSpecInstances{Exactly: intPtr(33)},
+			expected:  "33",
+		},
+		"empty": {
+			instances: AppSpecInstances{},
+			expected:  "",
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.instances.MaxAnnotationValue()
+
+			testutil.AssertEqual(t, "annotation", tc.expected, actual)
+		})
+	}
+}
+
+func TestAppSpecInstances_ScalingAnnotations(t *testing.T) {
+	cases := map[string]struct {
+		instances AppSpecInstances
+		expected  map[string]string
+	}{
+		"stopped": {
+			instances: AppSpecInstances{Stopped: true, Exactly: intPtr(10)},
+			expected: map[string]string{
+				autoscaling.MinScaleAnnotationKey: "0",
+				autoscaling.MaxScaleAnnotationKey: "0",
+			},
+		},
+		"max defined": {
+			instances: AppSpecInstances{Max: intPtr(30)},
+			expected: map[string]string{
+				autoscaling.MaxScaleAnnotationKey: "30",
+			},
+		},
+		"min defined": {
+			instances: AppSpecInstances{Min: intPtr(3)},
+			expected: map[string]string{
+				autoscaling.MinScaleAnnotationKey: "3",
+			},
+		},
+		"range defined": {
+			instances: AppSpecInstances{Min: intPtr(3), Max: intPtr(5)},
+			expected: map[string]string{
+				autoscaling.MinScaleAnnotationKey: "3",
+				autoscaling.MaxScaleAnnotationKey: "5",
+			},
+		},
+		"exactly defined": {
+			instances: AppSpecInstances{Exactly: intPtr(4)},
+			expected: map[string]string{
+				autoscaling.MinScaleAnnotationKey: "4",
+				autoscaling.MaxScaleAnnotationKey: "4",
+			},
+		},
+		"empty": {
+			instances: AppSpecInstances{},
+			expected:  map[string]string{},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.instances.ScalingAnnotations()
+
+			testutil.AssertEqual(t, "annotations", tc.expected, actual)
+		})
+	}
+}

--- a/pkg/apis/kf/v1alpha1/app_validation.go
+++ b/pkg/apis/kf/v1alpha1/app_validation.go
@@ -1,0 +1,104 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+
+	"github.com/knative/serving/pkg/apis/serving"
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+)
+
+// Validate checks for errors in the App's spec or status fields.
+func (app *App) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// If we're specifically updating status, don't reject the change because
+	// of a spec issue.
+	if !apis.IsInStatusUpdate(ctx) {
+		errs = errs.Also(app.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+	}
+
+	return errs
+}
+
+// Validate checks that the pod template the user has submitted is valid
+// and that the scaling and lifecycle is valid.
+func (spec *AppSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
+
+	errs = errs.Also(ValidatePodSpec(spec.Template.Spec).ViaField("template.spec"))
+	errs = errs.Also(spec.Instances.Validate(ctx).ViaField("instances"))
+
+	return errs
+}
+
+// Validate checks that the fields the user has specified in AppSpecInstances
+// can be used together.
+func (instances *AppSpecInstances) Validate(ctx context.Context) (errs *apis.FieldError) {
+	hasExactly := instances.Exactly != nil
+	hasMin := instances.Min != nil
+	hasMax := instances.Max != nil
+
+	if hasExactly && hasMin {
+		errs = errs.Also(apis.ErrMultipleOneOf("exactly", "min"))
+	}
+
+	if hasExactly && hasMax {
+		errs = errs.Also(apis.ErrMultipleOneOf("exactly", "max"))
+	}
+
+	if hasExactly && *instances.Exactly < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*instances.Exactly, "exactly"))
+	}
+
+	if hasMin && *instances.Min < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*instances.Min, "min"))
+	}
+
+	if hasMax && *instances.Max < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*instances.Max, "max"))
+	}
+
+	if hasMin && hasMax && *instances.Min > *instances.Max {
+		errs = errs.Also(&apis.FieldError{Message: "max must be >= min", Paths: []string{"min", "max"}})
+	}
+
+	return errs
+}
+
+// ValidatePodSpec proxies Knative Serving's checks on PodSpec, except for
+// one condition. We don't allow setting the container image directly on the
+// PodSpec because it'll be set by the source instead.
+func ValidatePodSpec(podSpec v1.PodSpec) (errs *apis.FieldError) {
+	// copy because we need to edit the PodSpec
+	ps := podSpec.DeepCopy()
+
+	switch len(ps.Containers) {
+	case 0:
+		errs = errs.Also(apis.ErrMissingField("containers"))
+	case 1:
+		if ps.Containers[0].Image != "" {
+			errs = errs.Also(apis.ErrDisallowedFields("image"))
+		}
+
+		// Use a valid dummy image so we can re-use the validation from Knative
+		// serving.
+		ps.Containers[0].Image = "gcr.io/dummy/image:latest"
+		errs = errs.Also(serving.ValidatePodSpec(*ps))
+	default:
+		errs = errs.Also(apis.ErrMultipleOneOf("containers"))
+	}
+
+	return errs
+}

--- a/pkg/apis/kf/v1alpha1/app_validation_test.go
+++ b/pkg/apis/kf/v1alpha1/app_validation_test.go
@@ -1,0 +1,189 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/kf/pkg/kf/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+func TestApp_Validate(t *testing.T) {
+	goodInstances := AppSpecInstances{Stopped: true}
+	goodTemplate := AppSpecTemplate{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{}},
+		},
+	}
+
+	cases := map[string]struct {
+		spec App
+		want *apis.FieldError
+	}{
+		"valid": {
+			spec: App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid",
+				},
+				Spec: AppSpec{
+					Template:  goodTemplate,
+					Instances: goodInstances,
+				},
+			},
+		},
+		"invalid instances": {
+			spec: App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid",
+				},
+				Spec: AppSpec{
+					Template:  goodTemplate,
+					Instances: AppSpecInstances{Exactly: intPtr(-1)},
+				},
+			},
+			want: apis.ErrInvalidValue(-1, "spec.instances.exactly"),
+		},
+		"invalid template": {
+			spec: App{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "valid",
+				},
+				Spec: AppSpec{
+					Template:  AppSpecTemplate{},
+					Instances: goodInstances,
+				},
+			},
+			want: apis.ErrMissingField("spec.template.spec.containers"),
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			got := tc.spec.Validate(context.Background())
+
+			testutil.AssertEqual(t, "validation errors", tc.want.Error(), got.Error())
+		})
+	}
+
+}
+
+func TestAppSpecInstances_Validate(t *testing.T) {
+	// These test cases are broken out separately because they're
+	// too extenstive to copy the whole service struct for.
+
+	cases := map[string]struct {
+		spec AppSpecInstances
+		want *apis.FieldError
+	}{
+		"blank": {
+			spec: AppSpecInstances{},
+		},
+		"stopped": {
+			spec: AppSpecInstances{Stopped: true},
+		},
+		"valid minmax": {
+			spec: AppSpecInstances{Min: intPtr(3), Max: intPtr(5)},
+		},
+		"valid exactly": {
+			spec: AppSpecInstances{Exactly: intPtr(3)},
+		},
+		"exactly and min": {
+			spec: AppSpecInstances{Exactly: intPtr(3), Min: intPtr(3)},
+			want: apis.ErrMultipleOneOf("exactly", "min"),
+		},
+		"exactly and max": {
+			spec: AppSpecInstances{Exactly: intPtr(3), Max: intPtr(3)},
+			want: apis.ErrMultipleOneOf("exactly", "max"),
+		},
+		"exactly lt 0": {
+			spec: AppSpecInstances{Exactly: intPtr(-1)},
+			want: apis.ErrInvalidValue(-1, "exactly"),
+		},
+		"min lt 0": {
+			spec: AppSpecInstances{Min: intPtr(-1)},
+			want: apis.ErrInvalidValue(-1, "min"),
+		},
+		"max lt 0": {
+			spec: AppSpecInstances{Max: intPtr(-1)},
+			want: apis.ErrInvalidValue(-1, "max"),
+		},
+		"max lt min": {
+			spec: AppSpecInstances{Max: intPtr(1), Min: intPtr(50)},
+			want: &apis.FieldError{Message: "max must be >= min", Paths: []string{"min", "max"}},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			got := tc.spec.Validate(context.Background())
+
+			testutil.AssertEqual(t, "validation errors", tc.want.Error(), got.Error())
+		})
+	}
+}
+
+func TestValidatePodSpec(t *testing.T) {
+	cases := map[string]struct {
+		spec corev1.PodSpec
+		want *apis.FieldError
+	}{
+		"missing container": {
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{},
+			},
+			want: apis.ErrMissingField("containers"),
+		},
+		"too many containers": {
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{{}, {}},
+			},
+			want: apis.ErrMultipleOneOf("containers"),
+		},
+		"container has image": {
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Image: "some-image"}},
+			},
+			want: apis.ErrDisallowedFields("image"),
+		},
+		"upstream failure": {
+			// NOTE: this test is intended to show that a Knative Serving error will
+			// be passed thorugh, it doesn't matter which upstream error. In the
+			// future Knative Serving may decide to allow InitContainers in which case
+			// this test will need to choose some other invalid field.
+			spec: corev1.PodSpec{
+				Containers:     []corev1.Container{{}},
+				InitContainers: []corev1.Container{{Image: "some-image"}},
+			},
+			want: apis.ErrDisallowedFields("initContainers"),
+		},
+		"missing image is okay": {
+			spec: corev1.PodSpec{
+				Containers: []corev1.Container{{}},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			got := ValidatePodSpec(tc.spec)
+
+			testutil.AssertEqual(t, "validation errors", tc.want.Error(), got.Error())
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the ability to generate scaling annotations based on an app's `instances` field. The field also gets validation via webhook along with validation for the PodSpec.