### PR TITLE
kf/builds: provide env vars to build steps

### DIFF
--- a/pkg/kf/builds/builtins.go
+++ b/pkg/kf/builds/builtins.go
@@ -29,7 +29,7 @@ func BuildpackTemplate() build.TemplateInstantiationSpec {
 	}
 }
 
-// allBuiltins returns a list of all ClusterBuildTemplates
+// clusterBuiltins returns a list of all ClusterBuildTemplates
 func clusterBuiltins() []build.TemplateInstantiationSpec {
 	return []build.TemplateInstantiationSpec{
 		BuildpackTemplate(),

--- a/pkg/kf/builds/options.go
+++ b/pkg/kf/builds/options.go
@@ -27,6 +27,8 @@ import (
 type createConfig struct {
 	// Args is the arguments to the build template
 	Args map[string]string
+	// Env is the environment variables that will be provided to the build
+	Env []corev1.EnvVar
 	// Namespace is the Kubernetes namespace to use
 	Namespace string
 	// Owner is a reference to the owner of this build
@@ -35,8 +37,6 @@ type createConfig struct {
 	ServiceAccount string
 	// SourceImage is a Kontext source image to seed this build with
 	SourceImage string
-	// Env contains environment variables available to the build
-	Env []corev1.EnvVar
 }
 
 // CreateOption is a single option for configuring a createConfig
@@ -71,6 +71,12 @@ func (opts CreateOptions) Args() map[string]string {
 	return opts.toConfig().Args
 }
 
+// Env returns the last set value for Env or the empty value
+// if not set.
+func (opts CreateOptions) Env() []corev1.EnvVar {
+	return opts.toConfig().Env
+}
+
 // Namespace returns the last set value for Namespace or the empty value
 // if not set.
 func (opts CreateOptions) Namespace() string {
@@ -95,16 +101,17 @@ func (opts CreateOptions) SourceImage() string {
 	return opts.toConfig().SourceImage
 }
 
-// Env returns the last set value for SourceImage or the empty value
-// if not set.
-func (opts CreateOptions) Env() []corev1.EnvVar {
-	return opts.toConfig().Env
-}
-
 // WithCreateArgs creates an Option that sets the arguments to the build template
 func WithCreateArgs(val map[string]string) CreateOption {
 	return func(cfg *createConfig) {
 		cfg.Args = val
+	}
+}
+
+// WithCreateEnv creates an Option that sets the environment variables that will be provided to the build
+func WithCreateEnv(val []corev1.EnvVar) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.Env = val
 	}
 }
 
@@ -133,13 +140,6 @@ func WithCreateServiceAccount(val string) CreateOption {
 func WithCreateSourceImage(val string) CreateOption {
 	return func(cfg *createConfig) {
 		cfg.SourceImage = val
-	}
-}
-
-// WithCreateEnv creates an Option that sets the environment variables for this build
-func WithCreateEnv(val []corev1.EnvVar) CreateOption {
-	return func(cfg *createConfig) {
-		cfg.Env = val
 	}
 }
 

--- a/pkg/kf/builds/options.go
+++ b/pkg/kf/builds/options.go
@@ -19,6 +19,7 @@ package builds
 import (
 	"context"
 	"io"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
 )
@@ -34,6 +35,8 @@ type createConfig struct {
 	ServiceAccount string
 	// SourceImage is a Kontext source image to seed this build with
 	SourceImage string
+	// Env contains environment variables available to the build
+	Env []corev1.EnvVar
 }
 
 // CreateOption is a single option for configuring a createConfig
@@ -92,6 +95,12 @@ func (opts CreateOptions) SourceImage() string {
 	return opts.toConfig().SourceImage
 }
 
+// Env returns the last set value for SourceImage or the empty value
+// if not set.
+func (opts CreateOptions) Env() []corev1.EnvVar {
+	return opts.toConfig().Env
+}
+
 // WithCreateArgs creates an Option that sets the arguments to the build template
 func WithCreateArgs(val map[string]string) CreateOption {
 	return func(cfg *createConfig) {
@@ -124,6 +133,13 @@ func WithCreateServiceAccount(val string) CreateOption {
 func WithCreateSourceImage(val string) CreateOption {
 	return func(cfg *createConfig) {
 		cfg.SourceImage = val
+	}
+}
+
+// WithCreateEnv creates an Option that sets the environment variables for this build
+func WithCreateEnv(val []corev1.EnvVar) CreateOption {
+	return func(cfg *createConfig) {
+		cfg.Env = val
 	}
 }
 

--- a/pkg/kf/builds/options.yml
+++ b/pkg/kf/builds/options.yml
@@ -1,7 +1,7 @@
 # This file contains options for option-builder.go
 ---
 package: builds
-imports: {"k8s.io/apimachinery/pkg/apis/meta/v1":"", "io":"", "context":"", "os":""}
+imports: {"k8s.io/apimachinery/pkg/apis/meta/v1":"", "io":"", "context":"", "os":"", "k8s.io/api/core/v1":"corev1"}
 common:
 - name: Namespace
   type: string
@@ -22,6 +22,9 @@ configs:
   - name: Owner
     type: "*v1.OwnerReference"
     description: a reference to the owner of this build
+  - name: Env
+    type: "[]corev1.EnvVar"
+    description: the environment variables that will be provided to the build
 - name: Status
 - name: Delete
 - name: Tail

--- a/pkg/kf/builds/util.go
+++ b/pkg/kf/builds/util.go
@@ -85,6 +85,7 @@ func PopulateTemplate(
 			Template: &build.TemplateInstantiationSpec{
 				Name:      template.Name,
 				Kind:      template.Kind,
+				Env:       cfg.Env,
 				Arguments: args,
 			},
 		},

--- a/pkg/kf/builds/util_test.go
+++ b/pkg/kf/builds/util_test.go
@@ -119,6 +119,28 @@ func TestPopulateTemplate(t *testing.T) {
 				testutil.AssertEqual(t, "owner values", "abcd-efgh-ijkl", string(actual.OwnerReferences[0].UID))
 			},
 		},
+		"envs": {
+			name:     "envs",
+			template: testTemplate,
+			opts: []builds.CreateOption{
+				builds.WithCreateEnv([]corev1.EnvVar{
+					{
+						Name:      "envName",
+						Value:     "envValue",
+						ValueFrom: nil,
+					},
+				}),
+			},
+
+			validate: func(t *testing.T, actual *build.Build) {
+				testutil.AssertEqual(t, "SchemeGroupVersion", build.SchemeGroupVersion.String(), actual.APIVersion)
+				testutil.AssertEqual(t, "Kind", "Build", actual.Kind)
+				testutil.AssertEqual(t, "Name", "envs", actual.Name)
+				testutil.AssertEqual(t, "owner count", 0, len(actual.OwnerReferences))
+				testutil.AssertEqual(t, "Spec.Template.Env count", 1, len(actual.Spec.Template.Env))
+				testutil.AssertEqual(t, "Spec.Template.Env", actual.Spec.Template.Env, []corev1.EnvVar{{Name: "envName", Value: "envValue", ValueFrom: nil}})
+			},
+		},
 		"defaults": {
 			name:     "defaults",
 			template: testTemplate,

--- a/pkg/kf/push.go
+++ b/pkg/kf/push.go
@@ -72,6 +72,7 @@ func (p *pusher) Push(appName, srcImage string, opts ...PushOption) error {
 		cfg.Namespace,
 		appName,
 		srcImage,
+		envs,
 		cfg.ContainerRegistry,
 		cfg.ServiceAccount,
 		cfg.Buildpack,
@@ -156,6 +157,7 @@ func (p *pusher) buildSpec(
 	namespace string,
 	appName string,
 	srcImage string,
+	envs []corev1.EnvVar,
 	containerRegistry string,
 	serviceAccount string,
 	buildpack string,
@@ -180,6 +182,7 @@ func (p *pusher) buildSpec(
 		builds.WithCreateArgs(args),
 		builds.WithCreateSourceImage(srcImage),
 		builds.WithCreateNamespace(namespace),
+		builds.WithCreateEnv(envs),
 	); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This change provides environment variables (declared in an app manifest or as
arguments to `kf push`) to all steps in the build, allowing things like buildpack
configuration via environment variables.

Fixes #275