### PR TITLE
pkg/kf/commands/apps: push will create default route

### DIFF
--- a/pkg/kf/apps/push-options.yml
+++ b/pkg/kf/apps/push-options.yml
@@ -50,4 +50,10 @@ configs:
   - name: Routes
     type: "[]v1alpha1.RouteSpecFields"
     description: routes for the app
+  - name: DefaultRouteDomain
+    type: string
+    description: Domain for a defaultroute. Only used if a route doesn't already exist
+  - name: RandomRouteDomain
+    type: string
+    description: Domain for a random route. Only used if a route doesn't already exist
 - name: Deploy

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -30,6 +30,8 @@ type pushConfig struct {
 	ContainerImage string
 	// ContainerRegistry is the container registry's URL
 	ContainerRegistry string
+	// DefaultRouteDomain is Domain for a defaultroute. Only used if a route doesn't already exist
+	DefaultRouteDomain string
 	// EnvironmentVariables is set environment variables
 	EnvironmentVariables map[string]string
 	// Grpc is setup the ports for the container to allow gRPC to work
@@ -46,6 +48,8 @@ type pushConfig struct {
 	NoStart bool
 	// Output is the io.Writer to write output such as build logs
 	Output io.Writer
+	// RandomRouteDomain is Domain for a random route. Only used if a route doesn't already exist
+	RandomRouteDomain string
 	// Routes is routes for the app
 	Routes []v1alpha1.RouteSpecFields
 	// ServiceAccount is the service account to authenticate with
@@ -98,6 +102,12 @@ func (opts PushOptions) ContainerRegistry() string {
 	return opts.toConfig().ContainerRegistry
 }
 
+// DefaultRouteDomain returns the last set value for DefaultRouteDomain or the empty value
+// if not set.
+func (opts PushOptions) DefaultRouteDomain() string {
+	return opts.toConfig().DefaultRouteDomain
+}
+
 // EnvironmentVariables returns the last set value for EnvironmentVariables or the empty value
 // if not set.
 func (opts PushOptions) EnvironmentVariables() map[string]string {
@@ -146,6 +156,12 @@ func (opts PushOptions) Output() io.Writer {
 	return opts.toConfig().Output
 }
 
+// RandomRouteDomain returns the last set value for RandomRouteDomain or the empty value
+// if not set.
+func (opts PushOptions) RandomRouteDomain() string {
+	return opts.toConfig().RandomRouteDomain
+}
+
 // Routes returns the last set value for Routes or the empty value
 // if not set.
 func (opts PushOptions) Routes() []v1alpha1.RouteSpecFields {
@@ -182,6 +198,13 @@ func WithPushContainerImage(val string) PushOption {
 func WithPushContainerRegistry(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.ContainerRegistry = val
+	}
+}
+
+// WithPushDefaultRouteDomain creates an Option that sets Domain for a defaultroute. Only used if a route doesn't already exist
+func WithPushDefaultRouteDomain(val string) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.DefaultRouteDomain = val
 	}
 }
 
@@ -238,6 +261,13 @@ func WithPushNoStart(val bool) PushOption {
 func WithPushOutput(val io.Writer) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.Output = val
+	}
+}
+
+// WithPushRandomRouteDomain creates an Option that sets Domain for a random route. Only used if a route doesn't already exist
+func WithPushRandomRouteDomain(val string) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.RandomRouteDomain = val
 	}
 }
 

--- a/pkg/kf/commands/apps/testdata/manifest.yml
+++ b/pkg/kf/commands/apps/testdata/manifest.yml
@@ -11,10 +11,15 @@ applications:
 - name: auto-buildpack-app
   path: example-app
 - name: routes-app
+  no-route: false
+  random-route: false
   routes:
   - route: example.com
   - route: www.example.com/foo
   - route: https://host.example.com/foo
+- name: random-route-app
+  no-route: false
+  random-route: true
 - name: http-health-check-app
   docker:
     image: gcr.io/http-health-check-app

--- a/pkg/kf/testutil/assertions.go
+++ b/pkg/kf/testutil/assertions.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Failable is an interface for testing.T like things. We can't use
@@ -28,6 +30,15 @@ import (
 type Failable interface {
 	Helper()
 	Fatalf(format string, args ...interface{})
+}
+
+// Assert causes a test to fail if the two values are not DeepEqual to
+// one another.
+func Assert(t Failable, m gomock.Matcher, actual interface{}) {
+	t.Helper()
+	if !m.Matches(actual) {
+		t.Fatalf(m.String())
+	}
 }
 
 // AssertEqual causes a test to fail if the two values are not DeepEqual to


### PR DESCRIPTION
If a route is not provided via flag or manifest, create a default one
(`<app-name>.<default-space-domain>`).

This CL also adds the following flags:
--routes - Define route strings (similar to manifest) for app
--no-route - Don't add a default route
--random-route - Adds a random route if the app doesn't have route

fixes #393
fixes #291
fixes #290
fixes #175