### PR TITLE
Add the --docker-image flag

### DIFF
--- a/pkg/kf/apps/fake/fake_pusher.go
+++ b/pkg/kf/apps/fake/fake_pusher.go
@@ -49,10 +49,10 @@ func (m *FakePusher) EXPECT() *FakePusherMockRecorder {
 }
 
 // Push mocks base method
-func (m *FakePusher) Push(arg0, arg1 string, arg2 ...apps.PushOption) error {
+func (m *FakePusher) Push(arg0 string, arg1 ...apps.PushOption) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1}
-	for _, a := range arg2 {
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Push", varargs...)
@@ -61,8 +61,8 @@ func (m *FakePusher) Push(arg0, arg1 string, arg2 ...apps.PushOption) error {
 }
 
 // Push indicates an expected call of Push
-func (mr *FakePusherMockRecorder) Push(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+func (mr *FakePusherMockRecorder) Push(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Push", reflect.TypeOf((*FakePusher)(nil).Push), varargs...)
 }

--- a/pkg/kf/apps/push-options.yml
+++ b/pkg/kf/apps/push-options.yml
@@ -10,6 +10,12 @@ common:
 configs:
 - name: Push
   options:
+  - name: SourceImage
+    type: string
+    description: the source code as a container image
+  - name: ContainerImage
+    type: string
+    description: the container to deploy
   - name: Buildpack
     type: string
     description: skip the detect buildpack step and use the given name

--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -35,7 +35,7 @@ type pusher struct {
 // Pusher deploys applications.
 type Pusher interface {
 	// Push deploys an application.
-	Push(appName, srcImageName string, opts ...PushOption) error
+	Push(appName string, opts ...PushOption) error
 }
 
 // NewPusher creates a new Pusher.
@@ -45,7 +45,7 @@ func NewPusher(client Client) Pusher {
 	}
 }
 
-func newApp(appName, srcImage string, opts ...PushOption) (*v1alpha1.App, error) {
+func newApp(appName string, opts ...PushOption) (*v1alpha1.App, error) {
 
 	cfg := PushOptionDefaults().Extend(opts).toConfig()
 
@@ -59,7 +59,8 @@ func newApp(appName, srcImage string, opts ...PushOption) (*v1alpha1.App, error)
 	}
 
 	src := sources.NewKfSource()
-	src.SetBuildpackBuildSource(srcImage)
+	src.SetBuildpackBuildSource(cfg.SourceImage)
+	src.SetContainerImageSource(cfg.ContainerImage)
 	src.SetBuildpackBuildRegistry(cfg.ContainerRegistry)
 	src.SetBuildpackBuildEnv(envs)
 	src.SetBuildpackBuildBuildpack(cfg.Buildpack)
@@ -83,10 +84,10 @@ func newApp(appName, srcImage string, opts ...PushOption) (*v1alpha1.App, error)
 
 // Push deploys an application to Knative. It can be configured via
 // Optionapp.
-func (p *pusher) Push(appName, srcImage string, opts ...PushOption) error {
+func (p *pusher) Push(appName string, opts ...PushOption) error {
 	cfg := PushOptionDefaults().Extend(opts).toConfig()
 
-	app, err := newApp(appName, srcImage, opts...)
+	app, err := newApp(appName, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create app: %s", err)
 	}

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -24,6 +24,8 @@ import (
 type pushConfig struct {
 	// Buildpack is skip the detect buildpack step and use the given name
 	Buildpack string
+	// ContainerImage is the container to deploy
+	ContainerImage string
 	// ContainerRegistry is the container registry's URL
 	ContainerRegistry string
 	// EnvironmentVariables is set environment variables
@@ -40,6 +42,8 @@ type pushConfig struct {
 	Output io.Writer
 	// ServiceAccount is the service account to authenticate with
 	ServiceAccount string
+	// SourceImage is the source code as a container image
+	SourceImage string
 }
 
 // PushOption is a single option for configuring a pushConfig
@@ -72,6 +76,12 @@ func (opts PushOptions) Extend(other PushOptions) PushOptions {
 // if not set.
 func (opts PushOptions) Buildpack() string {
 	return opts.toConfig().Buildpack
+}
+
+// ContainerImage returns the last set value for ContainerImage or the empty value
+// if not set.
+func (opts PushOptions) ContainerImage() string {
+	return opts.toConfig().ContainerImage
 }
 
 // ContainerRegistry returns the last set value for ContainerRegistry or the empty value
@@ -122,10 +132,23 @@ func (opts PushOptions) ServiceAccount() string {
 	return opts.toConfig().ServiceAccount
 }
 
+// SourceImage returns the last set value for SourceImage or the empty value
+// if not set.
+func (opts PushOptions) SourceImage() string {
+	return opts.toConfig().SourceImage
+}
+
 // WithPushBuildpack creates an Option that sets skip the detect buildpack step and use the given name
 func WithPushBuildpack(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.Buildpack = val
+	}
+}
+
+// WithPushContainerImage creates an Option that sets the container to deploy
+func WithPushContainerImage(val string) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.ContainerImage = val
 	}
 }
 
@@ -182,6 +205,13 @@ func WithPushOutput(val io.Writer) PushOption {
 func WithPushServiceAccount(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.ServiceAccount = val
+	}
+}
+
+// WithPushSourceImage creates an Option that sets the source code as a container image
+func WithPushSourceImage(val string) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.SourceImage = val
 	}
 }
 

--- a/pkg/kf/apps/push_test.go
+++ b/pkg/kf/apps/push_test.go
@@ -209,6 +209,20 @@ func TestPush(t *testing.T) {
 					Return(&v1alpha1.App{}, nil)
 			},
 		},
+		"pushes a container image": {
+			appName: "some-app",
+			opts: apps.PushOptions{
+				apps.WithPushContainerImage("some-image"),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "containerImage", "some-image", newObj.Spec.Source.ContainerImage.Image)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
 		"deployer returns an error": {
 			appName: "some-app",
 			opts: apps.PushOptions{

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -100,8 +100,7 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 				if buildpack != "" {
 					return errors.New("cannot use --buildpack and --docker-image simultaneously")
 				}
-				// the defualt value
-				if path != "." {
+				if path != "." { // the default value
 					return errors.New("cannot use --path and --docker-image simultaneously")
 				}
 			}

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -93,13 +93,28 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 				return err
 			}
 
+			if containerImage != "" {
+				if containerRegistry != "" {
+					return errors.New("cannot use --container-registry and --docker-image simultaneously")
+				}
+				if buildpack != "" {
+					return errors.New("cannot use --buildpack and --docker-image simultaneously")
+				}
+				// the defualt value
+				if path != "." {
+					return errors.New("cannot use --path and --docker-image simultaneously")
+				}
+			}
+
 			switch {
 			case containerRegistry != "":
 				break
 			case space.Spec.BuildpackBuild.ContainerRegistry != "":
 				containerRegistry = space.Spec.BuildpackBuild.ContainerRegistry
 			default:
-				return errors.New("container-registry is required")
+				if containerImage == "" {
+					return errors.New("container-registry is required for buildpack apps")
+				}
 			}
 
 			cmd.SilenceUsage = true

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -146,7 +146,7 @@ func TestPushCommand(t *testing.T) {
 		"container-registry is not provided": {
 			namespace: "some-namespace",
 			args:      []string{"app-name"},
-			wantErr:   errors.New("container-registry is required"),
+			wantErr:   errors.New("container-registry is required for buildpack apps"),
 		},
 		"container-registry comes from space": {
 			namespace: "some-namespace",
@@ -181,6 +181,46 @@ func TestPushCommand(t *testing.T) {
 				"--env", "invalid",
 			},
 			wantErr: errors.New("malformed environment variable: invalid"),
+		},
+		"container image": {
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--docker-image", "some-image",
+			},
+			wantOpts: []apps.PushOption{
+				apps.WithPushNamespace("some-namespace"),
+				apps.WithPushContainerImage("some-image"),
+				apps.WithPushMinScale(1),
+				apps.WithPushMaxScale(1),
+			},
+		},
+		"inavlid buildpack and container image": {
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--docker-image", "some-image",
+				"--buildpack", "some-buildpack",
+			},
+			wantErr: errors.New("cannot use --buildpack and --docker-image simultaneously"),
+		},
+		"inavlid container registry and container image": {
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--docker-image", "some-image",
+				"--container-registry", "some-registry",
+			},
+			wantErr: errors.New("cannot use --container-registry and --docker-image simultaneously"),
+		},
+		"inavlid path and container image": {
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--docker-image", "some-image",
+				"--path", "some-path",
+			},
+			wantErr: errors.New("cannot use --path and --docker-image simultaneously"),
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -195,6 +195,21 @@ func TestPushCommand(t *testing.T) {
 				apps.WithPushMaxScale(1),
 			},
 		},
+		"container image with env vars": {
+			namespace: "some-namespace",
+			args: []string{
+				"app-name",
+				"--docker-image", "some-image",
+				"--env", "WHATNOW=BROWNCOW",
+			},
+			wantOpts: []apps.PushOption{
+				apps.WithPushNamespace("some-namespace"),
+				apps.WithPushContainerImage("some-image"),
+				apps.WithPushMinScale(1),
+				apps.WithPushMaxScale(1),
+				apps.WithPushEnvironmentVariables(map[string]string{"WHATNOW": "BROWNCOW"}),
+			},
+		},
 		"inavlid buildpack and container image": {
 			namespace: "some-namespace",
 			args: []string{

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -194,8 +194,8 @@ func TestPushCommand(t *testing.T) {
 
 			fakePusher.
 				EXPECT().
-				Push(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(appName, srcImage string, opts ...apps.PushOption) error {
+				Push(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(appName string, opts ...apps.PushOption) error {
 					testutil.AssertEqual(t, "app name", tc.args[0], appName)
 
 					expectOpts := apps.PushOptions(tc.wantOpts)
@@ -209,9 +209,10 @@ func TestPushCommand(t *testing.T) {
 					testutil.AssertEqual(t, "min scale bound", expectOpts.MinScale(), actualOpts.MinScale())
 					testutil.AssertEqual(t, "max scale bound", expectOpts.MaxScale(), actualOpts.MaxScale())
 
-					if !strings.HasPrefix(srcImage, tc.wantImagePrefix) {
-						t.Errorf("Wanted srcImage to start with %s got: %s", tc.wantImagePrefix, srcImage)
+					if !strings.HasPrefix(actualOpts.SourceImage(), tc.wantImagePrefix) {
+						t.Errorf("Wanted srcImage to start with %s got: %s", tc.wantImagePrefix, actualOpts.SourceImage())
 					}
+					testutil.AssertEqual(t, "containerImage", expectOpts.ContainerImage(), actualOpts.ContainerImage())
 
 					return tc.pusherErr
 				})


### PR DESCRIPTION
Note my use of container-image throughout the code. This is a trend I started with the CRDs: to move away from the brand name Docker because of OCI. However, in CF the flag is `--docker-image` so I kept that. Maybe we should also add an alias `--container-image`?

The logic in push is too complicated, but I didn't want to muddle this PR by refactoring it.