### PR TITLE
added commands to manipulate space env vars

### DIFF
--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -1,0 +1,193 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spaces
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/internal/envutil"
+	"github.com/google/kf/pkg/kf/spaces"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/kmp"
+)
+
+// NewConfigSpaceCommand creates a command that can set facets of a space.
+func NewConfigSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "configure-space [subcommand]",
+		Aliases: []string{"config-space"},
+		Short:   "Set configuration for a space",
+		Args:    cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	subcommands := []spaceMutator{
+		newSetEnvMutator(),
+		newUnsetEnvMutator(),
+		newSetBuildpackEnvMutator(),
+		newUnsetBuildpackEnvMutator(),
+		newSetContainerRegistryMutator(),
+	}
+
+	for _, sm := range subcommands {
+		cmd.AddCommand(sm.ToCommand(client))
+	}
+
+	return cmd
+}
+
+type spaceMutator struct {
+	Name  string
+	Short string
+	Args  []string
+	Init  func(args []string) (spaces.Mutator, error)
+}
+
+func (sm spaceMutator) ToCommand(client spaces.Client) *cobra.Command {
+	return &cobra.Command{
+		Use:   fmt.Sprintf("%s SPACE_NAME %s", sm.Name, strings.Join(sm.Args, " ")),
+		Short: sm.Short,
+		Long:  sm.Short,
+		Args:  cobra.ExactArgs(1 + len(sm.Args)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			spaceName := args[0]
+
+			mutator, err := sm.Init(args[1:])
+			if err != nil {
+				return err
+			}
+
+			cmd.SilenceUsage = true
+
+			return client.Transform(spaceName, func(space *v1alpha1.Space) error {
+				before := space.DeepCopy()
+
+				if err := mutator(space); err != nil {
+					return err
+				}
+
+				printDiff(cmd.OutOrStdout(), before, space)
+
+				return nil
+			})
+		},
+	}
+}
+
+func printDiff(w io.Writer, original, new *v1alpha1.Space) {
+	diff, _ := kmp.SafeDiff(original.Spec, new.Spec)
+	if diff != "" {
+		fmt.Fprintln(w, "Space Spec (-original +new):")
+		fmt.Fprintln(w, diff)
+	} else {
+		fmt.Fprintln(w, "No changes")
+	}
+}
+
+func newSetContainerRegistryMutator() spaceMutator {
+	return spaceMutator{
+		Name:  "set-container-registry",
+		Short: "Set the container registry used for builds.",
+		Args:  []string{"REGISTRY"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			registry := args[0]
+
+			return func(space *v1alpha1.Space) error {
+				space.Spec.BuildpackBuild.ContainerRegistry = registry
+
+				return nil
+			}, nil
+		},
+	}
+}
+
+func newSetEnvMutator() spaceMutator {
+	return spaceMutator{
+		Name:  "set-env",
+		Short: "Set a space-wide environment variable.",
+		Args:  []string{"ENV_VAR_NAME", "ENV_VAR_VALUE"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			name := args[0]
+			value := args[1]
+
+			return func(space *v1alpha1.Space) error {
+				tmp := envutil.RemoveEnvVars([]string{name}, space.Spec.Execution.Env)
+				space.Spec.Execution.Env = append(tmp, corev1.EnvVar{Name: name, Value: value})
+
+				return nil
+			}, nil
+		},
+	}
+}
+
+func newUnsetEnvMutator() spaceMutator {
+	return spaceMutator{
+		Name:  "unset-env",
+		Short: "Unset a space-wide environment variable.",
+		Args:  []string{"ENV_VAR_NAME"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			name := args[0]
+
+			return func(space *v1alpha1.Space) error {
+				space.Spec.Execution.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.Execution.Env)
+
+				return nil
+			}, nil
+		},
+	}
+}
+
+func newSetBuildpackEnvMutator() spaceMutator {
+	return spaceMutator{
+		Name:  "set-buildpack-env",
+		Short: "Set an environment variable for buildpack builds in a space.",
+		Args:  []string{"ENV_VAR_NAME", "ENV_VAR_VALUE"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			name := args[0]
+			value := args[1]
+
+			return func(space *v1alpha1.Space) error {
+				tmp := envutil.RemoveEnvVars([]string{name}, space.Spec.BuildpackBuild.Env)
+				space.Spec.BuildpackBuild.Env = append(tmp, corev1.EnvVar{Name: name, Value: value})
+
+				return nil
+			}, nil
+		},
+	}
+}
+
+func newUnsetBuildpackEnvMutator() spaceMutator {
+	return spaceMutator{
+		Name:  "unset-buildpack-env",
+		Short: "Unset an environment variable for buildpack builds in a space.",
+		Args:  []string{"ENV_VAR_NAME"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			name := args[0]
+
+			return func(space *v1alpha1.Space) error {
+				space.Spec.BuildpackBuild.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.BuildpackBuild.Env)
+
+				return nil
+			}, nil
+		},
+	}
+}

--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -94,7 +94,12 @@ func (sm spaceMutator) ToCommand(client spaces.Client) *cobra.Command {
 }
 
 func printDiff(w io.Writer, original, new *v1alpha1.Space) {
-	diff, _ := kmp.SafeDiff(original.Spec, new.Spec)
+	diff, err := kmp.SafeDiff(original.Spec, new.Spec)
+	if err != nil {
+		fmt.Fprintf(w, "Couldn't format diff: %s\n", err.Error())
+		return
+	}
+
 	if diff != "" {
 		fmt.Fprintln(w, "Space Spec (-original +new):")
 		fmt.Fprintln(w, diff)

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -1,0 +1,192 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spaces
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/internal/envutil"
+	"github.com/google/kf/pkg/kf/spaces"
+	"github.com/google/kf/pkg/kf/spaces/fake"
+	"github.com/google/kf/pkg/kf/testutil"
+)
+
+func TestNewConfigSpaceCommand(t *testing.T) {
+	space := "my-space"
+
+	cases := map[string]struct {
+		args     []string
+		space    v1alpha1.Space
+		wantErr  error
+		validate func(*testing.T, *v1alpha1.Space)
+	}{
+		"base wrong number of args": {
+			args:    []string{"test"},
+			wantErr: errors.New("accepts 0 arg(s), received 1"),
+		},
+		"set-container-registry valid": {
+			args: []string{"set-container-registry", space, "gcr.io/foo"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "container registry", "gcr.io/foo", space.Spec.BuildpackBuild.ContainerRegistry)
+			},
+		},
+		"set-env valid": {
+			space: v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					Execution: v1alpha1.SpaceSpecExecution{
+						Env: envutil.MapToEnvVars(map[string]string{
+							"EXISTS": "FOO",
+							"BAR":    "BAZZ",
+						}),
+					},
+				},
+			},
+			args: []string{"set-env", space, "EXISTS", "REPLACED"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "execution env", map[string]string{
+					"EXISTS": "REPLACED",
+					"BAR":    "BAZZ",
+				}, envutil.EnvVarsToMap(space.Spec.Execution.Env))
+			},
+		},
+
+		"unset-env valid": {
+			space: v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					Execution: v1alpha1.SpaceSpecExecution{
+						Env: envutil.MapToEnvVars(map[string]string{
+							"EXISTS": "FOO",
+							"BAR":    "BAZZ",
+						}),
+					},
+				},
+			},
+			args: []string{"unset-env", space, "EXISTS"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "execution env", map[string]string{
+					"BAR": "BAZZ",
+				}, envutil.EnvVarsToMap(space.Spec.Execution.Env))
+			},
+		},
+
+		"set-buildpack-env valid": {
+			space: v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
+						Env: envutil.MapToEnvVars(map[string]string{
+							"EXISTS": "FOO",
+							"BAR":    "BAZZ",
+						}),
+					},
+				},
+			},
+			args: []string{"set-buildpack-env", space, "EXISTS", "REPLACED"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "buildpack env", map[string]string{
+					"EXISTS": "REPLACED",
+					"BAR":    "BAZZ",
+				}, envutil.EnvVarsToMap(space.Spec.BuildpackBuild.Env))
+			},
+		},
+
+		"unset-buildpack-env valid": {
+			space: v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
+						Env: envutil.MapToEnvVars(map[string]string{
+							"EXISTS": "FOO",
+							"BAR":    "BAZZ",
+						}),
+					},
+				},
+			},
+			args: []string{"unset-buildpack-env", space, "EXISTS"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "buildpack env", map[string]string{
+					"BAR": "BAZZ",
+				}, envutil.EnvVarsToMap(space.Spec.BuildpackBuild.Env))
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fakeSpaces := fake.NewFakeClient(ctrl)
+
+			output := tc.space.DeepCopy()
+			fakeSpaces.EXPECT().Transform(space, gomock.Any()).DoAndReturn(func(spaceName string, transformer spaces.Mutator) error {
+				return transformer(output)
+			})
+
+			buffer := &bytes.Buffer{}
+
+			c := NewConfigSpaceCommand(&config.KfParams{}, fakeSpaces)
+			c.SetOutput(buffer)
+			c.SetArgs(tc.args)
+
+			gotErr := c.Execute()
+			if tc.wantErr != nil || gotErr != nil {
+				testutil.AssertErrorsEqual(t, tc.wantErr, gotErr)
+				return
+			}
+
+			if tc.validate != nil {
+				tc.validate(t, output)
+			}
+
+			ctrl.Finish()
+		})
+	}
+}
+
+// func newUnsetEnvMutator() spaceMutator {
+// 	return spaceMutator{
+// 		Name:  "unset-env",
+// 		Short: "Unset a space-wide environment variable.",
+// 		Args:  []string{"ENV_VAR_NAME"},
+// 		Init: func(args []string) (spaces.Mutator, error) {
+// 			name := args[0]
+//
+// 			return func(space *v1alpha1.Space) error {
+// 				space.Spec.Execution.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.Execution.Env)
+//
+// 				return nil
+// 			}, nil
+// 		},
+// 	}
+// }
+//
+// func newUnsetBuildpackEnvMutator() spaceMutator {
+// 	return spaceMutator{
+// 		Name:  "unset-buildpack-env",
+// 		Short: "Unset an environment variable for buildpack builds in a space.",
+// 		Args:  []string{"ENV_VAR_NAME"},
+// 		Init: func(args []string) (spaces.Mutator, error) {
+// 			name := args[0]
+//
+// 			return func(space *v1alpha1.Space) error {
+// 				space.Spec.BuildpackBuild.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.BuildpackBuild.Env)
+//
+// 				return nil
+// 			}, nil
+// 		},
+// 	}
+// }

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -41,12 +41,14 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 			args:    []string{"test"},
 			wantErr: errors.New("accepts 0 arg(s), received 1"),
 		},
+
 		"set-container-registry valid": {
 			args: []string{"set-container-registry", space, "gcr.io/foo"},
 			validate: func(t *testing.T, space *v1alpha1.Space) {
 				testutil.AssertEqual(t, "container registry", "gcr.io/foo", space.Spec.BuildpackBuild.ContainerRegistry)
 			},
 		},
+
 		"set-env valid": {
 			space: v1alpha1.Space{
 				Spec: v1alpha1.SpaceSpec{
@@ -156,37 +158,3 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 		})
 	}
 }
-
-// func newUnsetEnvMutator() spaceMutator {
-// 	return spaceMutator{
-// 		Name:  "unset-env",
-// 		Short: "Unset a space-wide environment variable.",
-// 		Args:  []string{"ENV_VAR_NAME"},
-// 		Init: func(args []string) (spaces.Mutator, error) {
-// 			name := args[0]
-//
-// 			return func(space *v1alpha1.Space) error {
-// 				space.Spec.Execution.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.Execution.Env)
-//
-// 				return nil
-// 			}, nil
-// 		},
-// 	}
-// }
-//
-// func newUnsetBuildpackEnvMutator() spaceMutator {
-// 	return spaceMutator{
-// 		Name:  "unset-buildpack-env",
-// 		Short: "Unset an environment variable for buildpack builds in a space.",
-// 		Args:  []string{"ENV_VAR_NAME"},
-// 		Init: func(args []string) (spaces.Mutator, error) {
-// 			name := args[0]
-//
-// 			return func(space *v1alpha1.Space) error {
-// 				space.Spec.BuildpackBuild.Env = envutil.RemoveEnvVars([]string{name}, space.Spec.BuildpackBuild.Env)
-//
-// 				return nil
-// 			}, nil
-// 		},
-// 	}
-// }

--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -240,6 +240,14 @@ func InjectDeleteSpace(p *config.KfParams) *cobra.Command {
 	return command
 }
 
+func InjectConfigSpace(p *config.KfParams) *cobra.Command {
+	kfV1alpha1Interface := config.GetKfClient(p)
+	spacesGetter := provideKfSpaces(kfV1alpha1Interface)
+	client := spaces.NewClient(spacesGetter)
+	command := spaces2.NewConfigSpaceCommand(p, client)
+	return command
+}
+
 func InjectQuotas(p *config.KfParams) *cobra.Command {
 	kubernetesInterface := config.GetKubernetes(p)
 	resourceQuotasGetter := provideQuotaGetter(kubernetesInterface)

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -304,6 +304,12 @@ func InjectDeleteSpace(p *config.KfParams) *cobra.Command {
 	return nil
 }
 
+func InjectConfigSpace(p *config.KfParams) *cobra.Command {
+	wire.Build(cspaces.NewConfigSpaceCommand, SpacesSet)
+
+	return nil
+}
+
 ////////////////////
 // Quotas Command //
 ////////////////////


### PR DESCRIPTION
This command is intended to house all space configuration commands under a single root command `kf configure-space`.

CF's operator experience varies wildly when configuring the cluster or spaces seeming disjoint and it's unclear at any one point in time what can be configured on a space or the complete state. For example:

* enable-space-ssh - sets a specific feature flag
* disallow-space-ssh - sets a specific feature flag
* space-ssh-enabled - checks a specific feature flag
* running-environment-variable-group - gets list as a human friendly table
* staging-environment-variable-group - gets list as a human friendly table
* set-staging-environment-variable-group - set as a JSON object
* set-running-environment-variable-group - set as a JSON object
* feature-flags - gets a list of feature flags
* feature-flag - get the value for one feature flag
* enable-feature-flag - enable one feature flag
* disable-feature-flag - disable one feature flag

Instead, with all of these sub-commands in one place we can produce a consistent experience. All config commands are discoverable via `kf configure-space --help`, use `kf space myspace` to get the current state, all commands show you the diff, and they are scripting friendly (call unset-env rather than curl an HTTP endpoint, `jq` the results, and read it back when calling a command).

Once this is in, and a change is made to space to support multiple stacks we'll be able to configure them this way too.