### PR TITLE
pkg/kf/commands: adds version command

### DIFF
--- a/hack/upload-release.sh
+++ b/hack/upload-release.sh
@@ -63,6 +63,9 @@ gsutil cp ${RELEASE_BUCKET}/${release_name} ${RELEASE_BUCKET}/release-latest.yam
 # Generate kf CLI #
 ###################
 
+hash=$(git rev-parse HEAD)
+[ -z "$hash" ] && echo "failed to read hash" && exit 1
+
 # Build and upload the binaries
 for os in $(echo linux darwin windows); do
   destination=kf-${os}-${current_time}
@@ -74,7 +77,7 @@ for os in $(echo linux darwin windows); do
   fi
 
   # Build
-  GOOS=${os} go build -o /tmp/${destination} ./cmd/kf
+  GOOS=${os} go build -o /tmp/${destination} "-X github.com/google/kf/pkg/kf/commands.Version=${hash}" ./cmd/kf
 
   # Upload
   gsutil cp /tmp/${destination} ${CLI_RELEASE_BUCKET}/${destination}

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/google/kf/pkg/kf/commands/config"
@@ -155,6 +156,7 @@ func NewKfCommand() *cobra.Command {
 
 				completionCommand(rootCmd),
 				NewTargetCommand(p),
+				NewVersionCommand(Version, runtime.GOOS),
 			},
 		},
 	}

--- a/pkg/kf/commands/version.go
+++ b/pkg/kf/commands/version.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// NewVersionCommand returns a command that displays the version.
+func NewVersionCommand(version, goos string) *cobra.Command {
+	return &cobra.Command{
+		Use:     "version",
+		Short:   "Display the CLI version",
+		Example: `  kf version`,
+		Args:    cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintln(cmd.OutOrStdout(), "kf version", version, goos)
+			return nil
+		},
+	}
+}
+
+// Version is filled in via ldflags.
+var Version = "dev"


### PR DESCRIPTION
version will display the current version. The version is provided via
ldflags. The hack/upload-release.sh script (used by the nightly build)
has been updated to include the current hash.

fixes #320