### PR TITLE
pkg/kf/commands/apps: ensure push can scale apps

### DIFF
--- a/pkg/apis/kf/v1alpha1/route_types.go
+++ b/pkg/apis/kf/v1alpha1/route_types.go
@@ -15,6 +15,8 @@
 package v1alpha1
 
 import (
+	"path"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -59,6 +61,15 @@ type RouteSpecFields struct {
 	// Path is the URL path of the route.
 	// +optional
 	Path string `json:"path,omitempty"`
+}
+
+// String returns a RouteSpecFields converted into an address.
+func (route RouteSpecFields) String() string {
+	var hostnamePrefix string
+	if route.Hostname != "" {
+		hostnamePrefix = route.Hostname + "."
+	}
+	return hostnamePrefix + route.Domain + path.Join("/", route.Path)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kf/v1alpha1/route_types_test.go
+++ b/pkg/apis/kf/v1alpha1/route_types_test.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import "fmt"
+
+func ExampleRouteSpecFields_String() {
+	r := RouteSpecFields{
+		Hostname: "foo",
+		Domain:   "example.com",
+		Path:     "bar",
+	}
+
+	fmt.Println(r.String())
+
+	// Output: foo.example.com/bar
+}
+
+func ExampleRouteSpecFields_String_without_hostname() {
+	r := RouteSpecFields{
+		Domain: "example.com",
+		Path:   "bar",
+	}
+
+	fmt.Println(r.String())
+
+	// Output: example.com/bar
+}
+
+func ExampleRouteSpecFields_String_without_path() {
+	r := RouteSpecFields{
+		Hostname: "foo",
+		Domain:   "example.com",
+	}
+
+	fmt.Println(r.String())
+
+	// Output: foo.example.com/
+}

--- a/pkg/kf/apps/push-options.yml
+++ b/pkg/kf/apps/push-options.yml
@@ -36,11 +36,14 @@ configs:
     type: bool
     description: setup the ports for the container to allow gRPC to work
   - name: MinScale
-    type: int
+    type: "*int"
     description: the lower scale bound
   - name: MaxScale
-    type: int
+    type: "*int"
     description: the upper scale bound
+  - name: ExactScale
+    type: "*int"
+    description: scale exactly to this number of instances
   - name: NoStart
     type: bool
     description: setup the app without starting it

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -34,14 +34,16 @@ type pushConfig struct {
 	DefaultRouteDomain string
 	// EnvironmentVariables is set environment variables
 	EnvironmentVariables map[string]string
+	// ExactScale is scale exactly to this number of instances
+	ExactScale *int
 	// Grpc is setup the ports for the container to allow gRPC to work
 	Grpc bool
 	// HealthCheck is the health check to use on the app
 	HealthCheck *corev1.Probe
 	// MaxScale is the upper scale bound
-	MaxScale int
+	MaxScale *int
 	// MinScale is the lower scale bound
-	MinScale int
+	MinScale *int
 	// Namespace is the Kubernetes namespace to use
 	Namespace string
 	// NoStart is setup the app without starting it
@@ -114,6 +116,12 @@ func (opts PushOptions) EnvironmentVariables() map[string]string {
 	return opts.toConfig().EnvironmentVariables
 }
 
+// ExactScale returns the last set value for ExactScale or the empty value
+// if not set.
+func (opts PushOptions) ExactScale() *int {
+	return opts.toConfig().ExactScale
+}
+
 // Grpc returns the last set value for Grpc or the empty value
 // if not set.
 func (opts PushOptions) Grpc() bool {
@@ -128,13 +136,13 @@ func (opts PushOptions) HealthCheck() *corev1.Probe {
 
 // MaxScale returns the last set value for MaxScale or the empty value
 // if not set.
-func (opts PushOptions) MaxScale() int {
+func (opts PushOptions) MaxScale() *int {
 	return opts.toConfig().MaxScale
 }
 
 // MinScale returns the last set value for MinScale or the empty value
 // if not set.
-func (opts PushOptions) MinScale() int {
+func (opts PushOptions) MinScale() *int {
 	return opts.toConfig().MinScale
 }
 
@@ -215,6 +223,13 @@ func WithPushEnvironmentVariables(val map[string]string) PushOption {
 	}
 }
 
+// WithPushExactScale creates an Option that sets scale exactly to this number of instances
+func WithPushExactScale(val *int) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.ExactScale = val
+	}
+}
+
 // WithPushGrpc creates an Option that sets setup the ports for the container to allow gRPC to work
 func WithPushGrpc(val bool) PushOption {
 	return func(cfg *pushConfig) {
@@ -230,14 +245,14 @@ func WithPushHealthCheck(val *corev1.Probe) PushOption {
 }
 
 // WithPushMaxScale creates an Option that sets the upper scale bound
-func WithPushMaxScale(val int) PushOption {
+func WithPushMaxScale(val *int) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.MaxScale = val
 	}
 }
 
 // WithPushMinScale creates an Option that sets the lower scale bound
-func WithPushMinScale(val int) PushOption {
+func WithPushMinScale(val *int) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.MinScale = val
 	}

--- a/pkg/kf/apps/push_test.go
+++ b/pkg/kf/apps/push_test.go
@@ -118,8 +118,8 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						testutil.AssertEqual(t, "namespace", "some-namespace", newObj.Namespace)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "namespace", "some-namespace", newApp.Namespace)
 					}).
 					Return(&v1alpha1.App{}, nil)
 			},
@@ -134,8 +134,111 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						testutil.AssertEqual(t, "namespace", "default", newObj.Namespace)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "namespace", "default", newApp.Namespace)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
+		"pushes app with exact instances": {
+			appName:   "some-app",
+			buildpack: "some-buildpack",
+			opts: apps.PushOptions{
+				apps.WithPushSourceImage("some-image"),
+				apps.WithPushContainerRegistry("some-reg.io"),
+				apps.WithPushServiceAccount("some-service-account"),
+				apps.WithPushExactScale(intPtr(9)),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						oldApp := &v1alpha1.App{}
+						oldApp.Spec.Instances.Exactly = intPtr(9)
+						newApp = merge(newApp, oldApp)
+						testutil.Assert(t, gomock.Not(gomock.Nil()), newApp.Spec.Instances.Exactly)
+						testutil.AssertEqual(t, "instances.Exactly", 9, *newApp.Spec.Instances.Exactly)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
+		"pushes app but leaves exact instances": {
+			appName:   "some-app",
+			buildpack: "some-buildpack",
+			opts: apps.PushOptions{
+				apps.WithPushSourceImage("some-image"),
+				apps.WithPushContainerRegistry("some-reg.io"),
+				apps.WithPushServiceAccount("some-service-account"),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						oldApp := &v1alpha1.App{}
+						oldApp.Spec.Instances.Exactly = intPtr(9)
+						newApp = merge(newApp, oldApp)
+						testutil.AssertEqual(t, "instances.Exactly", 9, *newApp.Spec.Instances.Exactly)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
+		"pushes app with min and max instances": {
+			appName:   "some-app",
+			buildpack: "some-buildpack",
+			opts: apps.PushOptions{
+				apps.WithPushSourceImage("some-image"),
+				apps.WithPushContainerRegistry("some-reg.io"),
+				apps.WithPushServiceAccount("some-service-account"),
+				apps.WithPushMinScale(intPtr(9)),
+				apps.WithPushMaxScale(intPtr(11)),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "instances.Min", 9, *newApp.Spec.Instances.Min)
+						testutil.AssertEqual(t, "instances.Max", 11, *newApp.Spec.Instances.Max)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
+		"pushes app but leaves min and max instances": {
+			appName:   "some-app",
+			buildpack: "some-buildpack",
+			opts: apps.PushOptions{
+				apps.WithPushSourceImage("some-image"),
+				apps.WithPushContainerRegistry("some-reg.io"),
+				apps.WithPushServiceAccount("some-service-account"),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						oldApp := &v1alpha1.App{}
+						oldApp.Spec.Instances.Min = intPtr(9)
+						oldApp.Spec.Instances.Max = intPtr(11)
+						newApp = merge(newApp, oldApp)
+						testutil.AssertEqual(t, "instances.Min", 9, *newApp.Spec.Instances.Min)
+						testutil.AssertEqual(t, "instances.Max", 11, *newApp.Spec.Instances.Max)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+		},
+		"pushes app with default of exactly 1 instance": {
+			appName:   "some-app",
+			buildpack: "some-buildpack",
+			opts: apps.PushOptions{
+				apps.WithPushSourceImage("some-image"),
+				apps.WithPushContainerRegistry("some-reg.io"),
+				apps.WithPushServiceAccount("some-service-account"),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						oldApp := &v1alpha1.App{}
+						newApp = merge(newApp, oldApp)
+						testutil.AssertEqual(t, "instances.Exactly", 1, *newApp.Spec.Instances.Exactly)
 					}).
 					Return(&v1alpha1.App{}, nil)
 			},
@@ -162,12 +265,12 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						ka := apps.NewFromApp(newObj)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						ka := apps.NewFromApp(newApp)
 
-						testutil.AssertEqual(t, "service.Name", "some-app", newObj.Name)
-						testutil.AssertEqual(t, "service.Kind", "App", newObj.Kind)
-						testutil.AssertEqual(t, "service.APIVersion", "kf.dev/v1alpha1", newObj.APIVersion)
+						testutil.AssertEqual(t, "service.Name", "some-app", newApp.Name)
+						testutil.AssertEqual(t, "service.Kind", "App", newApp.Kind)
+						testutil.AssertEqual(t, "service.APIVersion", "kf.dev/v1alpha1", newApp.APIVersion)
 						testutil.AssertEqual(t, "Spec.ServiceAccountName", "some-service-account", ka.GetServiceAccount())
 					}).
 					Return(&v1alpha1.App{}, nil)
@@ -186,11 +289,11 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						testutil.AssertEqual(t, "namespace", "default", newObj.Namespace)
-						testutil.AssertEqual(t, "Spec.ServiceAccountName", "some-service-account", newObj.Spec.Template.Spec.ServiceAccountName)
-						testutil.AssertEqual(t, "image", "some-image", newObj.Spec.Source.BuildpackBuild.Source)
-						testutil.AssertEqual(t, "buildpack", "some-buildpack", newObj.Spec.Source.BuildpackBuild.Buildpack)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "namespace", "default", newApp.Namespace)
+						testutil.AssertEqual(t, "Spec.ServiceAccountName", "some-service-account", newApp.Spec.Template.Spec.ServiceAccountName)
+						testutil.AssertEqual(t, "image", "some-image", newApp.Spec.Source.BuildpackBuild.Source)
+						testutil.AssertEqual(t, "buildpack", "some-buildpack", newApp.Spec.Source.BuildpackBuild.Buildpack)
 
 					}).Return(&v1alpha1.App{}, nil)
 			},
@@ -206,8 +309,8 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						actual := envutil.GetAppEnvVars(newObj)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						actual := envutil.GetAppEnvVars(newApp)
 						envutil.SortEnvVars(actual)
 						testutil.AssertEqual(t, "envs",
 							[]corev1.EnvVar{{Name: "ENV1", Value: "val1"}, {Name: "ENV2", Value: "val2"}},
@@ -225,8 +328,8 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						testutil.AssertEqual(t, "containerImage", "some-image", newObj.Spec.Source.ContainerImage.Image)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "containerImage", "some-image", newApp.Spec.Source.ContainerImage.Image)
 					}).
 					Return(&v1alpha1.App{}, nil)
 			},
@@ -239,10 +342,10 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
 						testutil.AssertEqual(t, "Routes", []v1alpha1.RouteSpecFields{
 							{Hostname: "host-1"}, {Hostname: "host-2"},
-						}, newObj.Spec.Routes)
+						}, newApp.Spec.Routes)
 					}).
 					Return(&v1alpha1.App{}, nil)
 			},
@@ -304,12 +407,12 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						newObj = merge(newObj, newObj)
-						testutil.AssertEqual(t, "len(Routes)", 1, len(newObj.Spec.Routes))
-						testutil.AssertEqual(t, "Routes.Domain", "example.com", newObj.Spec.Routes[0].Domain)
-						testutil.Assert(t, gomock.Not(gomock.Eq("")), newObj.Spec.Routes[0].Hostname)
-						testutil.AssertEqual(t, "Routes.Path", "", newObj.Spec.Routes[0].Path)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						newApp = merge(newApp, newApp)
+						testutil.AssertEqual(t, "len(Routes)", 1, len(newApp.Spec.Routes))
+						testutil.AssertEqual(t, "Routes.Domain", "example.com", newApp.Spec.Routes[0].Domain)
+						testutil.Assert(t, gomock.Not(gomock.Eq("")), newApp.Spec.Routes[0].Hostname)
+						testutil.AssertEqual(t, "Routes.Path", "", newApp.Spec.Routes[0].Path)
 					}).
 					Return(&v1alpha1.App{}, nil)
 			},
@@ -325,7 +428,7 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
 						app := &v1alpha1.App{}
 						app.Spec.Routes = []v1alpha1.RouteSpecFields{
 							{Domain: "existing.com"},
@@ -367,8 +470,8 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						ka := apps.NewFromApp(newObj)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						ka := apps.NewFromApp(newApp)
 
 						testutil.AssertEqual(
 							t,
@@ -394,8 +497,8 @@ func TestPush(t *testing.T) {
 			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
 				appsClient.EXPECT().
 					Upsert(gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
-						testutil.AssertEqual(t, "app.Spec.Instances.Stopped", true, newObj.Spec.Instances.Stopped)
+					Do(func(namespace string, newApp *v1alpha1.App, merge apps.Merger) {
+						testutil.AssertEqual(t, "app.Spec.Instances.Stopped", true, newApp.Spec.Instances.Stopped)
 
 					}).Return(&v1alpha1.App{}, nil)
 			},
@@ -431,4 +534,8 @@ func TestPush(t *testing.T) {
 			ctrl.Finish()
 		})
 	}
+}
+
+func intPtr(i int) *int {
+	return &i
 }

--- a/pkg/kf/commands/apps/testdata/manifest.yml
+++ b/pkg/kf/commands/apps/testdata/manifest.yml
@@ -1,5 +1,10 @@
 ---
 applications:
+- name: instances-app
+  instances: 9
+- name: autoscaling-instances-app
+  min-scale: 9
+  max-scale: 11
 - name: docker-app
   docker:
     image: gcr.io/docker-app


### PR DESCRIPTION
pkg/kf/commands/apps: ensure push can scale apps

This CL fixes a bug where the scaling flag (`-i --instances`) was not
used while `push`ing an app.

It also adds the `--min-scale` and `--max-scale` flags to `push` along
with their corresponding manifest values (the CLI will display a warning
on STDERR while using the manifest to warn that the manifest values
might change per #95).

It also updates `kf apps` to match `cf apps`. It does NOT show the
actual number of pods, but instead shows the desired scaling (including
auto scaling vs exact).

fixes #429
fixes #313

(This needs to wait on #426)