### PR TITLE
Adds ability to poll until a predicate is done

### DIFF
--- a/pkg/apis/kf/v1alpha1/utils.go
+++ b/pkg/apis/kf/v1alpha1/utils.go
@@ -25,6 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	cv1alpha3 "knative.dev/pkg/client/clientset/versioned/typed/istio/v1alpha3"
 )
 
@@ -166,4 +167,20 @@ func SetupIstioClient(ctx context.Context, istioClient cv1alpha3.VirtualServices
 
 func IstioClientFromContext(ctx context.Context) cv1alpha3.VirtualServicesGetter {
 	return ctx.Value(istioClientKey{}).(cv1alpha3.VirtualServicesGetter)
+}
+
+// IsStatusFinal returns true if the Ready or Succeeded conditions are True or
+// False for a Status.
+func IsStatusFinal(duck duckv1beta1.Status) bool {
+	// Ready conditions are used for long running tasks while Succeeded conditions
+	// are used for one time tasks so it's okay to include both.
+	if cond := duck.GetCondition(apis.ConditionReady); cond != nil {
+		return cond.IsTrue() || cond.IsFalse()
+	}
+
+	if cond := duck.GetCondition(apis.ConditionSucceeded); cond != nil {
+		return cond.IsTrue() || cond.IsFalse()
+	}
+
+	return false
 }

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -20,6 +20,7 @@
 package fake
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	apps "github.com/google/kf/pkg/kf/apps"
@@ -236,7 +237,7 @@ func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // WaitFor mocks base method
-func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 apps.Predicate) (*v1alpha1.App, error) {
+func (m *FakeClient) WaitFor(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 apps.Predicate) (*v1alpha1.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.App)
@@ -251,7 +252,7 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface
 }
 
 // WaitForE mocks base method
-func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 apps.ConditionFuncE) (*v1alpha1.App, error) {
+func (m *FakeClient) WaitForE(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 apps.ConditionFuncE) (*v1alpha1.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.App)

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -25,6 +25,7 @@ import (
 	apps "github.com/google/kf/pkg/kf/apps"
 	io "io"
 	reflect "reflect"
+	time "time"
 )
 
 // FakeClient is a mock of Client interface
@@ -232,4 +233,34 @@ func (m *FakeClient) Upsert(arg0 string, arg1 *v1alpha1.App, arg2 apps.Merger) (
 func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1, arg2)
+}
+
+// WaitFor mocks base method
+func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 apps.Predicate) (*v1alpha1.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitFor indicates an expected call of WaitFor
+func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3, arg4)
+}
+
+// WaitForE mocks base method
+func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 apps.ConditionFuncE) (*v1alpha1.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForE indicates an expected call of WaitForE
+func (mr *FakeClientMockRecorder) WaitForE(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForE", reflect.TypeOf((*FakeClient)(nil).WaitForE), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -20,9 +20,13 @@ package apps
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -171,6 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.App, error)
 	Upsert(namespace string, newObj *v1alpha1.App, merge Merger) (*v1alpha1.App, error)
+	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.App, error)
+	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.App, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -320,4 +326,63 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.App, merge Mer
 	}
 
 	return core.Create(namespace, newObj)
+}
+
+// WaitFor is a convenience wrapper for WaitForE that fails if the error
+// passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
+func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.App, error) {
+	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+}
+
+// ConditionFuncE is a callback used by WaitForE. Done should be set to true
+// once the condition succeeds and shouldn't be called anymore. The error
+// error will be passed back to the user.
+//
+// This function MAY retrieve a nil instance and an apiErr. It's up to the
+// function to decide how to handle the apiErr.
+type ConditionFuncE func(instance *v1alpha1.App, apiErr error) (done bool, err error)
+
+// WaitForE polls for the given object every interval until the condition
+// function becomes done or the timeout expires. The first poll occurs
+// immediately after the function is invoked.
+//
+// The function polls infinitely if no timeout is supplied.
+func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.App, err error) {
+	if timeout == nil {
+		notimeout := time.Duration(math.MaxInt64)
+		timeout = &notimeout
+	}
+
+	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+		instance, err = core.kclient.Apps(namespace).Get(name, metav1.GetOptions{})
+		return condition(instance, err)
+	})
+
+	return
+}
+
+// ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
+// the cluster was a not found error.
+func ConditionDeleted(_ *v1alpha1.App, apiErr error) (bool, error) {
+	if apiErr != nil {
+		if apierrors.IsNotFound(apiErr) {
+			apiErr = nil
+		}
+
+		return true, apiErr
+	}
+
+	return false, nil
+}
+
+// wrapPredicate converts a predicate to a ConditionFuncE that fails if the
+// error is not nil
+func wrapPredicate(condition Predicate) ConditionFuncE {
+	return func(obj *v1alpha1.App, err error) (bool, error) {
+		if err != nil {
+			return true, err
+		}
+
+		return condition(obj), nil
+	}
 }

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -18,15 +18,15 @@ package apps
 
 // Generator defined imports
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -175,8 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.App, error)
 	Upsert(namespace string, newObj *v1alpha1.App, merge Merger) (*v1alpha1.App, error)
-	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.App, error)
-	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.App, error)
+	WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.App, error)
+	WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (*v1alpha1.App, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -330,13 +330,13 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.App, merge Mer
 
 // WaitFor is a convenience wrapper for WaitForE that fails if the error
 // passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
-func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.App, error) {
-	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+func (core *coreClient) WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.App, error) {
+	return core.WaitForE(ctx, namespace, name, interval, wrapPredicate(condition))
 }
 
 // ConditionFuncE is a callback used by WaitForE. Done should be set to true
 // once the condition succeeds and shouldn't be called anymore. The error
-// error will be passed back to the user.
+// will be passed back to the user.
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
@@ -347,18 +347,23 @@ type ConditionFuncE func(instance *v1alpha1.App, apiErr error) (done bool, err e
 // immediately after the function is invoked.
 //
 // The function polls infinitely if no timeout is supplied.
-func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.App, err error) {
-	if timeout == nil {
-		notimeout := time.Duration(math.MaxInt64)
-		timeout = &notimeout
-	}
+func (core *coreClient) WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (instance *v1alpha1.App, err error) {
+	var done bool
+	tick := time.Tick(interval)
 
-	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+	for {
 		instance, err = core.kclient.Apps(namespace).Get(name, metav1.GetOptions{})
-		return condition(instance, err)
-	})
+		if done, err = condition(instance, err); done {
+			return
+		}
 
-	return
+		select {
+		case <-tick:
+			// repeat instance check
+		case <-ctx.Done():
+			return nil, errors.New("waiting for App timed out")
+		}
+	}
 }
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by

--- a/pkg/kf/commands/spaces/create.go
+++ b/pkg/kf/commands/spaces/create.go
@@ -15,6 +15,7 @@
 package spaces
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -57,7 +58,7 @@ func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 			w := cmd.OutOrStdout()
 
 			fmt.Fprintln(w, "Space requested, waiting for subcomponents to be created")
-			space, err := client.WaitFor(name, 1*time.Second, nil, spaces.IsStatusFinal)
+			space, err := client.WaitFor(context.Background(), name, 1*time.Second, spaces.IsStatusFinal)
 			if err != nil {
 				return err
 			}

--- a/pkg/kf/commands/spaces/create.go
+++ b/pkg/kf/commands/spaces/create.go
@@ -16,9 +16,11 @@ package spaces
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/commands/config"
+	"github.com/google/kf/pkg/kf/describe"
 	"github.com/google/kf/pkg/kf/spaces"
 
 	"github.com/spf13/cobra"
@@ -53,7 +55,14 @@ func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 			}
 
 			w := cmd.OutOrStdout()
+
+			fmt.Fprintln(w, "Space requested, waiting for subcomponents to be created")
+			space, err := client.WaitFor(name, 1*time.Second, nil, spaces.IsStatusFinal)
+			if err != nil {
+				return err
+			}
 			fmt.Fprintln(w, "Space created")
+			describe.DuckStatus(w, space.Status.Status)
 			fmt.Fprintln(w)
 
 			printAdditionalCommands(cmd.OutOrStdout(), name)

--- a/pkg/kf/commands/spaces/create_test.go
+++ b/pkg/kf/commands/spaces/create_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
@@ -49,6 +50,8 @@ func TestNewCreateSpaceCommand(t *testing.T) {
 						testutil.AssertEqual(t, "sets container registry", "some-registry", space.Spec.BuildpackBuild.ContainerRegistry)
 						testutil.AssertEqual(t, "sets domains", []v1alpha1.SpaceDomain{{Domain: "domain-1", Default: true}, {Domain: "domain-2"}}, space.Spec.Execution.Domains)
 					})
+
+				fakeSpaces.EXPECT().WaitFor("my-ns", 1*time.Second, nil, gomock.Any()).Return(&v1alpha1.Space{}, nil)
 			},
 		},
 		"server failure": {

--- a/pkg/kf/commands/spaces/create_test.go
+++ b/pkg/kf/commands/spaces/create_test.go
@@ -51,7 +51,7 @@ func TestNewCreateSpaceCommand(t *testing.T) {
 						testutil.AssertEqual(t, "sets domains", []v1alpha1.SpaceDomain{{Domain: "domain-1", Default: true}, {Domain: "domain-2"}}, space.Spec.Execution.Domains)
 					})
 
-				fakeSpaces.EXPECT().WaitFor("my-ns", 1*time.Second, nil, gomock.Any()).Return(&v1alpha1.Space{}, nil)
+				fakeSpaces.EXPECT().WaitFor(gomock.Any(), "my-ns", 1*time.Second, gomock.Any()).Return(&v1alpha1.Space{}, nil)
 			},
 		},
 		"server failure": {

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -20,9 +20,13 @@ package gentest
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -171,6 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1.Secret, error)
 	Upsert(namespace string, newObj *v1.Secret, merge Merger) (*v1.Secret, error)
+	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1.Secret, error)
+	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1.Secret, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -320,4 +326,63 @@ func (core *coreClient) Upsert(namespace string, newObj *v1.Secret, merge Merger
 	}
 
 	return core.Create(namespace, newObj)
+}
+
+// WaitFor is a convenience wrapper for WaitForE that fails if the error
+// passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
+func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1.Secret, error) {
+	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+}
+
+// ConditionFuncE is a callback used by WaitForE. Done should be set to true
+// once the condition succeeds and shouldn't be called anymore. The error
+// error will be passed back to the user.
+//
+// This function MAY retrieve a nil instance and an apiErr. It's up to the
+// function to decide how to handle the apiErr.
+type ConditionFuncE func(instance *v1.Secret, apiErr error) (done bool, err error)
+
+// WaitForE polls for the given object every interval until the condition
+// function becomes done or the timeout expires. The first poll occurs
+// immediately after the function is invoked.
+//
+// The function polls infinitely if no timeout is supplied.
+func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1.Secret, err error) {
+	if timeout == nil {
+		notimeout := time.Duration(math.MaxInt64)
+		timeout = &notimeout
+	}
+
+	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+		instance, err = core.kclient.Secrets(namespace).Get(name, metav1.GetOptions{})
+		return condition(instance, err)
+	})
+
+	return
+}
+
+// ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
+// the cluster was a not found error.
+func ConditionDeleted(_ *v1.Secret, apiErr error) (bool, error) {
+	if apiErr != nil {
+		if apierrors.IsNotFound(apiErr) {
+			apiErr = nil
+		}
+
+		return true, apiErr
+	}
+
+	return false, nil
+}
+
+// wrapPredicate converts a predicate to a ConditionFuncE that fails if the
+// error is not nil
+func wrapPredicate(condition Predicate) ConditionFuncE {
+	return func(obj *v1.Secret, err error) (bool, error) {
+		if err != nil {
+			return true, err
+		}
+
+		return condition(obj), nil
+	}
 }

--- a/pkg/kf/internal/tools/clientgen/tmplheader.go
+++ b/pkg/kf/internal/tools/clientgen/tmplheader.go
@@ -31,9 +31,13 @@ package {{.Package}}
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
+	"time"
 
 	"knative.dev/pkg/kmp"
+	"k8s.io/apimachinery/pkg/util/wait"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/kf/internal/tools/clientgen/tmplheader.go
+++ b/pkg/kf/internal/tools/clientgen/tmplheader.go
@@ -29,14 +29,14 @@ package {{.Package}}
 
 // Generator defined imports
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"time"
 
 	"knative.dev/pkg/kmp"
-	"k8s.io/apimachinery/pkg/util/wait"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/kf/routes/fake/fake_client.go
+++ b/pkg/kf/routes/fake/fake_client.go
@@ -24,6 +24,7 @@ import (
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	routes "github.com/google/kf/pkg/kf/routes"
 	reflect "reflect"
+	time "time"
 )
 
 // FakeClient is a mock of Client interface
@@ -175,4 +176,34 @@ func (m *FakeClient) Upsert(arg0 string, arg1 *v1alpha1.Route, arg2 routes.Merge
 func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1, arg2)
+}
+
+// WaitFor mocks base method
+func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 routes.Predicate) (*v1alpha1.Route, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.Route)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitFor indicates an expected call of WaitFor
+func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3, arg4)
+}
+
+// WaitForE mocks base method
+func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 routes.ConditionFuncE) (*v1alpha1.Route, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.Route)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForE indicates an expected call of WaitForE
+func (mr *FakeClientMockRecorder) WaitForE(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForE", reflect.TypeOf((*FakeClient)(nil).WaitForE), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/kf/routes/fake/fake_client.go
+++ b/pkg/kf/routes/fake/fake_client.go
@@ -20,6 +20,7 @@
 package fake
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	routes "github.com/google/kf/pkg/kf/routes"
@@ -179,7 +180,7 @@ func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // WaitFor mocks base method
-func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 routes.Predicate) (*v1alpha1.Route, error) {
+func (m *FakeClient) WaitFor(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 routes.Predicate) (*v1alpha1.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.Route)
@@ -194,7 +195,7 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface
 }
 
 // WaitForE mocks base method
-func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 routes.ConditionFuncE) (*v1alpha1.Route, error) {
+func (m *FakeClient) WaitForE(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 routes.ConditionFuncE) (*v1alpha1.Route, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.Route)

--- a/pkg/kf/routes/zz_generated.client.go
+++ b/pkg/kf/routes/zz_generated.client.go
@@ -20,9 +20,13 @@ package routes
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -171,6 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.Route, error)
 	Upsert(namespace string, newObj *v1alpha1.Route, merge Merger) (*v1alpha1.Route, error)
+	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Route, error)
+	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.Route, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -320,4 +326,63 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.Route, merge M
 	}
 
 	return core.Create(namespace, newObj)
+}
+
+// WaitFor is a convenience wrapper for WaitForE that fails if the error
+// passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
+func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Route, error) {
+	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+}
+
+// ConditionFuncE is a callback used by WaitForE. Done should be set to true
+// once the condition succeeds and shouldn't be called anymore. The error
+// error will be passed back to the user.
+//
+// This function MAY retrieve a nil instance and an apiErr. It's up to the
+// function to decide how to handle the apiErr.
+type ConditionFuncE func(instance *v1alpha1.Route, apiErr error) (done bool, err error)
+
+// WaitForE polls for the given object every interval until the condition
+// function becomes done or the timeout expires. The first poll occurs
+// immediately after the function is invoked.
+//
+// The function polls infinitely if no timeout is supplied.
+func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.Route, err error) {
+	if timeout == nil {
+		notimeout := time.Duration(math.MaxInt64)
+		timeout = &notimeout
+	}
+
+	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+		instance, err = core.kclient.Routes(namespace).Get(name, metav1.GetOptions{})
+		return condition(instance, err)
+	})
+
+	return
+}
+
+// ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
+// the cluster was a not found error.
+func ConditionDeleted(_ *v1alpha1.Route, apiErr error) (bool, error) {
+	if apiErr != nil {
+		if apierrors.IsNotFound(apiErr) {
+			apiErr = nil
+		}
+
+		return true, apiErr
+	}
+
+	return false, nil
+}
+
+// wrapPredicate converts a predicate to a ConditionFuncE that fails if the
+// error is not nil
+func wrapPredicate(condition Predicate) ConditionFuncE {
+	return func(obj *v1alpha1.Route, err error) (bool, error) {
+		if err != nil {
+			return true, err
+		}
+
+		return condition(obj), nil
+	}
 }

--- a/pkg/kf/routes/zz_generated.client.go
+++ b/pkg/kf/routes/zz_generated.client.go
@@ -18,15 +18,15 @@ package routes
 
 // Generator defined imports
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -175,8 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.Route, error)
 	Upsert(namespace string, newObj *v1alpha1.Route, merge Merger) (*v1alpha1.Route, error)
-	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Route, error)
-	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.Route, error)
+	WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.Route, error)
+	WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (*v1alpha1.Route, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -330,13 +330,13 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.Route, merge M
 
 // WaitFor is a convenience wrapper for WaitForE that fails if the error
 // passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
-func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Route, error) {
-	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+func (core *coreClient) WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.Route, error) {
+	return core.WaitForE(ctx, namespace, name, interval, wrapPredicate(condition))
 }
 
 // ConditionFuncE is a callback used by WaitForE. Done should be set to true
 // once the condition succeeds and shouldn't be called anymore. The error
-// error will be passed back to the user.
+// will be passed back to the user.
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
@@ -347,18 +347,23 @@ type ConditionFuncE func(instance *v1alpha1.Route, apiErr error) (done bool, err
 // immediately after the function is invoked.
 //
 // The function polls infinitely if no timeout is supplied.
-func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.Route, err error) {
-	if timeout == nil {
-		notimeout := time.Duration(math.MaxInt64)
-		timeout = &notimeout
-	}
+func (core *coreClient) WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (instance *v1alpha1.Route, err error) {
+	var done bool
+	tick := time.Tick(interval)
 
-	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+	for {
 		instance, err = core.kclient.Routes(namespace).Get(name, metav1.GetOptions{})
-		return condition(instance, err)
-	})
+		if done, err = condition(instance, err); done {
+			return
+		}
 
-	return
+		select {
+		case <-tick:
+			// repeat instance check
+		case <-ctx.Done():
+			return nil, errors.New("waiting for Route timed out")
+		}
+	}
 }
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by

--- a/pkg/kf/sources/fake/fake_client.go
+++ b/pkg/kf/sources/fake/fake_client.go
@@ -210,7 +210,7 @@ func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // WaitFor mocks base method
-func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 sources.Predicate) (*v1alpha1.Source, error) {
+func (m *FakeClient) WaitFor(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 sources.Predicate) (*v1alpha1.Source, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.Source)
@@ -225,7 +225,7 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface
 }
 
 // WaitForE mocks base method
-func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 sources.ConditionFuncE) (*v1alpha1.Source, error) {
+func (m *FakeClient) WaitForE(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 sources.ConditionFuncE) (*v1alpha1.Source, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1alpha1.Source)

--- a/pkg/kf/sources/fake/fake_client.go
+++ b/pkg/kf/sources/fake/fake_client.go
@@ -26,6 +26,7 @@ import (
 	sources "github.com/google/kf/pkg/kf/sources"
 	io "io"
 	reflect "reflect"
+	time "time"
 )
 
 // FakeClient is a mock of Client interface
@@ -206,4 +207,34 @@ func (m *FakeClient) Upsert(arg0 string, arg1 *v1alpha1.Source, arg2 sources.Mer
 func (mr *FakeClientMockRecorder) Upsert(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1, arg2)
+}
+
+// WaitFor mocks base method
+func (m *FakeClient) WaitFor(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 sources.Predicate) (*v1alpha1.Source, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.Source)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitFor indicates an expected call of WaitFor
+func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3, arg4)
+}
+
+// WaitForE mocks base method
+func (m *FakeClient) WaitForE(arg0, arg1 string, arg2 time.Duration, arg3 *time.Duration, arg4 sources.ConditionFuncE) (*v1alpha1.Source, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(*v1alpha1.Source)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForE indicates an expected call of WaitForE
+func (mr *FakeClientMockRecorder) WaitForE(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForE", reflect.TypeOf((*FakeClient)(nil).WaitForE), arg0, arg1, arg2, arg3, arg4)
 }

--- a/pkg/kf/sources/zz_generated.client.go
+++ b/pkg/kf/sources/zz_generated.client.go
@@ -20,9 +20,13 @@ package sources
 import (
 	"fmt"
 	"io"
+	"math"
 	"strings"
+	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -171,6 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.Source, error)
 	Upsert(namespace string, newObj *v1alpha1.Source, merge Merger) (*v1alpha1.Source, error)
+	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Source, error)
+	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.Source, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -320,4 +326,63 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.Source, merge 
 	}
 
 	return core.Create(namespace, newObj)
+}
+
+// WaitFor is a convenience wrapper for WaitForE that fails if the error
+// passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
+func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Source, error) {
+	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+}
+
+// ConditionFuncE is a callback used by WaitForE. Done should be set to true
+// once the condition succeeds and shouldn't be called anymore. The error
+// error will be passed back to the user.
+//
+// This function MAY retrieve a nil instance and an apiErr. It's up to the
+// function to decide how to handle the apiErr.
+type ConditionFuncE func(instance *v1alpha1.Source, apiErr error) (done bool, err error)
+
+// WaitForE polls for the given object every interval until the condition
+// function becomes done or the timeout expires. The first poll occurs
+// immediately after the function is invoked.
+//
+// The function polls infinitely if no timeout is supplied.
+func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.Source, err error) {
+	if timeout == nil {
+		notimeout := time.Duration(math.MaxInt64)
+		timeout = &notimeout
+	}
+
+	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+		instance, err = core.kclient.Sources(namespace).Get(name, metav1.GetOptions{})
+		return condition(instance, err)
+	})
+
+	return
+}
+
+// ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
+// the cluster was a not found error.
+func ConditionDeleted(_ *v1alpha1.Source, apiErr error) (bool, error) {
+	if apiErr != nil {
+		if apierrors.IsNotFound(apiErr) {
+			apiErr = nil
+		}
+
+		return true, apiErr
+	}
+
+	return false, nil
+}
+
+// wrapPredicate converts a predicate to a ConditionFuncE that fails if the
+// error is not nil
+func wrapPredicate(condition Predicate) ConditionFuncE {
+	return func(obj *v1alpha1.Source, err error) (bool, error) {
+		if err != nil {
+			return true, err
+		}
+
+		return condition(obj), nil
+	}
 }

--- a/pkg/kf/sources/zz_generated.client.go
+++ b/pkg/kf/sources/zz_generated.client.go
@@ -18,15 +18,15 @@ package sources
 
 // Generator defined imports
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
-	"math"
 	"strings"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/kmp"
 )
 
@@ -175,8 +175,8 @@ type Client interface {
 	Delete(namespace string, name string, opts ...DeleteOption) error
 	List(namespace string, opts ...ListOption) ([]v1alpha1.Source, error)
 	Upsert(namespace string, newObj *v1alpha1.Source, merge Merger) (*v1alpha1.Source, error)
-	WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Source, error)
-	WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (*v1alpha1.Source, error)
+	WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.Source, error)
+	WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (*v1alpha1.Source, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -330,13 +330,13 @@ func (core *coreClient) Upsert(namespace string, newObj *v1alpha1.Source, merge 
 
 // WaitFor is a convenience wrapper for WaitForE that fails if the error
 // passed is non-nil. It allows the use of Predicates instead of ConditionFuncE.
-func (core *coreClient) WaitFor(namespace string, name string, interval time.Duration, timeout *time.Duration, condition Predicate) (*v1alpha1.Source, error) {
-	return core.WaitForE(namespace, name, interval, timeout, wrapPredicate(condition))
+func (core *coreClient) WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1alpha1.Source, error) {
+	return core.WaitForE(ctx, namespace, name, interval, wrapPredicate(condition))
 }
 
 // ConditionFuncE is a callback used by WaitForE. Done should be set to true
 // once the condition succeeds and shouldn't be called anymore. The error
-// error will be passed back to the user.
+// will be passed back to the user.
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
@@ -347,18 +347,23 @@ type ConditionFuncE func(instance *v1alpha1.Source, apiErr error) (done bool, er
 // immediately after the function is invoked.
 //
 // The function polls infinitely if no timeout is supplied.
-func (core *coreClient) WaitForE(namespace string, name string, interval time.Duration, timeout *time.Duration, condition ConditionFuncE) (instance *v1alpha1.Source, err error) {
-	if timeout == nil {
-		notimeout := time.Duration(math.MaxInt64)
-		timeout = &notimeout
-	}
+func (core *coreClient) WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (instance *v1alpha1.Source, err error) {
+	var done bool
+	tick := time.Tick(interval)
 
-	err = wait.PollImmediate(interval, *timeout, func() (bool, error) {
+	for {
 		instance, err = core.kclient.Sources(namespace).Get(name, metav1.GetOptions{})
-		return condition(instance, err)
-	})
+		if done, err = condition(instance, err); done {
+			return
+		}
 
-	return
+		select {
+		case <-tick:
+			// repeat instance check
+		case <-ctx.Done():
+			return nil, errors.New("waiting for Build timed out")
+		}
+	}
 }
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by

--- a/pkg/kf/spaces/client.go
+++ b/pkg/kf/spaces/client.go
@@ -15,6 +15,7 @@
 package spaces
 
 import (
+	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	cv1alpha1 "github.com/google/kf/pkg/client/clientset/versioned/typed/kf/v1alpha1"
 )
 
@@ -31,4 +32,9 @@ func NewClient(kclient cv1alpha1.SpacesGetter) Client {
 		},
 		membershipValidator: AllPredicate(), // all spaces can be managed by Kf
 	}
+}
+
+// IsStatusFinal checks if the space has been fully synchronized.
+func IsStatusFinal(space *v1alpha1.Space) bool {
+	return v1alpha1.IsStatusFinal(space.Status.Status)
 }

--- a/pkg/kf/spaces/fake/fake_client.go
+++ b/pkg/kf/spaces/fake/fake_client.go
@@ -24,6 +24,7 @@ import (
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	spaces "github.com/google/kf/pkg/kf/spaces"
 	reflect "reflect"
+	time "time"
 )
 
 // FakeClient is a mock of Client interface
@@ -174,4 +175,34 @@ func (m *FakeClient) Upsert(arg0 *v1alpha1.Space, arg1 spaces.Merger) (*v1alpha1
 func (mr *FakeClientMockRecorder) Upsert(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*FakeClient)(nil).Upsert), arg0, arg1)
+}
+
+// WaitFor mocks base method
+func (m *FakeClient) WaitFor(arg0 string, arg1 time.Duration, arg2 *time.Duration, arg3 spaces.Predicate) (*v1alpha1.Space, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.Space)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitFor indicates an expected call of WaitFor
+func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3)
+}
+
+// WaitForE mocks base method
+func (m *FakeClient) WaitForE(arg0 string, arg1 time.Duration, arg2 *time.Duration, arg3 spaces.ConditionFuncE) (*v1alpha1.Space, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.Space)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForE indicates an expected call of WaitForE
+func (mr *FakeClientMockRecorder) WaitForE(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForE", reflect.TypeOf((*FakeClient)(nil).WaitForE), arg0, arg1, arg2, arg3)
 }

--- a/pkg/kf/spaces/fake/fake_client.go
+++ b/pkg/kf/spaces/fake/fake_client.go
@@ -20,6 +20,7 @@
 package fake
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	spaces "github.com/google/kf/pkg/kf/spaces"
@@ -178,7 +179,7 @@ func (mr *FakeClientMockRecorder) Upsert(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // WaitFor mocks base method
-func (m *FakeClient) WaitFor(arg0 string, arg1 time.Duration, arg2 *time.Duration, arg3 spaces.Predicate) (*v1alpha1.Space, error) {
+func (m *FakeClient) WaitFor(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 spaces.Predicate) (*v1alpha1.Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitFor", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*v1alpha1.Space)
@@ -193,7 +194,7 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3 interface{}) *g
 }
 
 // WaitForE mocks base method
-func (m *FakeClient) WaitForE(arg0 string, arg1 time.Duration, arg2 *time.Duration, arg3 spaces.ConditionFuncE) (*v1alpha1.Space, error) {
+func (m *FakeClient) WaitForE(arg0 context.Context, arg1 string, arg2 time.Duration, arg3 spaces.ConditionFuncE) (*v1alpha1.Space, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitForE", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*v1alpha1.Space)


### PR DESCRIPTION
This PR fixes #371 by borrowing concepts from the service catalog.
It adds WaitFor and WaitForE to every generated client which are
utilities to poll a k8s cluster until a predicate is true.

One predicate is provided for each client to allow the CLI to wait
for deletions.

Additionally, a function that checks if a duck type is completed
is added which resolves #377.