### PR TITLE
pkg/kf/commands/apps: apps command uses SilenceUsage

### DIFF
--- a/pkg/kf/commands/apps/apps.go
+++ b/pkg/kf/commands/apps/apps.go
@@ -35,6 +35,7 @@ func NewAppsCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command {
 			if err := utils.ValidateNamespace(p); err != nil {
 				return err
 			}
+			cmd.SilenceUsage = true
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Getting apps in namespace: %s\n", p.Namespace)
 

--- a/pkg/kf/commands/apps/apps_test.go
+++ b/pkg/kf/commands/apps/apps_test.go
@@ -143,6 +143,7 @@ func TestAppsCommand(t *testing.T) {
 				testutil.AssertErrorsEqual(t, tc.wantErr, gotErr)
 				return
 			}
+			testutil.AssertEqual(t, "SilenceUsage", true, c.SilenceUsage)
 
 			if tc.assert != nil {
 				tc.assert(t, buffer)


### PR DESCRIPTION
If there is an error connecting to the K8s cluster, showing the user
usage information is confusing.