### PR TITLE
cmd/webhook: adds validation for v1alpha1.Route

### DIFF
--- a/pkg/apis/kf/v1alpha1/route_validation.go
+++ b/pkg/apis/kf/v1alpha1/route_validation.go
@@ -29,6 +29,12 @@ const (
 
 // Validate makes sure that Route is properly configured.
 func (r *Route) Validate(ctx context.Context) (errs *apis.FieldError) {
+	// If we're specifically updating status, don't reject the change because
+	// of a spec issue.
+	if apis.IsInStatusUpdate(ctx) {
+		return
+	}
+
 	if r.Name == "" {
 		errs = errs.Also(apis.ErrMissingField("name"))
 	}

--- a/pkg/apis/kf/v1alpha1/route_validation.go
+++ b/pkg/apis/kf/v1alpha1/route_validation.go
@@ -1,0 +1,86 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"fmt"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+)
+
+const (
+	KfNamespace = "kf"
+)
+
+// Validate makes sure that Route is properly configured.
+func (r *Route) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if r.Name == "" {
+		errs = errs.Also(apis.ErrMissingField("name"))
+	}
+	if r.Namespace == "" {
+		errs = errs.Also(apis.ErrMissingField("namespace"))
+	}
+
+	errs = errs.Also(r.Spec.Validate(apis.WithinSpec(ctx)).ViaField("spec"))
+
+	// If we have errors, bail. No need to do the network call.
+	if errs.Error() != "" {
+		return errs
+	}
+
+	// XXX: We probably shouldn't be fetching VirtualServices in a webhook,
+	// however we need to ensure the resulting VirtualService doesn't
+	// conflict.
+	vs, err := IstioClientFromContext(ctx).
+		VirtualServices(KfNamespace).
+		Get(GenerateName(r.Spec.Hostname, r.Spec.Domain), metav1.GetOptions{})
+
+	if apierrs.IsNotFound(err) {
+		vs = nil
+	} else if err != nil {
+		return errs.Also(&apis.FieldError{
+			Message: "failed to validate hostname + domain collisions",
+			Details: fmt.Sprintf("failed to fetch VirtualServices: %s", err),
+		})
+	}
+
+	if vs != nil && vs.Annotations["space"] != r.GetNamespace() {
+		errs = errs.Also(&apis.FieldError{
+			Message: "Immutable field changed",
+			Paths:   []string{"namespace"},
+			Details: fmt.Sprintf("The route is invalid: Routes for this host and domain have been reserved for another space."),
+		})
+	}
+
+	return errs
+}
+
+func (r *RouteSpec) Validate(ctx context.Context) (errs *apis.FieldError) {
+	if r.Domain == "" {
+		errs = errs.Also(apis.ErrMissingField("domain"))
+	}
+
+	// validate we only have one KnativeServiceNames.
+	// TODO: We don't want to keep this:
+	// https://github.com/google/kf/issues/279
+	for i := 1; i < len(r.KnativeServiceNames); i++ {
+		errs = errs.Also(apis.ErrInvalidArrayValue(r.KnativeServiceNames[i], "knativeServiceName", i))
+	}
+
+	return errs
+}

--- a/pkg/apis/kf/v1alpha1/route_validation_test.go
+++ b/pkg/apis/kf/v1alpha1/route_validation_test.go
@@ -1,0 +1,171 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/kf/pkg/kf/testutil"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ktesting "k8s.io/client-go/testing"
+	"knative.dev/pkg/apis"
+	"knative.dev/pkg/apis/istio/v1alpha3"
+	"knative.dev/pkg/client/clientset/versioned/typed/istio/v1alpha3/fake"
+)
+
+func TestRouteValidation(t *testing.T) {
+	goodObjMeta := metav1.ObjectMeta{
+		Name:      "valid",
+		Namespace: "valid",
+	}
+	goodRouteSpec := RouteSpec{
+		Domain: "example.com",
+	}
+
+	cases := map[string]struct {
+		route *Route
+		want  *apis.FieldError
+		setup func(t *testing.T, fake *fake.FakeNetworkingV1alpha3)
+	}{
+		"good": {
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec:       goodRouteSpec,
+			},
+		},
+		"missing name": {
+			route: &Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: "valid"},
+				Spec:       goodRouteSpec,
+			},
+			want: apis.ErrMissingField("name"),
+		},
+		"missing namespace": {
+			route: &Route{
+				ObjectMeta: metav1.ObjectMeta{Name: "valid", Namespace: ""},
+				Spec:       goodRouteSpec,
+			},
+			want: apis.ErrMissingField("namespace"),
+		},
+		"missing domain": {
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec: RouteSpec{
+					KnativeServiceNames: []string{"app-1"},
+					Domain:              "",
+				},
+			},
+			want: apis.ErrMissingField("spec.domain"),
+		},
+		"multiple knativeServiceName": {
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec: RouteSpec{
+					KnativeServiceNames: []string{"app-1", "app-2", "app-3"},
+					Domain:              "example.com",
+				},
+			},
+			want: apis.ErrInvalidArrayValue("app-2", "spec.knativeServiceName", 1).Also(apis.ErrInvalidArrayValue("app-3", "spec.knativeServiceName", 2)),
+		},
+		"fetching VirtualServices returns an error": {
+			setup: func(t *testing.T, fake *fake.FakeNetworkingV1alpha3) {
+				fake.AddReactor("get", "virtualservices", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					testutil.AssertEqual(t, "namespace", KfNamespace, action.GetNamespace())
+					return true, nil, errors.New("some-error")
+				})
+			},
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec:       goodRouteSpec,
+			},
+			want: &apis.FieldError{
+				Message: "failed to validate hostname + domain collisions",
+				Details: "failed to fetch VirtualServices: some-error",
+			},
+		},
+		"fetching VirtualServices returns a not found error": {
+			setup: func(t *testing.T, fake *fake.FakeNetworkingV1alpha3) {
+				fake.AddReactor("get", "virtualservices", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					testutil.AssertEqual(t, "namespace", KfNamespace, action.GetNamespace())
+					return true, nil, apierrs.NewNotFound(schema.GroupResource{}, "some-name")
+				})
+			},
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec:       goodRouteSpec,
+			},
+		},
+		"existing VirtualService has different space annotation": {
+			setup: func(t *testing.T, fake *fake.FakeNetworkingV1alpha3) {
+				fake.AddReactor("get", "virtualservices", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+					testutil.AssertEqual(t, "namespace", KfNamespace, action.GetNamespace())
+					return true, &v1alpha3.VirtualService{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"space": "some-other-space",
+							},
+						},
+					}, nil
+				})
+			},
+			route: &Route{
+				ObjectMeta: goodObjMeta,
+				Spec:       goodRouteSpec,
+			},
+			want: &apis.FieldError{
+				Message: "Immutable field changed",
+				Paths:   []string{"namespace"},
+				Details: fmt.Sprintf("The route is invalid: Routes for this host and domain have been reserved for another space."),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			f := &fake.FakeNetworkingV1alpha3{
+				Fake: &ktesting.Fake{},
+			}
+
+			if tc.setup == nil {
+				tc.setup = func(t *testing.T, fake *fake.FakeNetworkingV1alpha3) {
+					fake.AddReactor("get", "virtualservices", func(action ktesting.Action) (handled bool, ret runtime.Object, err error) {
+						testutil.AssertEqual(t, "namespace", KfNamespace, action.GetNamespace())
+						return true, &v1alpha3.VirtualService{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"space": "valid",
+								},
+							},
+						}, nil
+					})
+				}
+			}
+
+			tc.setup(t, f)
+
+			ctx := SetupIstioClient(context.Background(), f)
+			got := tc.route.Validate(ctx)
+
+			testutil.AssertEqual(t, "validation errors", tc.want.Error(), got.Error())
+		})
+
+	}
+}

--- a/pkg/apis/kf/v1alpha1/utils_test.go
+++ b/pkg/apis/kf/v1alpha1/utils_test.go
@@ -17,6 +17,9 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"math/rand"
+	"path"
+	"strings"
 	"testing"
 
 	"github.com/google/kf/pkg/kf/testutil"
@@ -133,4 +136,57 @@ func ExampleSingleConditionManager_MarkReconciliationError() {
 	// Message: Error occurred while updating Dummy: update err
 	// Reason: ReconciliationError
 	// Error: Error occurred while updating Dummy: update err
+}
+
+func TestGenerateName_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	r1 := GenerateName("host-1", "example1.com")
+	r2 := GenerateName("host-1", "example1.com")
+	r3 := GenerateName("host-2", "example1.com")
+	r4 := GenerateName("host-1", "example2.com")
+
+	testutil.AssertEqual(t, "r1 and r2", r1, r2)
+	testutil.AssertEqual(t, "r1 and r2", r1, r2)
+
+	for _, r := range []string{r3, r4} {
+		if r1 == r {
+			t.Fatalf("expected %s to not equal %s", r, r1)
+		}
+	}
+}
+
+func TestGenerateName_ValidDNS(t *testing.T) {
+	t.Parallel()
+
+	// We'll use an instantiation of rand so we can seed it with 0 for
+	// repeatable tests.
+	rand := rand.New(rand.NewSource(0))
+	randStr := func() string {
+		buf := make([]byte, rand.Intn(128)+1)
+		for i := range buf {
+			buf[i] = byte(rand.Intn('z'-'a') + 'a')
+		}
+		return strings.ToUpper(path.Join("./", string(buf)))
+	}
+
+	history := map[string]bool{}
+
+	validDNS := func(r string) {
+		testutil.AssertRegexp(t, "valid DNS", `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`, r)
+		testutil.AssertEqual(t, fmt.Sprintf("len: %d", len(r)), true, len(r) <= 64)
+		testutil.AssertEqual(t, "collison", false, history[r])
+	}
+
+	for i := 0; i < 10000; i++ {
+		r := GenerateName(randStr(), randStr())
+		validDNS(r)
+		history[r] = true
+	}
+
+	// Empty name
+	validDNS(GenerateName())
+
+	// Only non-alphanumeric characters
+	validDNS(GenerateName(".", "-", "$"))
 }

--- a/pkg/kf/commands/routes/create_route.go
+++ b/pkg/kf/commands/routes/create_route.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/routes"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cv1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -87,7 +86,8 @@ Instead use the --namespace flag.`)
 					Kind: "Route",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: resources.VirtualServiceName(
+					Namespace: space,
+					Name: v1alpha1.GenerateName(
 						hostname,
 						domain,
 						urlPath,

--- a/pkg/kf/commands/routes/create_route_test.go
+++ b/pkg/kf/commands/routes/create_route_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/kf/pkg/kf/commands/utils"
 	routesfake "github.com/google/kf/pkg/kf/routes/fake"
 	"github.com/google/kf/pkg/kf/testutil"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -177,7 +176,8 @@ func TestCreateRoute(t *testing.T) {
 							Kind: "Route",
 						},
 						ObjectMeta: metav1.ObjectMeta{
-							Name: resources.VirtualServiceName("some-hostname", "example.com", "/somepath"),
+							Namespace: "some-space",
+							Name:      v1alpha1.GenerateName("some-hostname", "example.com", "/somepath"),
 							OwnerReferences: []metav1.OwnerReference{
 								{
 									APIVersion: "v1",

--- a/pkg/kf/commands/routes/delete_route.go
+++ b/pkg/kf/commands/routes/delete_route.go
@@ -18,10 +18,10 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/routes"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ func NewDeleteRouteCommand(
 			cmd.SilenceUsage = true
 			if err := c.Delete(
 				p.Namespace,
-				resources.VirtualServiceName(hostname, domain, path.Join("/", urlPath)),
+				v1alpha1.GenerateName(hostname, domain, path.Join("/", urlPath)),
 			); err != nil {
 				return fmt.Errorf("failed to delete Route: %s", err)
 			}

--- a/pkg/kf/commands/routes/delete_route_test.go
+++ b/pkg/kf/commands/routes/delete_route_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/routes"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/routes/fake"
 	"github.com/google/kf/pkg/kf/testutil"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 )
 
 func TestDeleteRoute(t *testing.T) {
@@ -76,7 +76,7 @@ func TestDeleteRoute(t *testing.T) {
 			Args:      []string{"example.com", "--hostname=some-hostname", "--path=somepath"},
 			Namespace: "some-namespace",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				expectedName := resources.VirtualServiceName("some-hostname", "example.com", "/somepath")
+				expectedName := v1alpha1.GenerateName("some-hostname", "example.com", "/somepath")
 				fake.EXPECT().Delete(
 					gomock.Any(),
 					expectedName,

--- a/pkg/kf/commands/routes/integration_test.go
+++ b/pkg/kf/commands/routes/integration_test.go
@@ -30,11 +30,11 @@ func TestIntegration_Routes(t *testing.T) {
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		hostname := fmt.Sprintf("some-host-%d", time.Now().UnixNano())
 
-		findRoute := func(hostname string, shouldFind bool) {
+		findRoute := func(shouldFind bool) {
 			RetryOnPanic(ctx, t, func() {
 				var found bool
 				for _, line := range kf.Routes(ctx) {
-					expected := hostname + " example.com some-path"
+					expected := hostname + " example.com /some-path"
 					actual := strings.Join(strings.Fields(line), " ")
 					if expected == actual {
 						found = true
@@ -44,7 +44,7 @@ func TestIntegration_Routes(t *testing.T) {
 
 				if shouldFind != found {
 					// We'll panic so we can use our retry logic
-					panic(fmt.Errorf("found route. Wanted %v, got %v", shouldFind, found))
+					panic(fmt.Errorf("Wanted %v, got %v", shouldFind, found))
 				}
 			})
 		}
@@ -53,8 +53,8 @@ func TestIntegration_Routes(t *testing.T) {
 
 		// TODO: use the domain from the cluster.
 		kf.CreateRoute(ctx, "example.com", "--hostname="+hostname, "--path=some-path")
-		findRoute(hostname, true)
+		findRoute(true)
 		kf.DeleteRoute(ctx, "example.com", "--hostname="+hostname, "--path=some-path")
-		findRoute(hostname, false)
+		findRoute(false)
 	})
 }

--- a/pkg/kf/commands/routes/map_route.go
+++ b/pkg/kf/commands/routes/map_route.go
@@ -23,7 +23,6 @@ import (
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/routes"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -78,7 +77,7 @@ func NewMapRouteCommand(
 					Kind: "Route",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: resources.VirtualServiceName(
+					Name: v1alpha1.GenerateName(
 						hostname,
 						domain,
 						urlPath,

--- a/pkg/kf/commands/routes/map_route_test.go
+++ b/pkg/kf/commands/routes/map_route_test.go
@@ -28,7 +28,6 @@ import (
 	clientroutes "github.com/google/kf/pkg/kf/routes"
 	routesfake "github.com/google/kf/pkg/kf/routes/fake"
 	"github.com/google/kf/pkg/kf/testutil"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -114,7 +113,7 @@ func TestMapRoute(t *testing.T) {
 				}, nil)
 				routesfake.EXPECT().Upsert(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(_ string, newR *v1alpha1.Route, m clientroutes.Merger) {
 					testutil.AssertEqual(t, "name",
-						resources.VirtualServiceName(
+						v1alpha1.GenerateName(
 							"some-host",
 							"example.com",
 							"/some-path",

--- a/pkg/kf/commands/routes/unmap_route.go
+++ b/pkg/kf/commands/routes/unmap_route.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/routes"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +70,7 @@ func NewUnmapRouteCommand(
 			})
 
 			urlPath = path.Join("/", urlPath)
-			ksvcName := resources.VirtualServiceName(hostname, domain, urlPath)
+			ksvcName := v1alpha1.GenerateName(hostname, domain, urlPath)
 			if err := c.Transform(p.Namespace, ksvcName, mutator); err != nil {
 				return fmt.Errorf("failed to unmap Route: %s", err)
 			}

--- a/pkg/kf/commands/routes/unmap_route_test.go
+++ b/pkg/kf/commands/routes/unmap_route_test.go
@@ -27,7 +27,6 @@ import (
 	clientroutes "github.com/google/kf/pkg/kf/routes"
 	"github.com/google/kf/pkg/kf/routes/fake"
 	"github.com/google/kf/pkg/kf/testutil"
-	"github.com/google/kf/pkg/reconciler/route/resources"
 )
 
 func TestUnmapRoute(t *testing.T) {
@@ -78,7 +77,7 @@ func TestUnmapRoute(t *testing.T) {
 			Args:      []string{"some-app", "example.com", "--hostname=some-host", "--path=some-path"},
 			Namespace: "some-space",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				fake.EXPECT().Transform(gomock.Any(), resources.VirtualServiceName("some-host", "example.com", "/some-path"), gomock.Any())
+				fake.EXPECT().Transform(gomock.Any(), v1alpha1.GenerateName("some-host", "example.com", "/some-path"), gomock.Any())
 			},
 			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
 				testutil.AssertNil(t, "err", err)

--- a/pkg/reconciler/route/reconciler.go
+++ b/pkg/reconciler/route/reconciler.go
@@ -184,6 +184,7 @@ func (r *Reconciler) reconcile(desired, actual *networking.VirtualService, delet
 
 	// Preserve the rest of the object (e.g. ObjectMeta except for labels).
 	existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
+	existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
 
 	if deleted {
 		existing.OwnerReferences = algorithms.Delete(

--- a/pkg/reconciler/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/route/resources/virtual_service_test.go
@@ -16,11 +16,8 @@ package resources_test
 
 import (
 	"fmt"
-	"math/rand"
 	"net/http"
-	"path"
 	"sort"
-	"strings"
 	"testing"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
@@ -33,59 +30,6 @@ import (
 	networking "knative.dev/pkg/apis/istio/v1alpha3"
 	"knative.dev/pkg/kmeta"
 )
-
-func TestVirtualServiceName_Deterministic(t *testing.T) {
-	t.Parallel()
-
-	r1 := resources.VirtualServiceName("host-1", "example1.com")
-	r2 := resources.VirtualServiceName("host-1", "example1.com")
-	r3 := resources.VirtualServiceName("host-2", "example1.com")
-	r4 := resources.VirtualServiceName("host-1", "example2.com")
-
-	testutil.AssertEqual(t, "r1 and r2", r1, r2)
-	testutil.AssertEqual(t, "r1 and r2", r1, r2)
-
-	for _, r := range []string{r3, r4} {
-		if r1 == r {
-			t.Fatalf("expected %s to not equal %s", r, r1)
-		}
-	}
-}
-
-func TestVirtualServiceName_ValidDNS(t *testing.T) {
-	t.Parallel()
-
-	// We'll use an instantiation of rand so we can seed it with 0 for
-	// repeatable tests.
-	rand := rand.New(rand.NewSource(0))
-	randStr := func() string {
-		buf := make([]byte, rand.Intn(128)+1)
-		for i := range buf {
-			buf[i] = byte(rand.Intn('z'-'a') + 'a')
-		}
-		return strings.ToUpper(path.Join("./", string(buf)))
-	}
-
-	history := map[string]bool{}
-
-	validDNS := func(r string) {
-		testutil.AssertRegexp(t, "valid DNS", `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`, r)
-		testutil.AssertEqual(t, fmt.Sprintf("len: %d", len(r)), true, len(r) <= 64)
-		testutil.AssertEqual(t, "collison", false, history[r])
-	}
-
-	for i := 0; i < 10000; i++ {
-		r := resources.VirtualServiceName(randStr(), randStr())
-		validDNS(r)
-		history[r] = true
-	}
-
-	// Empty name
-	validDNS(resources.VirtualServiceName())
-
-	// Only non-alphanumeric characters
-	validDNS(resources.VirtualServiceName(".", "-", "$"))
-}
 
 func TestMakeVirtualService(t *testing.T) {
 	t.Parallel()
@@ -126,13 +70,13 @@ func TestMakeVirtualService(t *testing.T) {
 				ownerRef.BlockOwnerDeletion = nil
 
 				testutil.AssertEqual(t, "ObjectMeta", metav1.ObjectMeta{
-					Name:      resources.VirtualServiceName(route.Spec.Hostname, route.Spec.Domain),
-					Namespace: "some-namespace",
+					Name:      v1alpha1.GenerateName(route.Spec.Hostname, route.Spec.Domain),
+					Namespace: v1alpha1.KfNamespace,
 					Labels:    map[string]string{"a": "1", "b": "2"},
 					Annotations: map[string]string{
 						"domain":   "example.com",
 						"hostname": "some-host",
-						"path":     "/some-path",
+						"space":    "some-namespace",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						ownerRef,


### PR DESCRIPTION
Routes are validated via a webhook that they have the proper fields:
- Name
- Namespace
- Spec.Domain

VirtualServices are also checked to ensure the hostname and domain
combination are available for that space.