### PR TITLE
Making registry settings more generic.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,8 @@ store your Docker registry details in an environment variable. This
 install guide uses Google Container Registry (GCR) on GKE.
 
 ```
-export KF_REGISTRY=gcr.io/<PROJECT_ID>
+export KF_REGISTRY=<your-container-registry>
+e.g: export KF_REGISTRY=gcr.io/<PROJECT_ID>
 ```
 
 ## Install dependencies

--- a/hack/upload-buildpacks-stack.sh
+++ b/hack/upload-buildpacks-stack.sh
@@ -21,11 +21,11 @@ publish=${PUBLISH:-false}
 
 rootpath=$(cd $(dirname $0)/.. && pwd)
 dir=${rootpath}/samples/buildpacks/stacks/bionic
-gcr=gcr.io/$(gcloud config get-value project)
+KF_REGISTRY=$1
 
-base_image=${gcr}/base:${version}
-run_image=${gcr}/run:${version}
-build_image=${gcr}/build:${version}
+base_image=${KF_REGISTRY}/base:${version}
+run_image=${KF_REGISTRY}/run:${version}
+build_image=${KF_REGISTRY}/build:${version}
 docker build -t "${base_image}" "$dir/base"
 docker build --build-arg "base_image=${base_image}" -t "${build_image}"  "$dir/build"
 docker build --build-arg "base_image=${base_image}" -t "${run_image}" "$dir/run"

--- a/hack/upload-buildpacks.sh
+++ b/hack/upload-buildpacks.sh
@@ -21,7 +21,7 @@ scriptpath=$(cd $(dirname $0)/.. && pwd)
 # Set the container registry
 # If KF_REGISTRY is populated then use that otherwise try setting it to gcr
 function setregistry {
- if [ -z ${KF_REGISTRY} ]; then
+ if [ -z ${KF_REGISTRY:-} ]; then
     proj_id=$(gcloud config get-value project)
     if [ -z $proj_id ]; then
        echo "could not set container registry..."


### PR DESCRIPTION
Currently `gcr` is hardcoded as the container registry for buildpack uploads. This change intends to make it more generic. If user supplies their own container registry in `$KF_REGISTRY` then use that otherwise try defaulting to `gcr`(to preserve existing behaviour).