### PR TITLE
pkg/kf/commands/apps: adds start and stop commands

### DIFF
--- a/pkg/kf/commands/apps/start.go
+++ b/pkg/kf/commands/apps/start.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/apps"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/commands/utils"
+	"github.com/spf13/cobra"
+)
+
+// NewStartCommand creates a command capable of starting an app.
+func NewStartCommand(
+	p *config.KfParams,
+	client apps.Client,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:   "start APP_NAME",
+		Short: "Start starts the app",
+		Example: `
+  kf start myapp
+  `,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := utils.ValidateNamespace(p); err != nil {
+				return err
+			}
+
+			appName := args[0]
+
+			cmd.SilenceUsage = true
+
+			mutator := func(app *v1alpha1.App) error {
+				app.Spec.Instances.Stopped = false
+				return nil
+			}
+
+			if err := client.Transform(p.Namespace, appName, mutator); err != nil {
+				return fmt.Errorf("failed to start app: %s", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/pkg/kf/commands/apps/start_test.go
+++ b/pkg/kf/commands/apps/start_test.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/apps"
+	"github.com/google/kf/pkg/kf/apps/fake"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/testutil"
+)
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Namespace       string
+		Args            []string
+		ExpectedStrings []string
+		ExpectedErr     error
+		Setup           func(t *testing.T, fake *fake.FakeClient)
+	}{
+		"starts app": {
+			Namespace: "default",
+			Args:      []string{"my-app"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Transform("default", "my-app", gomock.Any()).
+					Do(func(_, _ string, mutator apps.Mutator) {
+						var app v1alpha1.App
+						mutator(&app)
+						testutil.AssertEqual(t, "app.spec.instances.stopped", false, app.Spec.Instances.Stopped)
+					})
+			},
+		},
+		"no app name": {
+			Namespace:   "default",
+			Args:        []string{},
+			ExpectedErr: errors.New("accepts 1 arg(s), received 0"),
+		},
+		"starting app fails": {
+			Namespace:   "default",
+			Args:        []string{"my-app"},
+			ExpectedErr: errors.New("failed to start app: some-error"),
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Transform(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("some-error"))
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fake := fake.NewFakeClient(ctrl)
+
+			if tc.Setup != nil {
+				tc.Setup(t, fake)
+			}
+
+			buf := new(bytes.Buffer)
+			p := &config.KfParams{
+				Namespace: tc.Namespace,
+			}
+
+			cmd := NewStartCommand(p, fake)
+			cmd.SetOutput(buf)
+			cmd.SetArgs(tc.Args)
+			_, actualErr := cmd.ExecuteC()
+			if tc.ExpectedErr != nil || actualErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectedErr, actualErr)
+				return
+			}
+
+			testutil.AssertContainsAll(t, buf.String(), tc.ExpectedStrings)
+			testutil.AssertEqual(t, "SilenceUsage", true, cmd.SilenceUsage)
+
+			ctrl.Finish()
+		})
+	}
+}

--- a/pkg/kf/commands/apps/stop.go
+++ b/pkg/kf/commands/apps/stop.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"fmt"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/apps"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/commands/utils"
+	"github.com/spf13/cobra"
+)
+
+// NewStopCommand creates a command capable of stopping an app.
+func NewStopCommand(
+	p *config.KfParams,
+	client apps.Client,
+) *cobra.Command {
+	return &cobra.Command{
+		Use:   "stop APP_NAME",
+		Short: "Stop stops the app",
+		Example: `
+  kf stop myapp
+  `,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := utils.ValidateNamespace(p); err != nil {
+				return err
+			}
+
+			appName := args[0]
+
+			cmd.SilenceUsage = true
+
+			mutator := func(app *v1alpha1.App) error {
+				app.Spec.Instances.Stopped = true
+				return nil
+			}
+
+			if err := client.Transform(p.Namespace, appName, mutator); err != nil {
+				return fmt.Errorf("failed to stop app: %s", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/pkg/kf/commands/apps/stop_test.go
+++ b/pkg/kf/commands/apps/stop_test.go
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/apps"
+	"github.com/google/kf/pkg/kf/apps/fake"
+	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/testutil"
+)
+
+func TestStop(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		Namespace       string
+		Args            []string
+		ExpectedStrings []string
+		ExpectedErr     error
+		Setup           func(t *testing.T, fake *fake.FakeClient)
+	}{
+		"stops app": {
+			Namespace: "default",
+			Args:      []string{"my-app"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Transform("default", "my-app", gomock.Any()).
+					Do(func(_, _ string, mutator apps.Mutator) {
+						var app v1alpha1.App
+						mutator(&app)
+						testutil.AssertEqual(t, "app.spec.instances.stopped", true, app.Spec.Instances.Stopped)
+					})
+			},
+		},
+		"no app name": {
+			Namespace:   "default",
+			Args:        []string{},
+			ExpectedErr: errors.New("accepts 1 arg(s), received 0"),
+		},
+		"stopping app fails": {
+			Namespace:   "default",
+			Args:        []string{"my-app"},
+			ExpectedErr: errors.New("failed to stop app: some-error"),
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().
+					Transform(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("some-error"))
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fake := fake.NewFakeClient(ctrl)
+
+			if tc.Setup != nil {
+				tc.Setup(t, fake)
+			}
+
+			buf := new(bytes.Buffer)
+			p := &config.KfParams{
+				Namespace: tc.Namespace,
+			}
+
+			cmd := NewStopCommand(p, fake)
+			cmd.SetOutput(buf)
+			cmd.SetArgs(tc.Args)
+			_, actualErr := cmd.ExecuteC()
+			if tc.ExpectedErr != nil || actualErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectedErr, actualErr)
+				return
+			}
+
+			testutil.AssertContainsAll(t, buf.String(), tc.ExpectedStrings)
+			testutil.AssertEqual(t, "SilenceUsage", true, cmd.SilenceUsage)
+
+			ctrl.Finish()
+		})
+	}
+}

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -64,6 +64,8 @@ func NewKfCommand() *cobra.Command {
 				InjectPush(p),
 				InjectDelete(p),
 				InjectApps(p),
+				InjectStart(p),
+				InjectStop(p),
 				InjectRestart(p),
 				InjectRestage(p),
 				InjectScale(p),

--- a/pkg/kf/commands/wire_gen.go
+++ b/pkg/kf/commands/wire_gen.go
@@ -93,6 +93,30 @@ func InjectScale(p *config.KfParams) *cobra.Command {
 	return command
 }
 
+func InjectStart(p *config.KfParams) *cobra.Command {
+	kfV1alpha1Interface := config.GetKfClient(p)
+	appsGetter := provideAppsGetter(kfV1alpha1Interface)
+	systemEnvInjectorInterface := provideSystemEnvInjector(p)
+	sourcesGetter := provideKfSources(kfV1alpha1Interface)
+	buildTailer := provideSourcesBuildTailer()
+	client := sources.NewClient(sourcesGetter, buildTailer)
+	appsClient := apps.NewClient(appsGetter, systemEnvInjectorInterface, client)
+	command := apps2.NewStartCommand(p, appsClient)
+	return command
+}
+
+func InjectStop(p *config.KfParams) *cobra.Command {
+	kfV1alpha1Interface := config.GetKfClient(p)
+	appsGetter := provideAppsGetter(kfV1alpha1Interface)
+	systemEnvInjectorInterface := provideSystemEnvInjector(p)
+	sourcesGetter := provideKfSources(kfV1alpha1Interface)
+	buildTailer := provideSourcesBuildTailer()
+	client := sources.NewClient(sourcesGetter, buildTailer)
+	appsClient := apps.NewClient(appsGetter, systemEnvInjectorInterface, client)
+	command := apps2.NewStopCommand(p, appsClient)
+	return command
+}
+
 func InjectRestart(p *config.KfParams) *cobra.Command {
 	kfV1alpha1Interface := config.GetKfClient(p)
 	appsGetter := provideAppsGetter(kfV1alpha1Interface)

--- a/pkg/kf/commands/wire_injector.go
+++ b/pkg/kf/commands/wire_injector.go
@@ -98,6 +98,16 @@ func InjectScale(p *config.KfParams) *cobra.Command {
 	return nil
 }
 
+func InjectStart(p *config.KfParams) *cobra.Command {
+	wire.Build(capps.NewStartCommand, AppsSet)
+	return nil
+}
+
+func InjectStop(p *config.KfParams) *cobra.Command {
+	wire.Build(capps.NewStopCommand, AppsSet)
+	return nil
+}
+
 func InjectRestart(p *config.KfParams) *cobra.Command {
 	wire.Build(capps.NewRestartCommand, AppsSet)
 	return nil

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -598,6 +598,36 @@ func (k *Kf) Delete(ctx context.Context, appName string) {
 	StreamOutput(ctx, k.t, output)
 }
 
+// Stop stops an application.
+func (k *Kf) Stop(ctx context.Context, appName string) {
+	k.t.Helper()
+	Logf(k.t, "stopping %q...", appName)
+	defer Logf(k.t, "done stopping %q.", appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"stop",
+			appName,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("stop %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// Start starts an application.
+func (k *Kf) Start(ctx context.Context, appName string) {
+	k.t.Helper()
+	Logf(k.t, "starting %q...", appName)
+	defer Logf(k.t, "done starting %q.", appName)
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: []string{
+			"start",
+			appName,
+		},
+	})
+	PanicOnError(ctx, k.t, fmt.Sprintf("start %q", appName), errs)
+	StreamOutput(ctx, k.t, output)
+}
+
 // Proxy starts a proxy for an application.
 func (k *Kf) Proxy(ctx context.Context, appName string, port int) {
 	k.t.Helper()


### PR DESCRIPTION
The commands simply toggle the app.Spec.Instances.Stopped value. The
controller has been updated to delete the knative service if the app is
stopped. This is required because knative will otherwise delete the pods
and bring back a single pod for a while (even if scaling is set to 0):
https://github.com/knative/serving/issues/4098

fixes #282