### PR TITLE
Feature/push uses space

### DIFF
--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -57,12 +57,13 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 	)
 
 	var pushCmd = &cobra.Command{
-		Use:   "push APP_NAME [--container-registry CONTAINER_REGISTRY]",
+		Use:   "push APP_NAME",
 		Short: "Push a new app or sync changes to an existing app",
 		Example: `
+	kf push myapp
   kf push myapp --container-registry gcr.io/myproject
-  kf push myapp --container-registry gcr.io/myproject --buildpack my.special.buildpack # Discover via kf buildpacks
-  kf push myapp --container-registry gcr.io/myproject --env FOO=bar --env BAZ=foo
+  kf push myapp --buildpack my.special.buildpack # Discover via kf buildpacks
+  kf push myapp --env FOO=bar --env BAZ=foo
   `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -70,9 +71,20 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 				return err
 			}
 
-			if containerRegistry == "" {
+			space, err := p.GetTargetSpaceOrDefault()
+			if err != nil {
+				return err
+			}
+
+			switch {
+			case containerRegistry != "":
+				break
+			case space.Spec.BuildpackBuild.ContainerRegistry != "":
+				containerRegistry = space.Spec.BuildpackBuild.ContainerRegistry
+			default:
 				return errors.New("container-registry is required")
 			}
+
 			cmd.SilenceUsage = true
 
 			appName := ""
@@ -81,7 +93,6 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 			}
 
 			// Kontext has to have a absolute path.
-			var err error
 			path, err = filepath.Abs(path)
 			if err != nil {
 				return err
@@ -181,7 +192,7 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 		&containerRegistry,
 		"container-registry",
 		"",
-		"The container registry to push containers (REQUIRED).",
+		"The container registry to push containers. Required if not targeting a Kf space.",
 	)
 
 	pushCmd.Flags().StringVar(

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -60,7 +60,7 @@ func NewPushCommand(p *config.KfParams, pusher kf.Pusher, b SrcImageBuilder) *co
 		Use:   "push APP_NAME",
 		Short: "Push a new app or sync changes to an existing app",
 		Example: `
-	kf push myapp
+  kf push myapp
   kf push myapp --container-registry gcr.io/myproject
   kf push myapp --buildpack my.special.buildpack # Discover via kf buildpacks
   kf push myapp --env FOO=bar --env BAZ=foo

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf"
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
@@ -36,128 +36,154 @@ func TestPushCommand(t *testing.T) {
 	t.Parallel()
 
 	for tn, tc := range map[string]struct {
-		args              []string
-		namespace         string
-		containerRegistry string
-		buildpack         string
-		path              string
-		serviceAccount    string
-		sourceImage       string
-		grpc              bool
-		wantErr           error
-		pusherErr         error
-		envVars           []string
-		wantEnvMap        map[string]string
-		srcImageBuilder   SrcImageBuilderFunc
-		wantImagePrefix   string
-		instances         int
+		args            []string
+		namespace       string
+		wantErr         error
+		pusherErr       error
+		srcImageBuilder SrcImageBuilderFunc
+		wantImagePrefix string
+		targetSpace     *v1alpha1.Space
+
+		wantOpts []kf.PushOption
 	}{
 		"uses configured properties": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "some-reg.io",
-			serviceAccount:    "some-service-account",
-			path:              "some-path",
-			grpc:              true,
-			buildpack:         "some-buildpack",
-			envVars:           []string{"env1=val1", "env2=val2"},
-			wantEnvMap:        map[string]string{"env1": "val1", "env2": "val2"},
-			wantImagePrefix:   "some-reg.io/src-some-namespace-app-name",
+			namespace: "some-namespace",
+			args: []string{
+				"example-app",
+				"--buildpack", "some-buildpack",
+				"--service-account", "some-service-account",
+				"--grpc",
+				"--env", "env1=val1",
+				"-e", "env2=val2",
+				"--container-registry", "some-reg.io",
+				"--instances", "1",
+				"--path", "testdata/example-app",
+			},
+			wantImagePrefix: "some-reg.io/src-some-namespace-example-app",
 			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
-				testutil.AssertEqual(t, "path", true, strings.Contains(dir, "some-path"))
+				testutil.AssertEqual(t, "path", true, strings.Contains(dir, "example-app"))
 				testutil.AssertEqual(t, "path is abs", true, filepath.IsAbs(dir))
 				return nil
 			},
-			instances: 1,
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("some-namespace"),
+				kf.WithPushContainerRegistry("some-reg.io"),
+				kf.WithPushServiceAccount("some-service-account"),
+				kf.WithPushGrpc(true),
+				kf.WithPushBuildpack("some-buildpack"),
+				kf.WithPushEnvironmentVariables(map[string]string{"env1": "val1", "env2": "val2"}),
+				kf.WithPushMinScale(1),
+				kf.WithPushMaxScale(1),
+			},
 		},
 		"uses current working directory for empty path": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "some-reg.io",
-			path:              "",
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--container-registry", "some-reg.io",
+			},
 			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
 				cwd, err := os.Getwd()
 				testutil.AssertNil(t, "cwd err", err)
 				testutil.AssertEqual(t, "path", cwd, dir)
 				return nil
 			},
-			instances: 1,
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("some-namespace"),
+				kf.WithPushContainerRegistry("some-reg.io"),
+				kf.WithPushMinScale(1),
+				kf.WithPushMaxScale(1),
+			},
 		},
 		"custom-source": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "some-reg.io",
-			serviceAccount:    "some-service-account",
-			grpc:              true,
-			buildpack:         "some-buildpack",
-			envVars:           []string{"env1=val1", "env2=val2"},
-			wantEnvMap:        map[string]string{"env1": "val1", "env2": "val2"},
-			sourceImage:       "custom-reg.io/source-image:latest",
-			wantImagePrefix:   "custom-reg.io/source-image:latest",
-			instances:         1,
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--container-registry", "some-reg.io",
+				"--source-image", "custom-reg.io/source-image:latest",
+			},
+			wantImagePrefix: "custom-reg.io/source-image:latest",
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("some-namespace"),
+				kf.WithPushContainerRegistry("some-reg.io"),
+				kf.WithPushMinScale(1),
+				kf.WithPushMaxScale(1),
+			},
 		},
 		"specify-instances": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "some-reg.io",
-			serviceAccount:    "some-service-account",
-			grpc:              true,
-			buildpack:         "some-buildpack",
-			envVars:           []string{"env1=val1", "env2=val2"},
-			wantEnvMap:        map[string]string{"env1": "val1", "env2": "val2"},
-			sourceImage:       "custom-reg.io/source-image:latest",
-			wantImagePrefix:   "custom-reg.io/source-image:latest",
-			instances:         2,
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--container-registry", "some-reg.io",
+				"--instances", "2",
+				"--source-image", "custom-reg.io/source-image:latest",
+			},
+			wantImagePrefix: "custom-reg.io/source-image:latest",
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("some-namespace"),
+				kf.WithPushMinScale(2),
+				kf.WithPushMaxScale(2),
+				kf.WithPushContainerRegistry("some-reg.io"),
+			},
 		},
 		"service create error": {
-			namespace:         "default",
-			args:              []string{"app-name"},
-			wantErr:           errors.New("some error"),
-			pusherErr:         errors.New("some error"),
-			containerRegistry: "some-reg.io",
-			serviceAccount:    "some-service-account",
-			wantImagePrefix:   "some-reg.io/src-default-app-name",
-			instances:         1,
+			namespace:       "default",
+			args:            []string{"app-name", "--container-registry", "some-reg.io"},
+			wantErr:         errors.New("some error"),
+			pusherErr:       errors.New("some error"),
+			wantImagePrefix: "some-reg.io/src-default-app-name",
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("default"),
+				kf.WithPushContainerRegistry("some-reg.io"),
+				kf.WithPushMinScale(1),
+				kf.WithPushMaxScale(1),
+			},
 		},
 		"namespace is not provided": {
-			args:              []string{"app-name"},
-			containerRegistry: "",
-			wantErr:           errors.New(utils.EmptyNamespaceError),
-			instances:         1,
+			args:    []string{"app-name"},
+			wantErr: errors.New(utils.EmptyNamespaceError),
 		},
 		"container-registry is not provided": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "",
-			wantErr:           errors.New("container-registry is required"),
-			instances:         1,
+			namespace: "some-namespace",
+			args:      []string{"app-name"},
+			wantErr:   errors.New("container-registry is required"),
+		},
+		"container-registry comes from space": {
+			namespace: "some-namespace",
+			args:      []string{"app-name"},
+			targetSpace: &v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
+						ContainerRegistry: "space-reg.io",
+					},
+				},
+			},
+			wantOpts: []kf.PushOption{
+				kf.WithPushNamespace("some-namespace"),
+				kf.WithPushContainerRegistry("space-reg.io"),
+				kf.WithPushMinScale(1),
+				kf.WithPushMaxScale(1),
+			},
 		},
 		"SrcImageBuilder returns an error": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			containerRegistry: "some-reg.io",
-			wantErr:           errors.New("some error"),
+			namespace: "some-namespace",
+			args:      []string{"app-name", "--container-registry", "some-reg.io"},
+			wantErr:   errors.New("some error"),
 			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
 				return errors.New("some error")
 			},
-			instances: 1,
 		},
 		"invalid environment variable, returns error": {
-			namespace:         "some-namespace",
-			args:              []string{"app-name"},
-			envVars:           []string{"invalid"},
-			containerRegistry: "some-reg.io",
-			wantErr:           errors.New("malformed environment variable: invalid"),
-			instances:         1,
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--container-registry", "some-reg.io",
+				"--env", "invalid",
+			},
+			wantErr: errors.New("malformed environment variable: invalid"),
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
-
-			if tc.path != "" {
-				os.MkdirAll(tc.path, 0755)
-				defer os.RemoveAll(tc.path)
-			}
-
 			if tc.srcImageBuilder == nil {
 				tc.srcImageBuilder = func(dir, srcImage string, rebase bool) error { return nil }
 			}
@@ -170,14 +196,17 @@ func TestPushCommand(t *testing.T) {
 				Push(gomock.Any(), gomock.Any(), gomock.Any()).
 				DoAndReturn(func(appName, srcImage string, opts ...kf.PushOption) error {
 					testutil.AssertEqual(t, "app name", tc.args[0], appName)
-					testutil.AssertEqual(t, "namespace", tc.namespace, kf.PushOptions(opts).Namespace())
-					testutil.AssertEqual(t, "container registry", tc.containerRegistry, kf.PushOptions(opts).ContainerRegistry())
-					testutil.AssertEqual(t, "buildpack", tc.buildpack, kf.PushOptions(opts).Buildpack())
-					testutil.AssertEqual(t, "service account", tc.serviceAccount, kf.PushOptions(opts).ServiceAccount())
-					testutil.AssertEqual(t, "grpc", tc.grpc, kf.PushOptions(opts).Grpc())
-					testutil.AssertEqual(t, "env vars", tc.wantEnvMap, kf.PushOptions(opts).EnvironmentVariables())
-					testutil.AssertEqual(t, "min scale bound", tc.instances, kf.PushOptions(opts).MaxScale())
-					testutil.AssertEqual(t, "max scale bound", tc.instances, kf.PushOptions(opts).MaxScale())
+
+					expectOpts := kf.PushOptions(tc.wantOpts)
+					actualOpts := kf.PushOptions(opts)
+					testutil.AssertEqual(t, "namespace", expectOpts.Namespace(), actualOpts.Namespace())
+					testutil.AssertEqual(t, "container registry", expectOpts.ContainerRegistry(), actualOpts.ContainerRegistry())
+					testutil.AssertEqual(t, "buildpack", expectOpts.Buildpack(), actualOpts.Buildpack())
+					testutil.AssertEqual(t, "service account", expectOpts.ServiceAccount(), actualOpts.ServiceAccount())
+					testutil.AssertEqual(t, "grpc", expectOpts.Grpc(), actualOpts.Grpc())
+					testutil.AssertEqual(t, "env vars", expectOpts.EnvironmentVariables(), actualOpts.EnvironmentVariables())
+					testutil.AssertEqual(t, "min scale bound", expectOpts.MinScale(), actualOpts.MinScale())
+					testutil.AssertEqual(t, "max scale bound", expectOpts.MaxScale(), actualOpts.MaxScale())
 
 					if !strings.HasPrefix(srcImage, tc.wantImagePrefix) {
 						t.Errorf("Wanted srcImage to start with %s got: %s", tc.wantImagePrefix, srcImage)
@@ -186,27 +215,20 @@ func TestPushCommand(t *testing.T) {
 					return tc.pusherErr
 				})
 
-			c := NewPushCommand(&config.KfParams{
-				Namespace: tc.namespace,
-			},
-				fakePusher,
-				tc.srcImageBuilder,
-			)
+			params := &config.KfParams{
+				Namespace:   tc.namespace,
+				TargetSpace: tc.targetSpace,
+			}
+
+			if params.TargetSpace == nil {
+				params.SetTargetSpaceToDefault()
+			}
+
+			c := NewPushCommand(params, fakePusher, tc.srcImageBuilder)
 			buffer := &bytes.Buffer{}
 			c.SetOutput(buffer)
-
-			c.Flags().Set("container-registry", tc.containerRegistry)
-			c.Flags().Set("service-account", tc.serviceAccount)
-			c.Flags().Set("path", tc.path)
-			c.Flags().Set("grpc", strconv.FormatBool(tc.grpc))
-			c.Flags().Set("buildpack", tc.buildpack)
-			c.Flags().Set("source-image", tc.sourceImage)
-			c.Flags().Set("instances", strconv.Itoa(tc.instances))
-
-			for _, env := range tc.envVars {
-				c.Flags().Set("env", env)
-			}
-			gotErr := c.RunE(c, tc.args)
+			c.SetArgs(tc.args)
+			_, gotErr := c.ExecuteC()
 			if tc.wantErr != nil || gotErr != nil {
 				if fmt.Sprint(tc.wantErr) != fmt.Sprint(gotErr) {
 					t.Fatalf("wanted err: %v, got: %v", tc.wantErr, gotErr)

--- a/pkg/kf/commands/apps/testdata/example-app/manifest.yml
+++ b/pkg/kf/commands/apps/testdata/example-app/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+- name: example-app


### PR DESCRIPTION
It turns out this was a prerequisite to getting Sources to push locally.

I refactored push_test as part of this and we can now unit-test manifest loading and a larger variety of options with that.

This opens up #158 to be worked on.