### PR TITLE
space defaulting and validation

### DIFF
--- a/pkg/apis/kf/v1alpha1/space_defaults.go
+++ b/pkg/apis/kf/v1alpha1/space_defaults.go
@@ -14,7 +14,14 @@
 
 package v1alpha1
 
-import "context"
+import (
+	"context"
+)
+
+const (
+	// DefaultBuilderImage contains the default buildpack builder image.
+	DefaultBuilderImage = "gcr.io/kf-releases/buildpack-builder:latest"
+)
 
 // SetDefaults implements apis.Defaultable
 func (k *Space) SetDefaults(ctx context.Context) {
@@ -23,5 +30,30 @@ func (k *Space) SetDefaults(ctx context.Context) {
 
 // SetDefaults implements apis.Defaultable
 func (k *SpaceSpec) SetDefaults(ctx context.Context) {
+	k.Security.SetDefaults(ctx)
+	k.BuildpackBuild.SetDefaults(ctx)
+	k.Execution.SetDefaults(ctx)
+	k.ResourceLimits.SetDefaults(ctx)
+}
+
+// SetDefaults implements apis.Defaultable
+func (k *SpaceSpecSecurity) SetDefaults(ctx context.Context) {
+	// XXX: currently no defaults to set
+}
+
+// SetDefaults implements apis.Defaultable
+func (k *SpaceSpecBuildpackBuild) SetDefaults(ctx context.Context) {
+	if k.BuilderImage == "" {
+		k.BuilderImage = DefaultBuilderImage
+	}
+}
+
+// SetDefaults implements apis.Defaultable
+func (k *SpaceSpecExecution) SetDefaults(ctx context.Context) {
+	// XXX: currently no defaults to set
+}
+
+// SetDefaults implements apis.Defaultable
+func (k *SpaceSpecResourceLimits) SetDefaults(ctx context.Context) {
 	// XXX: currently no defaults to set
 }

--- a/pkg/apis/kf/v1alpha1/space_defaults_test.go
+++ b/pkg/apis/kf/v1alpha1/space_defaults_test.go
@@ -1,0 +1,29 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+)
+
+func ExampleSpace_SetDefaults() {
+	space := Space{}
+	space.SetDefaults(context.Background())
+
+	fmt.Println("Builder:", space.Spec.BuildpackBuild.BuilderImage)
+
+	// Output: Builder: gcr.io/kf-releases/buildpack-builder:latest
+}

--- a/pkg/apis/kf/v1alpha1/space_types.go
+++ b/pkg/apis/kf/v1alpha1/space_types.go
@@ -73,12 +73,10 @@ type SpaceSpecBuildpackBuild struct {
 	// NOTE: The false value for each field should be the default and safe.
 
 	// BuilderImage is a buildpacks.io builder image.
-	// +optional
 	BuilderImage string `json:"builderImage,omitempty"`
 
 	// ContainerRegistry holds the container registry that buildpack builds are
 	// stored in.
-	// +optional
 	ContainerRegistry string `json:"containerRegistry,omitempty"`
 
 	// Env sets default environment variables on the builder.

--- a/pkg/apis/kf/v1alpha1/space_validation.go
+++ b/pkg/apis/kf/v1alpha1/space_validation.go
@@ -22,6 +22,13 @@ import (
 
 // Validate makes sure that Space is properly configured.
 func (space *Space) Validate(ctx context.Context) (errs *apis.FieldError) {
+
+	// If we're specifically updating status, don't reject the change because
+	// of a spec issue.
+	if apis.IsInStatusUpdate(ctx) {
+		return
+	}
+
 	// validate name
 	switch {
 	case space.Name == "":
@@ -30,5 +37,48 @@ func (space *Space) Validate(ctx context.Context) (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(space.Name, "name"))
 	}
 
+	errs = errs.Also(space.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+
+	return errs
+}
+
+// Validate makes sure that SpaceSpec is properly configured.
+func (s *SpaceSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
+	errs = errs.Also(s.Security.Validate(ctx).ViaField("security"))
+	errs = errs.Also(s.BuildpackBuild.Validate(ctx).ViaField("buildpackBuild"))
+	errs = errs.Also(s.Execution.Validate(ctx).ViaField("execution"))
+	errs = errs.Also(s.ResourceLimits.Validate(ctx).ViaField("resourceLimits"))
+
+	return errs
+}
+
+// Validate makes sure that SpaceSpecSecurity is properly configured.
+func (s *SpaceSpecSecurity) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// XXX: no validation
+	return errs
+}
+
+// Validate makes sure that SpaceSpecBuildpackBuild is properly configured.
+func (s *SpaceSpecBuildpackBuild) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if s.BuilderImage == "" {
+		errs = errs.Also(apis.ErrMissingField("builderImage"))
+	}
+
+	if s.ContainerRegistry == "" {
+		errs = errs.Also(apis.ErrMissingField("containerRegistry"))
+	}
+
+	return errs
+}
+
+// Validate makes sure that SpaceSpecExecution is properly configured.
+func (s *SpaceSpecExecution) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// XXX: no validation
+	return errs
+}
+
+// Validate makes sure that SpaceSpecResourceLimits is properly configured.
+func (s *SpaceSpecResourceLimits) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// XXX: no validation
 	return errs
 }

--- a/pkg/apis/kf/v1alpha1/space_validation_test.go
+++ b/pkg/apis/kf/v1alpha1/space_validation_test.go
@@ -24,7 +24,14 @@ import (
 )
 
 func TestSpaceValidation(t *testing.T) {
-	goodSpaceSpec := SpaceSpec{}
+	goodBuildpackBuild := SpaceSpecBuildpackBuild{
+		BuilderImage:      DefaultBuilderImage,
+		ContainerRegistry: "gcr.io/test",
+	}
+
+	goodSpaceSpec := SpaceSpec{
+		BuildpackBuild: goodBuildpackBuild,
+	}
 
 	cases := map[string]struct {
 		space *Space
@@ -57,6 +64,28 @@ func TestSpaceValidation(t *testing.T) {
 			},
 			want: apis.ErrInvalidValue("default", "name"),
 		},
+		"no container registry": {
+			space: &Space{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid"},
+				Spec: SpaceSpec{
+					BuildpackBuild: SpaceSpecBuildpackBuild{
+						BuilderImage: DefaultBuilderImage,
+					},
+				},
+			},
+			want: apis.ErrMissingField("spec.buildpackBuild.containerRegistry"),
+		},
+		"no builder image": {
+			space: &Space{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid"},
+				Spec: SpaceSpec{
+					BuildpackBuild: SpaceSpecBuildpackBuild{
+						ContainerRegistry: "gcr.io/test",
+					},
+				},
+			},
+			want: apis.ErrMissingField("spec.buildpackBuild.builderImage"),
+		},
 	}
 
 	for tn, tc := range cases {
@@ -65,6 +94,5 @@ func TestSpaceValidation(t *testing.T) {
 
 			testutil.AssertEqual(t, "validation errors", tc.want.Error(), got.Error())
 		})
-
 	}
 }

--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -34,7 +34,6 @@ func NewConfigSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 		Use:     "configure-space [subcommand]",
 		Aliases: []string{"config-space"},
 		Short:   "Set configuration for a space",
-		Args:    cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
 		},

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -16,7 +16,6 @@ package spaces
 
 import (
 	"bytes"
-	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -37,11 +36,6 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 		wantErr  error
 		validate func(*testing.T, *v1alpha1.Space)
 	}{
-		"base wrong number of args": {
-			args:    []string{"test"},
-			wantErr: errors.New("accepts 0 arg(s), received 1"),
-		},
-
 		"set-container-registry valid": {
 			args: []string{"set-container-registry", space, "gcr.io/foo"},
 			validate: func(t *testing.T, space *v1alpha1.Space) {

--- a/pkg/kf/commands/spaces/create.go
+++ b/pkg/kf/commands/spaces/create.go
@@ -15,6 +15,8 @@
 package spaces
 
 import (
+	"fmt"
+
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/spaces"
 
@@ -23,6 +25,10 @@ import (
 
 // NewCreateSpaceCommand allows users to create spaces.
 func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
+	var (
+		containerRegistry string
+	)
+
 	cmd := &cobra.Command{
 		Use:   "create-space SPACE",
 		Short: "Create a space",
@@ -34,14 +40,27 @@ func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 
 			toCreate := spaces.NewKfSpace()
 			toCreate.SetName(name)
+			toCreate.SetContainerRegistry(containerRegistry)
 
 			if _, err := client.Create(toCreate.ToSpace()); err != nil {
 				return err
 			}
 
+			w := cmd.OutOrStdout()
+			fmt.Fprintln(w, "Space created")
+			fmt.Fprintln(w)
+
+			printAdditionalCommands(cmd.OutOrStdout(), name)
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVar(
+		&containerRegistry,
+		"container-registry",
+		"",
+		"The container registry apps and sources will be stored in.",
+	)
 
 	return cmd
 }

--- a/pkg/kf/commands/spaces/get.go
+++ b/pkg/kf/commands/spaces/get.go
@@ -80,6 +80,9 @@ func NewGetSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Command
 			fmt.Fprintf(w, "Environment: %v variable(s)\n", len(execution.Env))
 			printEnvGroup(w, execution.Env)
 
+			fmt.Fprintln(w)
+			printAdditionalCommands(w, space.Name)
+
 			return nil
 		},
 	}
@@ -105,4 +108,10 @@ func printEnvGroup(out io.Writer, envVars []corev1.EnvVar) {
 		fmt.Fprintf(w, "%s\t%s", env.Name, env.Value)
 		fmt.Fprintln(w)
 	}
+}
+
+func printAdditionalCommands(w io.Writer, spaceName string) {
+	fmt.Fprintf(w, "Use 'kf space %s' to get the current state of the space.\n", spaceName)
+	fmt.Fprintf(w, "Use 'kf target -s %s' to set the default space kf works with.\n", spaceName)
+	fmt.Fprintln(w, "Use 'kf configure-space' to manage the space.")
 }

--- a/pkg/kf/spaces/kfspace.go
+++ b/pkg/kf/spaces/kfspace.go
@@ -32,6 +32,16 @@ func (k *KfSpace) SetName(name string) {
 	k.Name = name
 }
 
+// GetContainerRegistry gets the container registry for the space.
+func (k *KfSpace) GetContainerRegistry() string {
+	return k.Spec.BuildpackBuild.ContainerRegistry
+}
+
+// SetContainerRegistry sets the container registry for the space.
+func (k *KfSpace) SetContainerRegistry(registry string) {
+	k.Spec.BuildpackBuild.ContainerRegistry = registry
+}
+
 // ToSpace casts this alias back into a Namespace.
 func (k *KfSpace) ToSpace() *v1alpha1.Space {
 	return (*v1alpha1.Space)(k)

--- a/pkg/kf/spaces/kfspace_test.go
+++ b/pkg/kf/spaces/kfspace_test.go
@@ -26,11 +26,14 @@ func ExampleKfSpace() {
 	space := NewKfSpace()
 	// Setup
 	space.SetName("nsname")
+	space.SetContainerRegistry("gcr.io/my-registry")
 
 	// Values
-	fmt.Println(space.GetName())
+	fmt.Println("Name:", space.GetName())
+	fmt.Println("Registry:", space.GetContainerRegistry())
 
-	// Output: nsname
+	// Output: Name: nsname
+	// Registry: gcr.io/my-registry
 }
 
 func TestKfSpace_ToSpace(t *testing.T) {


### PR DESCRIPTION
Adds defaulting and validation to spaces. They now require a container registry and buildpack builder. If no builder is supplied then the default one is chosen.

Additional info about what you can do with a space once it's created is now printed out.