### PR TITLE
pkg/reconciler: AppStatus doesn't display stale Source

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle.go
@@ -74,6 +74,7 @@ func (status *SourceStatus) PropagateBuildStatus(build *build.Build) {
 	}
 
 	status.BuildName = build.Name
+	status.manage().MarkUnknown(SourceConditionBuildSucceeded, "initializing", "Build in progress")
 
 	for _, condition := range build.Status.GetConditions() {
 		if condition.Type == "Succeeded" {

--- a/pkg/apis/kf/v1alpha1/utils.go
+++ b/pkg/apis/kf/v1alpha1/utils.go
@@ -35,6 +35,7 @@ import (
 func PropagateCondition(manager apis.ConditionManager, destination apis.ConditionType, source *apis.Condition) bool {
 	switch {
 	case source == nil:
+		manager.MarkUnknown(destination, "Unknown", "source status is nil")
 		return false
 	case source.IsFalse():
 		manager.MarkFalse(destination, source.Reason, source.Message)

--- a/pkg/apis/kf/v1alpha1/utils_test.go
+++ b/pkg/apis/kf/v1alpha1/utils_test.go
@@ -38,7 +38,11 @@ func TestPropagateCondition(t *testing.T) {
 		expectReturn  bool
 	}{
 		"nil source": {
-			source: nil,
+			source:        nil,
+			expectMessage: "source status is nil",
+			expectStatus:  "Unknown",
+			expectReason:  "Unknown",
+			expectReturn:  false,
 		},
 		"unknown source": {
 			source:        &apis.Condition{Status: "Unknown", Message: "u-message", Reason: "UReason"},
@@ -74,11 +78,6 @@ func TestPropagateCondition(t *testing.T) {
 			testutil.AssertEqual(t, "return value", tc.expectReturn, returnValue)
 
 			resultCond := manager.GetCondition("TestCondition")
-			if tc.source == nil {
-				testutil.AssertEqual(t, "condition", (*apis.Condition)(nil), resultCond)
-				return
-			}
-
 			testutil.AssertEqual(t, "message", tc.expectMessage, resultCond.Message)
 			testutil.AssertEqual(t, "status", tc.expectStatus, string(resultCond.Status))
 			testutil.AssertEqual(t, "reason", tc.expectReason, resultCond.Reason)

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -60,7 +60,6 @@ func TestIntegration_Push(t *testing.T) {
 // then posts to it. It then updates the app to the helloworld app by pushing
 // to the same app name. It finally deletes the app.
 func TestIntegration_Push_update(t *testing.T) {
-	t.Skip("TODO #372")
 	t.Parallel()
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
@@ -73,7 +72,7 @@ func TestIntegration_Push_update(t *testing.T) {
 		)
 		defer kf.Delete(ctx, appName)
 		checkEchoApp(ctx, t, kf, appName, 8087, ExpectedAddr(appName, ""))
-		checkHelloWorldApp(ctx, t, kf, appName, 8087, ExpectedAddr(appName, ""))
+		checkHelloWorldApp(ctx, t, kf, appName, 8088, ExpectedAddr(appName, ""))
 	})
 }
 

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -93,6 +93,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 // ApplyChanges updates the linked resources in the cluster with the current
 // status of the source.
 func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) error {
+	source.Status.InitializeConditions()
+
 	// Sync build
 	{
 		desired, err := resources.MakeBuild(source)


### PR DESCRIPTION
Previously, when a user would try to update an app by pusing again, the
build would seemingly finish instantly. However, the app wasn't actually
updated or readay yet. What was happening was the AppStatus was
returning a stale Source and Build information which was being picked up
by the CLI.

This CL ensures the AppStatus is properly marked as Unknown (instead of
Ready) for app updates.

fixes #372