### PR TITLE
add build name to source status

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle.go
@@ -44,7 +44,7 @@ func (status *SourceStatus) manage() apis.ConditionManager {
 	return apis.NewBatchConditionSet(SourceConditionBuildSucceeded).Manage(status)
 }
 
-// IsReady returns if the space is ready to be used.
+// Succeeded returns if the space is ready to be used.
 func (status *SourceStatus) Succeeded() bool {
 	return status.manage().IsHappy()
 }
@@ -73,8 +73,9 @@ func (status *SourceStatus) PropagateBuildStatus(build *build.Build) {
 		return
 	}
 
-	for _, condition := range build.Status.GetConditions() {
+	status.BuildName = build.Name
 
+	for _, condition := range build.Status.GetConditions() {
 		if condition.Type == "Succeeded" {
 			switch condition.Status {
 			case corev1.ConditionTrue:

--- a/pkg/apis/kf/v1alpha1/source_types.go
+++ b/pkg/apis/kf/v1alpha1/source_types.go
@@ -101,6 +101,10 @@ type SourceStatusFields struct {
 	// Image is the latest successfully built image.
 	// +optional
 	Image string `json:"image,omitempty"`
+
+	// BuildName is the name of the build that produced the image.
+	// +optional
+	BuildName string `json:"buildName,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
This was preventing us from tailing logs given a source (no way to track back to a particular build).