### PR TITLE
hack: remove any usage of `realpath`

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 set -eux
-cd $(realpath $(dirname "$(realpath $0)")/..)
+cd "${0%/*}"/..
 mkdir -p bin
 go build -o bin/kf ./cmd/kf/...

--- a/hack/codegen-packages.txt
+++ b/hack/codegen-packages.txt
@@ -1,4 +1,4 @@
-github.com/golang/mock/mockgen/model
+github.com/golang/mock/mockgen
 github.com/knative/serving/pkg/apis
 github.com/knative/build/pkg/apis
 github.com/poy/service-catalog/pkg/apis

--- a/hack/setup-codegen.sh
+++ b/hack/setup-codegen.sh
@@ -17,14 +17,14 @@
 
 set -xeu
 
-packages=$(cat $(realpath $(dirname "$(realpath $0)")/codegen-packages.txt))
+cd "${0%/*}"
+packages=$(cat codegen-packages.txt)
 
 cd $(go env GOPATH)
 for p in $packages; do
-  go get -u $p/...
+  GO111MODULE=off go get -u $p/...
 done
 
-cd $(go env GOPATH)
 mkdir -p src/github.com/knative/
 cd src/github.com/knative
 if [ ! -d "pkg" ]; then

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -28,7 +28,7 @@ while getopts "v" opt; do
   esac
 done
 
-HACK_DIR=$(realpath $(dirname "$(realpath $0)"))
+HACK_DIR="${0%/*}"
 CODEGEN_PKG=$(go env GOPATH)/src/k8s.io/code-generator
 CODEGEN_PACKAGES=$(cat $HACK_DIR/codegen-packages.txt)
 KF_PACKAGE="github.com/google/kf"
@@ -57,7 +57,7 @@ for PACKAGE in ${CODEGEN_PACKAGES}; do
   fi
 done
 
-if [ "$(realpath $KF_PACKAGE_LOCATION)" != "$(git rev-parse --show-toplevel)" ]; then
+if [ "$GOPATH/src/github.com/google/kf" != "$(git rev-parse --show-toplevel)" ]; then
     echo "The generator scripts aren't go module compatible (yet)." 1>&2
     exit 1
 fi


### PR DESCRIPTION
`realpath` is not installed on OSX. Therefore the scripts were harder to
run for mac users.

fixes #297