### PR TITLE
pkg/kf/commands/app: adds restart command

### DIFF
--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -30,7 +30,10 @@ type appsClient struct {
 }
 
 // NewClient creates a new application client.
-func NewClient(kclient cserving.ServingV1alpha1Interface, envInjector systemenvinjector.SystemEnvInjectorInterface) Client {
+func NewClient(
+	kclient cserving.ServingV1alpha1Interface,
+	envInjector systemenvinjector.SystemEnvInjectorInterface,
+) Client {
 	return &appsClient{
 		coreClient{
 			kclient: kclient,

--- a/pkg/kf/commands/apps/proxy.go
+++ b/pkg/kf/commands/apps/proxy.go
@@ -39,7 +39,7 @@ func NewProxyCommand(p *config.KfParams, appsClient apps.Client, ingressLister k
 
 	var proxy = &cobra.Command{
 		Use:     "proxy APP_NAME",
-		Short:   "Creates a proxy to an app on a local port.",
+		Short:   "Creates a proxy to an app on a local port",
 		Example: `  kf proxy myapp`,
 		Long: `
 	This command creates a local proxy to a remote gateway modifying the request

--- a/pkg/kf/commands/apps/restart.go
+++ b/pkg/kf/commands/apps/restart.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/commands/utils"
+	"github.com/google/kf/pkg/kf/kfapps"
+	"github.com/spf13/cobra"
+)
+
+// NewRestartCommand creates a command capable of restarting an app.
+func NewRestartCommand(
+	p *config.KfParams,
+	client kfapps.Client,
+) *cobra.Command {
+	var restart = &cobra.Command{
+		Use:   "restart APP_NAME",
+		Short: "Restart stops the current pods and create new ones",
+		Example: `
+  kf restart myapp
+  `,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := utils.ValidateNamespace(p); err != nil {
+				return err
+			}
+
+			appName := args[0]
+
+			cmd.SilenceUsage = true
+
+			if err := client.Restart(p.Namespace, appName); err != nil {
+				return fmt.Errorf("failed to restart app: %s", err)
+			}
+
+			return nil
+		},
+	}
+	return restart
+}

--- a/pkg/kf/commands/apps/restart_test.go
+++ b/pkg/kf/commands/apps/restart_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/kfapps/fake"
+	"github.com/google/kf/pkg/kf/testutil"
+)
+
+func TestRestart(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Namespace       string
+		Args            []string
+		ExpectedStrings []string
+		ExpectedErr     error
+		Setup           func(t *testing.T, fake *fake.FakeClient)
+	}{
+		"restarts app": {
+			Namespace: "default",
+			Args:      []string{"my-app"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Restart("default", "my-app")
+			},
+		},
+		"no app name": {
+			Namespace:   "default",
+			Args:        []string{},
+			ExpectedErr: errors.New("accepts 1 arg(s), received 0"),
+		},
+		"restart app fails": {
+			Namespace:   "default",
+			Args:        []string{"my-app"},
+			ExpectedErr: errors.New("failed to restart app: some-error"),
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Restart(gomock.Any(), gomock.Any()).
+					Return(errors.New("some-error"))
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fake := fake.NewFakeClient(ctrl)
+
+			if tc.Setup != nil {
+				tc.Setup(t, fake)
+			}
+
+			buf := new(bytes.Buffer)
+			p := &config.KfParams{
+				Namespace: tc.Namespace,
+			}
+
+			cmd := NewRestartCommand(p, fake)
+			cmd.SetOutput(buf)
+			cmd.SetArgs(tc.Args)
+			_, actualErr := cmd.ExecuteC()
+			if tc.ExpectedErr != nil || actualErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectedErr, actualErr)
+				return
+			}
+
+			testutil.AssertContainsAll(t, buf.String(), tc.ExpectedStrings)
+			testutil.AssertEqual(t, "SilenceUsage", true, cmd.SilenceUsage)
+
+			ctrl.Finish()
+		})
+	}
+}

--- a/pkg/kf/commands/apps/scale.go
+++ b/pkg/kf/commands/apps/scale.go
@@ -39,7 +39,7 @@ func NewScaleCommand(
 
 	var scale = &cobra.Command{
 		Use:   "scale APP_NAME",
-		Short: "Change the instance count for an app.",
+		Short: "Change the instance count for an app",
 		Example: `
   kf scale myapp --i 3 # Scale to exactly 3 instances
   kf scale myapp --instances 3 # Scale to exactly 3 instances

--- a/pkg/kf/commands/buildpacks/buildpacks.go
+++ b/pkg/kf/commands/buildpacks/buildpacks.go
@@ -29,7 +29,7 @@ import (
 func NewBuildpacksCommand(p *config.KfParams, l buildpacks.Client) *cobra.Command {
 	var buildpacksCmd = &cobra.Command{
 		Use:   "buildpacks",
-		Short: "List buildpacks in the current space.",
+		Short: "List buildpacks in current builder",
 		Args:  cobra.ExactArgs(0),
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/kf/commands/buildpacks/stacks.go
+++ b/pkg/kf/commands/buildpacks/stacks.go
@@ -29,7 +29,7 @@ import (
 func NewStacksCommand(p *config.KfParams, l buildpacks.Client) *cobra.Command {
 	var buildpacksCmd = &cobra.Command{
 		Use:   "stacks",
-		Short: "List stacks in the builder for the current space.",
+		Short: "List stacks in current builder",
 		Args:  cobra.ExactArgs(0),
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -63,9 +63,10 @@ func NewKfCommand() *cobra.Command {
 				InjectPush(p),
 				InjectDelete(p),
 				InjectApps(p),
+				InjectRestart(p),
 				InjectScale(p),
-				InjectProxy(p),
 				InjectLogs(p),
+				InjectProxy(p),
 			},
 		},
 		{

--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -82,6 +82,13 @@ func InjectScale(p *config.KfParams) *cobra.Command {
 	return command
 }
 
+func InjectRestart(p *config.KfParams) *cobra.Command {
+	kfV1alpha1Interface := config.GetKfClient(p)
+	client := kfapps.NewClient(kfV1alpha1Interface)
+	command := apps2.NewRestartCommand(p, client)
+	return command
+}
+
 func InjectProxy(p *config.KfParams) *cobra.Command {
 	servingV1alpha1Interface := config.GetServingClient(p)
 	systemEnvInjectorInterface := provideSystemEnvInjector(p)

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -104,6 +104,11 @@ func InjectScale(p *config.KfParams) *cobra.Command {
 	return nil
 }
 
+func InjectRestart(p *config.KfParams) *cobra.Command {
+	wire.Build(capps.NewRestartCommand, KfappsSet)
+	return nil
+}
+
 func InjectProxy(p *config.KfParams) *cobra.Command {
 	wire.Build(
 		capps.NewProxyCommand,

--- a/pkg/kf/kfapps/client.go
+++ b/pkg/kf/kfapps/client.go
@@ -21,6 +21,7 @@ import (
 
 // ClientExtension holds additional functions that should be exposed by client.
 type ClientExtension interface {
+	Restart(namespace, name string) error
 }
 
 type appsClient struct {
@@ -38,4 +39,13 @@ func NewClient(kclient cv1alpha1.KfV1alpha1Interface) Client {
 			membershipValidator: func(_ *v1alpha1.App) bool { return true },
 		},
 	}
+}
+
+// Restart causes the controller to create a new revision for the knative
+// service.
+func (ac *appsClient) Restart(namespace, name string) error {
+	return ac.coreClient.Transform(namespace, name, func(a *v1alpha1.App) error {
+		a.Spec.Template.UpdateRequests++
+		return nil
+	})
 }

--- a/pkg/kf/kfapps/fake/fake_client.go
+++ b/pkg/kf/kfapps/fake/fake_client.go
@@ -128,6 +128,20 @@ func (mr *FakeClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*FakeClient)(nil).List), varargs...)
 }
 
+// Restart mocks base method
+func (m *FakeClient) Restart(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Restart", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Restart indicates an expected call of Restart
+func (mr *FakeClientMockRecorder) Restart(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*FakeClient)(nil).Restart), arg0, arg1)
+}
+
 // Transform mocks base method
 func (m *FakeClient) Transform(arg0, arg1 string, arg2 kfapps.Mutator) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When a user does `kf restart`, kf will increment the
app.Spec.Template.UpdateRequests. The app controller will then update
the knative service, which will then result in a new revision.

fixes #286