### PR TITLE
fix proxy command

### DIFF
--- a/pkg/kf/commands/apps/proxy.go
+++ b/pkg/kf/commands/apps/proxy.go
@@ -84,7 +84,7 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 				return nil
 			}
 
-			return http.Serve(listener, createProxy(cmd.OutOrStdout(), app.Status.Address.Hostname, gateway))
+			return http.Serve(listener, createProxy(cmd.OutOrStdout(), app.Status.URL.Host, gateway))
 		},
 	}
 


### PR DESCRIPTION
The Hostname field is no longer being populated in the latest version on knative