### PR TITLE
pkg/reconciler/app: garbage collect revisions

### DIFF
--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -22,6 +22,7 @@ import (
 	sourceinformer "github.com/google/kf/pkg/client/injection/informers/kf/v1alpha1/source"
 	spaceinformer "github.com/google/kf/pkg/client/injection/informers/kf/v1alpha1/space"
 	"github.com/google/kf/pkg/reconciler"
+	krevisioninformer "github.com/knative/serving/pkg/client/injection/informers/serving/v1alpha1/revision"
 	kserviceinformer "github.com/knative/serving/pkg/client/injection/informers/serving/v1alpha1/service"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
@@ -35,17 +36,19 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Get informers off context
 	knativeServiceInformer := kserviceinformer.Get(ctx)
+	knativeRevisionInformer := krevisioninformer.Get(ctx)
 	sourceInformer := sourceinformer.Get(ctx)
 	appInformer := appinformer.Get(ctx)
 	spaceInformer := spaceinformer.Get(ctx)
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                 reconciler.NewBase(ctx, "app-controller", cmw),
-		knativeServiceLister: knativeServiceInformer.Lister(),
-		sourceLister:         sourceInformer.Lister(),
-		appLister:            appInformer.Lister(),
-		spaceLister:          spaceInformer.Lister(),
+		Base:                  reconciler.NewBase(ctx, "app-controller", cmw),
+		knativeServiceLister:  knativeServiceInformer.Lister(),
+		knativeRevisionLister: knativeRevisionInformer.Lister(),
+		sourceLister:          sourceInformer.Lister(),
+		appLister:             appInformer.Lister(),
+		spaceLister:           spaceInformer.Lister(),
 	}
 
 	impl := controller.NewImpl(c, logger, "Apps")

--- a/pkg/reconciler/app/reconciler.go
+++ b/pkg/reconciler/app/reconciler.go
@@ -19,11 +19,13 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	kflisters "github.com/google/kf/pkg/client/listers/kf/v1alpha1"
 	"github.com/google/kf/pkg/reconciler"
 	"github.com/google/kf/pkg/reconciler/app/resources"
+	"github.com/knative/serving/pkg/apis/autoscaling"
 	serving "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	servinglisters "github.com/knative/serving/pkg/client/listers/serving/v1alpha1"
 	"go.uber.org/zap"
@@ -40,10 +42,11 @@ import (
 type Reconciler struct {
 	*reconciler.Base
 
-	knativeServiceLister servinglisters.ServiceLister
-	sourceLister         kflisters.SourceLister
-	appLister            kflisters.AppLister
-	spaceLister          kflisters.SpaceLister
+	knativeServiceLister  servinglisters.ServiceLister
+	knativeRevisionLister servinglisters.RevisionLister
+	sourceLister          kflisters.SourceLister
+	appLister             kflisters.AppLister
+	spaceLister           kflisters.SpaceLister
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -174,7 +177,7 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, app *v1alpha1.App) error 
 	// Making it to the bottom of the reconciler means we've synchronized.
 	app.Status.ObservedGeneration = app.Generation
 
-	return nil
+	return r.gcRevisions(ctx, app)
 }
 
 func (r *Reconciler) latestSource(app *v1alpha1.App) (*v1alpha1.Source, error) {
@@ -246,4 +249,61 @@ func (r *Reconciler) updateStatus(desired *v1alpha1.App) (*v1alpha1.App, error) 
 	existing.Status = desired.Status
 
 	return r.KfClientSet.KfV1alpha1().Apps(existing.GetNamespace()).UpdateStatus(existing)
+}
+
+// gcRevisions is necessary because Knative won't scale down revisions
+// that have a `minScale` greater than 0. Therefore we are going to delete the
+// older revisions. The revisions are keeping pods around when app has been
+// scaled up. Therefore, if we don't GC the revisions, we leak pods.
+// TODO: Reevaluate once https://github.com/knative/serving/issues/4183 is
+// resolved.
+func (r *Reconciler) gcRevisions(ctx context.Context, app *v1alpha1.App) error {
+	r.Logger.Debugf("Checking for revisions that need to adjust %s...", autoscaling.MinScaleAnnotationKey)
+	defer r.Logger.Debugf("Done checking for revisions that need to adjust %s.", autoscaling.MinScaleAnnotationKey)
+
+	if app.Status.LatestCreatedRevisionName != app.Status.LatestReadyRevisionName {
+		r.Logger.Debugf("Not willing to garbage collection Revisions while the latest is not ready...")
+		return nil
+	}
+
+	selector := labels.Set{"serving.knative.dev/configuration": app.Name}.AsSelector()
+	revs, err := r.knativeRevisionLister.Revisions(app.Namespace).List(selector)
+	if err != nil {
+		return err
+	}
+
+	if len(revs) == 0 {
+		return nil
+	}
+
+	revisionClient := r.ServingClientSet.ServingV1alpha1().Revisions(app.Namespace)
+
+	parseGeneration := func(rev *serving.Revision) int64 {
+		v, ok := rev.Labels["serving.knative.dev/configurationGeneration"]
+		if !ok {
+			r.Logger.Warnf("Revision did not contain ConfigurationGeneration")
+			return -1
+		}
+
+		x, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			r.Logger.Warnf("Revision had an invalid ConfigurationGeneration: %s", err)
+			return -1
+		}
+		return x
+	}
+
+	// descending
+	sort.Slice(revs, func(i int, j int) bool {
+		return parseGeneration(revs[j]) < parseGeneration(revs[i])
+	})
+
+	// delete everything after the latest generation
+	for _, rev := range revs[1:] {
+		r.Logger.Infof("Garbage collecting Revision %s...", rev.Name)
+		if err := revisionClient.Delete(rev.Name, &metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
The app reconciler will look at related revisions for each update to an
App. Once the Status of the App has matching LatestReadyRevisionName and
LatestCreatedRevisionName, it will delete all the revisions but the one
with the largest "serving.knative.dev/configurationGeneration".

fixes #335