### PR TITLE
pkg/kf/commands/app: adds restage command

### DIFF
--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -31,6 +31,7 @@ type ClientExtension interface {
 	// out.  The method exits once the logs are done streaming.
 	DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error
 	Restart(namespace, name string) error
+	Restage(namespace, name string) error
 }
 
 type appsClient struct {
@@ -67,6 +68,15 @@ func (ac *appsClient) DeleteInForeground(namespace string, name string) error {
 func (ac *appsClient) Restart(namespace, name string) error {
 	return ac.coreClient.Transform(namespace, name, func(a *v1alpha1.App) error {
 		a.Spec.Template.UpdateRequests++
+		return nil
+	})
+}
+
+// Restage causes the controller to create a new build and then deploy the
+// resulting container.
+func (ac *appsClient) Restage(namespace, name string) error {
+	return ac.coreClient.Transform(namespace, name, func(a *v1alpha1.App) error {
+		a.Spec.Source.UpdateRequests++
 		return nil
 	})
 }

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -157,6 +157,20 @@ func (mr *FakeClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*FakeClient)(nil).List), varargs...)
 }
 
+// Restage mocks base method
+func (m *FakeClient) Restage(arg0, arg1 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Restage", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Restage indicates an expected call of Restage
+func (mr *FakeClientMockRecorder) Restage(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restage", reflect.TypeOf((*FakeClient)(nil).Restage), arg0, arg1)
+}
+
 // Restart mocks base method
 func (m *FakeClient) Restart(arg0, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/kf/commands/apps/restage.go
+++ b/pkg/kf/commands/apps/restage.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/google/kf/pkg/kf/apps"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/commands/utils"
+	"github.com/spf13/cobra"
+)
+
+// NewRestageCommand creates a command capable of restaging an app.
+func NewRestageCommand(
+	p *config.KfParams,
+	client apps.Client,
+) *cobra.Command {
+	var restage = &cobra.Command{
+		Use:   "restage APP_NAME",
+		Short: "Restage creates a new container using the given source code and current buildpacks",
+		Example: `
+  kf restage myapp
+  `,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := utils.ValidateNamespace(p); err != nil {
+				return err
+			}
+
+			appName := args[0]
+
+			cmd.SilenceUsage = true
+
+			if err := client.Restage(p.Namespace, appName); err != nil {
+				return fmt.Errorf("failed to restage app: %s", err)
+			}
+
+			return nil
+		},
+	}
+	return restage
+}

--- a/pkg/kf/commands/apps/restage_test.go
+++ b/pkg/kf/commands/apps/restage_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/google/kf/pkg/kf/apps/fake"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/testutil"
+)
+
+func TestRestage(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Namespace       string
+		Args            []string
+		ExpectedStrings []string
+		ExpectedErr     error
+		Setup           func(t *testing.T, fake *fake.FakeClient)
+	}{
+		"restages app": {
+			Namespace: "default",
+			Args:      []string{"my-app"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Restage("default", "my-app")
+			},
+		},
+		"no app name": {
+			Namespace:   "default",
+			Args:        []string{},
+			ExpectedErr: errors.New("accepts 1 arg(s), received 0"),
+		},
+		"restage app fails": {
+			Namespace:   "default",
+			Args:        []string{"my-app"},
+			ExpectedErr: errors.New("failed to restage app: some-error"),
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Restage(gomock.Any(), gomock.Any()).
+					Return(errors.New("some-error"))
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fake := fake.NewFakeClient(ctrl)
+
+			if tc.Setup != nil {
+				tc.Setup(t, fake)
+			}
+
+			buf := new(bytes.Buffer)
+			p := &config.KfParams{
+				Namespace: tc.Namespace,
+			}
+
+			cmd := NewRestageCommand(p, fake)
+			cmd.SetOutput(buf)
+			cmd.SetArgs(tc.Args)
+			_, actualErr := cmd.ExecuteC()
+			if tc.ExpectedErr != nil || actualErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectedErr, actualErr)
+				return
+			}
+
+			testutil.AssertContainsAll(t, buf.String(), tc.ExpectedStrings)
+			testutil.AssertEqual(t, "SilenceUsage", true, cmd.SilenceUsage)
+
+			ctrl.Finish()
+		})
+	}
+}

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -64,6 +64,7 @@ func NewKfCommand() *cobra.Command {
 				InjectDelete(p),
 				InjectApps(p),
 				InjectRestart(p),
+				InjectRestage(p),
 				InjectScale(p),
 				InjectLogs(p),
 				InjectProxy(p),

--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -105,6 +105,18 @@ func InjectRestart(p *config.KfParams) *cobra.Command {
 	return command
 }
 
+func InjectRestage(p *config.KfParams) *cobra.Command {
+	kfV1alpha1Interface := config.GetKfClient(p)
+	appsGetter := provideAppsGetter(kfV1alpha1Interface)
+	systemEnvInjectorInterface := provideSystemEnvInjector(p)
+	sourcesGetter := provideKfSources(kfV1alpha1Interface)
+	buildTailer := provideSourcesBuildTailer()
+	client := sources.NewClient(sourcesGetter, buildTailer)
+	appsClient := apps.NewClient(appsGetter, systemEnvInjectorInterface, client)
+	command := apps2.NewRestageCommand(p, appsClient)
+	return command
+}
+
 func InjectProxy(p *config.KfParams) *cobra.Command {
 	kfV1alpha1Interface := config.GetKfClient(p)
 	appsGetter := provideAppsGetter(kfV1alpha1Interface)

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -103,6 +103,11 @@ func InjectRestart(p *config.KfParams) *cobra.Command {
 	return nil
 }
 
+func InjectRestage(p *config.KfParams) *cobra.Command {
+	wire.Build(capps.NewRestageCommand, AppsSet)
+	return nil
+}
+
 func InjectProxy(p *config.KfParams) *cobra.Command {
 	wire.Build(
 		capps.NewProxyCommand,


### PR DESCRIPTION
When a user does `kf restage`, kf will increment the
app.Spec.Source.UpdateRequests. The app controller will then update the
knative build, which will then result in a new container and then
revision.

fixes #287