### PR TITLE
added examples to proxy

### DIFF
--- a/pkg/kf/commands/apps/proxy.go
+++ b/pkg/kf/commands/apps/proxy.go
@@ -77,7 +77,20 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 				return err
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Forwarding requests from http://%s to http://%s\n", listener.Addr(), gateway)
+			appHost := app.Status.URL.Host
+
+			w := cmd.OutOrStdout()
+			fmt.Fprintf(w, "Forwarding requests from %s to %s with host %s\n", listener.Addr(), gateway, appHost)
+			fmt.Fprintln(w, "Example GET:")
+			fmt.Fprintf(w, "  curl -H \"Host: %s\" http://%s\n", appHost, gateway)
+			fmt.Fprintln(w, "Example POST:")
+			fmt.Fprintf(w, "  curl --request POST -H \"Host: %s\" http://%s --data \"POST data\"\n", appHost, gateway)
+			fmt.Fprintln(w, "Browser link:")
+			fmt.Fprintf(w, "  http://%s\n", listener.Addr())
+
+			fmt.Fprintln(w)
+
+			fmt.Fprintln(w, "\033[33m[NOTE: the first request may take some time if the app is scaled to zero]\033[0m")
 
 			if noStart {
 				fmt.Fprintln(cmd.OutOrStdout(), "exiting because no-start flag was provided")
@@ -115,6 +128,7 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 
 func createProxy(w io.Writer, appHost, gateway string) *httputil.ReverseProxy {
 	logger := log.New(w, fmt.Sprintf("\033[34m[%s via %s]\033[0m ", appHost, gateway), log.Ltime)
+
 	return &httputil.ReverseProxy{
 		Director: func(req *http.Request) {
 			req.Host = appHost

--- a/pkg/kf/commands/apps/proxy.go
+++ b/pkg/kf/commands/apps/proxy.go
@@ -90,7 +90,7 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 
 			fmt.Fprintln(w)
 
-			fmt.Fprintln(w, "\033[33m[NOTE: the first request may take some time if the app is scaled to zero]\033[0m")
+			fmt.Fprintln(w, "\033[33mNOTE: the first request may take some time if the app is scaled to zero\033[0m")
 
 			if noStart {
 				fmt.Fprintln(cmd.OutOrStdout(), "exiting because no-start flag was provided")

--- a/pkg/kf/commands/apps/proxy_test.go
+++ b/pkg/kf/commands/apps/proxy_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/kf/pkg/kf/fake"
 	"github.com/google/kf/pkg/kf/testutil"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"knative.dev/pkg/apis"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -50,7 +51,15 @@ func TestNewProxyCommand(t *testing.T) {
 			ExpectedErr: nil,
 			Setup: func(t *testing.T, lister *fakeapps.FakeClient, istio *fake.FakeIstioClient) {
 				istio.EXPECT().ListIngresses(gomock.Any()).Return([]corev1.LoadBalancerIngress{{IP: "8.8.8.8"}}, nil)
-				lister.EXPECT().Get("default", "my-app").Return(&serving.Service{}, nil)
+				lister.EXPECT().Get("default", "my-app").Return(&serving.Service{
+					Status: serving.ServiceStatus{
+						RouteStatusFields: serving.RouteStatusFields{
+							URL: &apis.URL{
+								Host: "example.com",
+							},
+						},
+					},
+				}, nil)
 			},
 		},
 		"autodetect failure": {


### PR DESCRIPTION
This updates the proxy command to include examples of how to use `curl`:

```
Autodetecting app gateway. Specify a custom gateway using the --gateway flag.
Forwarding requests from 127.0.0.1:8080 to 35.192.224.169 with host echo.joseph.example.com
Example GET:
  curl -H "Host: echo.joseph.example.com" http://35.192.224.169
Example POST:
  curl --request POST -H "Host: echo.joseph.example.com" http://35.192.224.169 --data "POST data"
Browser link:
  http://127.0.0.1:8080

NOTE: the first request may take some time if the app is scaled to zero
```