### PR TITLE
pkg/kf/apps: adds --no-start flag to push

### DIFF
--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -29,7 +29,7 @@ type ClientExtension interface {
 
 	// DeployLogs writes the logs for the build and deploy stage to the given
 	// out.  The method exits once the logs are done streaming.
-	DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error
+	DeployLogs(out io.Writer, appName, resourceVersion, namespace string, noStart bool) error
 	Restart(namespace, name string) error
 	Restage(namespace, name string) error
 }

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -104,17 +104,17 @@ func (mr *FakeClientMockRecorder) DeleteInForeground(arg0, arg1 interface{}) *go
 }
 
 // DeployLogs mocks base method
-func (m *FakeClient) DeployLogs(arg0 io.Writer, arg1, arg2, arg3 string) error {
+func (m *FakeClient) DeployLogs(arg0 io.Writer, arg1, arg2, arg3 string, arg4 bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeployLogs", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "DeployLogs", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeployLogs indicates an expected call of DeployLogs
-func (mr *FakeClientMockRecorder) DeployLogs(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *FakeClientMockRecorder) DeployLogs(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLogs", reflect.TypeOf((*FakeClient)(nil).DeployLogs), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLogs", reflect.TypeOf((*FakeClient)(nil).DeployLogs), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Get mocks base method

--- a/pkg/kf/apps/log_tailer.go
+++ b/pkg/kf/apps/log_tailer.go
@@ -32,7 +32,13 @@ import (
 
 // DeployLogs writes the logs for the deploy step for the resourceVersion
 // to out. It blocks until the operation has completed.
-func (a *appsClient) DeployLogs(out io.Writer, appName, resourceVersion, namespace string) error {
+func (a *appsClient) DeployLogs(
+	out io.Writer,
+	appName string,
+	resourceVersion string,
+	namespace string,
+	noStart bool,
+) error {
 	logger := log.New(out, "\033[32m[build]\033[0m ", 0)
 	logger.Printf("Starting app: %s\n", appName)
 	start := time.Now()
@@ -88,6 +94,11 @@ func (a *appsClient) DeployLogs(out io.Writer, appName, resourceVersion, namespa
 				},
 			)
 			continue
+		}
+
+		if noStart {
+			logger.Printf("Total deploy time %0.2f seconds\n", time.Now().Sub(deployStart).Seconds())
+			return nil
 		}
 
 		appReady := app.Status.GetCondition(v1alpha1.AppConditionReady)

--- a/pkg/kf/apps/log_tailer_test.go
+++ b/pkg/kf/apps/log_tailer_test.go
@@ -42,6 +42,7 @@ func TestLogTailer_DeployLogs_ServiceLogs(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		appName                  string
 		namespace                string
+		noStart                  bool
 		resourceVersion          string
 		serviceWatchErr          error
 		events                   []watch.Event
@@ -66,6 +67,27 @@ func TestLogTailer_DeployLogs_ServiceLogs(t *testing.T) {
 			},
 			),
 			wantedMsgs: []string{"msg-1", "msg-2"},
+		},
+		"NoStart don't display deployment messages": {
+			appName:         "some-app",
+			namespace:       "default",
+			resourceVersion: "some-version",
+			noStart:         true,
+			events: createMsgEvents("some-app", duckv1beta1.Conditions{
+				{
+					Type:    "SourceReady",
+					Status:  "True",
+					Message: "msg-1",
+				},
+				{
+					Type:    "Ready",
+					Status:  "True",
+					Message: "msg-2",
+				},
+			},
+			),
+			wantedMsgs:   []string{"msg-1"},
+			unwantedMsgs: []string{"msg-2"},
 		},
 		"watch service returns an error, return error": {
 			appName:         "some-app",
@@ -117,7 +139,13 @@ func TestLogTailer_DeployLogs_ServiceLogs(t *testing.T) {
 			lt := apps.NewClient(fakeApps, seif, sourceClient)
 
 			var buffer bytes.Buffer
-			gotErr := lt.DeployLogs(&buffer, tc.appName, tc.resourceVersion, tc.namespace)
+			gotErr := lt.DeployLogs(
+				&buffer,
+				tc.appName,
+				tc.resourceVersion,
+				tc.namespace,
+				tc.noStart,
+			)
 			if tc.wantErr != nil || gotErr != nil {
 				testutil.AssertErrorsEqual(t, tc.wantErr, gotErr)
 				return

--- a/pkg/kf/apps/push-options.yml
+++ b/pkg/kf/apps/push-options.yml
@@ -41,4 +41,7 @@ configs:
   - name: MaxScale
     type: int
     description: the upper scale bound
+  - name: NoStart
+    type: bool
+    description: setup the app without starting it
 - name: Deploy

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -38,6 +38,8 @@ type pushConfig struct {
 	MinScale int
 	// Namespace is the Kubernetes namespace to use
 	Namespace string
+	// NoStart is setup the app without starting it
+	NoStart bool
 	// Output is the io.Writer to write output such as build logs
 	Output io.Writer
 	// ServiceAccount is the service account to authenticate with
@@ -120,6 +122,12 @@ func (opts PushOptions) Namespace() string {
 	return opts.toConfig().Namespace
 }
 
+// NoStart returns the last set value for NoStart or the empty value
+// if not set.
+func (opts PushOptions) NoStart() bool {
+	return opts.toConfig().NoStart
+}
+
 // Output returns the last set value for Output or the empty value
 // if not set.
 func (opts PushOptions) Output() io.Writer {
@@ -191,6 +199,13 @@ func WithPushMinScale(val int) PushOption {
 func WithPushNamespace(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.Namespace = val
+	}
+}
+
+// WithPushNoStart creates an Option that sets setup the app without starting it
+func WithPushNoStart(val bool) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.NoStart = val
 	}
 }
 

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -71,6 +71,7 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 		buildpack         string
 		envs              []string
 		grpc              bool
+		noStart           bool
 	)
 
 	var pushCmd = &cobra.Command{
@@ -212,6 +213,7 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 					apps.WithPushBuildpack(buildpack),
 					apps.WithPushMinScale(minScale),
 					apps.WithPushMaxScale(maxScale),
+					apps.WithPushNoStart(noStart),
 				)
 
 				cmd.SilenceUsage = !kfi.ConfigError(err)
@@ -299,6 +301,13 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 		"i",
 		-1, // -1 represents non-user input
 		"the number of instances (default is 1)",
+	)
+
+	pushCmd.Flags().BoolVar(
+		&noStart,
+		"no-start",
+		false,
+		"Do not start an app after pushing",
 	)
 
 	return pushCmd

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -58,6 +58,7 @@ func TestPushCommand(t *testing.T) {
 				"--container-registry", "some-reg.io",
 				"--instances", "1",
 				"--path", "testdata/example-app",
+				"--no-start",
 			},
 			wantImagePrefix: "some-reg.io/src-some-namespace-example-app",
 			srcImageBuilder: func(dir, srcImage string, rebase bool) error {
@@ -74,6 +75,7 @@ func TestPushCommand(t *testing.T) {
 				apps.WithPushEnvironmentVariables(map[string]string{"env1": "val1", "env2": "val2"}),
 				apps.WithPushMinScale(1),
 				apps.WithPushMaxScale(1),
+				apps.WithPushNoStart(true),
 			},
 		},
 		"uses current working directory for empty path": {
@@ -263,6 +265,7 @@ func TestPushCommand(t *testing.T) {
 					testutil.AssertEqual(t, "env vars", expectOpts.EnvironmentVariables(), actualOpts.EnvironmentVariables())
 					testutil.AssertEqual(t, "min scale bound", expectOpts.MinScale(), actualOpts.MinScale())
 					testutil.AssertEqual(t, "max scale bound", expectOpts.MaxScale(), actualOpts.MaxScale())
+					testutil.AssertEqual(t, "no start", expectOpts.NoStart(), actualOpts.NoStart())
 
 					if !strings.HasPrefix(actualOpts.SourceImage(), tc.wantImagePrefix) {
 						t.Errorf("Wanted srcImage to start with %s got: %s", tc.wantImagePrefix, actualOpts.SourceImage())


### PR DESCRIPTION
When the --no-start flag is used, the source code is uploaded and built,
however the knative service is not created.

fixes #289