### PR TITLE
added additional printer columns to routes

### DIFF
--- a/config/300-route.yaml
+++ b/config/300-route.yaml
@@ -30,6 +30,18 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
+  - name: Host
+    type: string
+    JSONPath: .spec.hostname
+  - name: Domain
+    type: string
+    JSONPath: .spec.domain
+  - name: Path
+    type: string
+    JSONPath: .spec.path
+  - name: Apps
+    type: string
+    JSONPath: .spec.knativeServiceNames
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp


### PR DESCRIPTION
changes this:

```
$ kubectl get routes
NAME                   AGE
12061478071379941285   14h

```

to this:

```
$ kubectl get routes
NAME                   HOST   DOMAIN          PATH   APPS     AGE
12061478071379941285   test   kf.beesdb.com          [test]   15h

```