### PR TITLE
Using anonymous auth for fetching images

### DIFF
--- a/pkg/kf/buildpacks/client.go
+++ b/pkg/kf/buildpacks/client.go
@@ -107,7 +107,7 @@ func (c *client) fetchConfig(builderImage string) (*gcrv1.ConfigFile, error) {
 		return nil, err
 	}
 
-	image, err := c.imageFetcher(imageRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	image, err := c.imageFetcher(imageRef, remote.WithAuth(authn.Anonymous))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR sets docker registry authentication to anonymous while fetching the builder image. Since the builder image will be public there is no need for authentication.

The current mechanism also falls back to anonymous after attempting to authenticate, however requires `docker-credential-gcr` set in `$PATH`. This removes the need for having it. 

Also addresses https://github.com/google/kf/issues/322.

## Test plan

`kf buildpacks` should run fine without `docker-credential-gcr` set in `$PATH`.
