### PR TITLE
pkg/kf/testutil: use DOCKER_REGISTRY for integration tests

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -30,11 +30,11 @@ trap finish EXIT
 
 if [ "${SKIP_INTEGRATION:-false}" = "true" ]; then
     echo "SKIP_INTEGRATION set to 'true'. Skipping integration tests..."
-    export GCP_PROJECT_ID=""
+    export DOCKER_REGISTRY=""
 else
-  if [ "${GCP_PROJECT_ID}" = "" ]; then
+  if [ "${DOCKER_REGISTRY}" = "" ]; then
     echo running integration tests
-    export GCP_PROJECT_ID=$(gcloud config get-value project)
+    export DOCKER_REGISTRY="gcr.io/$(gcloud config get-value project)"
   fi
 fi
 

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -50,7 +50,7 @@ func TestIntegration_Push(t *testing.T) {
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 		)
 		defer kf.Delete(ctx, appName)
 
@@ -103,7 +103,7 @@ func TestIntegration_Push_manifest(t *testing.T) {
 		// Push an app with a manifest file.
 		kf.Push(ctx, appName,
 			"--path", appPath,
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 			"--manifest", newManifestFile,
 		)
 		defer kf.Delete(ctx, appName)
@@ -179,7 +179,7 @@ func TestIntegration_Delete(t *testing.T) {
 		// simplies replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 		)
 
 		// This is only in place for cleanup if the test fails.
@@ -218,7 +218,7 @@ func TestIntegration_Envs(t *testing.T) {
 		// variables (ENV1 and ENV2).
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 			"--env", "ENV1=VALUE1",
 			"--env=ENV2=VALUE2",
 		)
@@ -265,7 +265,7 @@ func TestIntegration_Logs(t *testing.T) {
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 		)
 		defer kf.Delete(ctx, appName)
 
@@ -448,7 +448,7 @@ func TestIntegration_Push_Instances(t *testing.T) {
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", fmt.Sprintf("gcr.io/%s", GCPProjectID()),
+			"--container-registry", DockerRegistry(),
 			"--instances", "2",
 		)
 		defer kf.Delete(ctx, appName)

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -32,15 +32,16 @@ import (
 )
 
 const (
-	// EnvGcpProjectID is the environment variable used to store the GCP
-	// project ID for the integration tests. If this is not set, then the
-	// integration tests are skipped.
-	EnvGcpProjectID = "GCP_PROJECT_ID"
+	// EnvDockerRegistry is the environment variable used to store the
+	// registry we will push containers to for the integration tests. If this
+	// is not set, then the integration tests are skipped.
+	EnvDockerRegistry = "DOCKER_REGISTRY"
 )
 
-// GCPProjectID returns the configured GCP Project ID.
-func GCPProjectID() string {
-	return os.Getenv(EnvGcpProjectID)
+// DockerRegistry returns the configured docker registry for the integration
+// tests.
+func DockerRegistry() string {
+	return os.Getenv(EnvDockerRegistry)
 }
 
 // RunIntegrationTest skips the tests if testing.Short() is true (via --short
@@ -51,9 +52,9 @@ func RunIntegrationTest(t *testing.T, test func(ctx context.Context, t *testing.
 		t.Skip()
 	}
 
-	projID := os.Getenv(EnvGcpProjectID)
+	projID := os.Getenv(EnvDockerRegistry)
 	if projID == "" {
-		t.Skipf("%s is required for integration tests... Skipping...", EnvGcpProjectID)
+		t.Skipf("%s is required for integration tests... Skipping...", EnvDockerRegistry)
 	}
 
 	// Setup context that will allow us to cleanup if the user wants to


### PR DESCRIPTION
Before this CL, we assumed gcr.io for the docker registry. This CL
allows a developer to set any docker registry.