### PR TITLE
pkg/kf/commands/apps: allow for path to point to a file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e
+	github.com/poy/kontext v0.0.0-20190801225340-1f98414f4e12
 	github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c
 	github.com/rogpeppe/go-internal v1.3.0 // indirect
 	github.com/segmentio/textio v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -346,8 +346,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmorie/go-open-service-broker-client v0.0.0-20181213160916-6988c0983446/go.mod h1:6d5FSWVMC68G2RoLKixGVhkoNlgoEC/phmruM0yHdjQ=
 github.com/poy/knative-pkg v99.0.0+incompatible h1:onvjBYN3yXNLGESi51Sajk70NBU7i5LISPor5ANJ59M=
 github.com/poy/knative-pkg v99.0.0+incompatible/go.mod h1:+LGy4PaS4RL2Ii5I2Ow8OGR9dMhJZ9+LCKUdwtDgyUU=
-github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e h1:HZPqpLefwCMwGfEwjvY0ZcS8biQDaMBzsunN6TqgL+0=
-github.com/poy/kontext v0.0.0-20190411202914-cc5532543f2e/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
+github.com/poy/kontext v0.0.0-20190801225340-1f98414f4e12 h1:oqr2ATVxA+L8ymMwVeWUWvsiBFvqA3vw1133ih+V8so=
+github.com/poy/kontext v0.0.0-20190801225340-1f98414f4e12/go.mod h1:EZ/Zsx68w8CAzOTosTajuX/M9sL+2s1IMy8jpzuJm2Q=
 github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c h1:5tVj7ImrbnEHf8FNnasPiDBDuSaFRVq8r2ilMLfukzA=
 github.com/poy/service-catalog v0.0.0-20190305064623-db385b1d332c/go.mod h1:D3X0fYjTImKyVV+A+FaU7e5xIDbU2VOdejI7m5KL0CA=
 github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=

--- a/pkg/kf/commands/apps/push.go
+++ b/pkg/kf/commands/apps/push.go
@@ -64,7 +64,13 @@ func (f SrcImageBuilderFunc) BuildSrcImage(dir, srcImage string) error {
 }
 
 // NewPushCommand creates a push command.
-func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, b SrcImageBuilder, serviceBindingClient servicebindings.ClientInterface) *cobra.Command {
+func NewPushCommand(
+	p *config.KfParams,
+	client apps.Client,
+	pusher apps.Pusher,
+	b SrcImageBuilder,
+	serviceBindingClient servicebindings.ClientInterface,
+) *cobra.Command {
 	var (
 		containerRegistry  string
 		sourceImage        string
@@ -114,12 +120,6 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 			appName := ""
 			if len(args) > 0 {
 				appName = args[0]
-			}
-
-			// Kontext has to have a absolute path.
-			path, err = filepath.Abs(path)
-			if err != nil {
-				return err
 			}
 
 			var pushManifest *manifest.Manifest
@@ -261,7 +261,8 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 					apps.WithPushDefaultRouteDomain(defaultRouteDomain),
 				}
 
-				if app.Docker.Image == "" { // buildpack app
+				if app.Docker.Image == "" {
+					// buildpack app
 					registry := containerRegistry
 					switch {
 					case registry != "":
@@ -280,6 +281,11 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 					default:
 						imageName = apps.JoinRepositoryImage(registry, apps.SourceImageName(p.Namespace, app.Name))
 
+						// Kontext has to have a absolute path.
+						srcPath, err = filepath.Abs(srcPath)
+						if err != nil {
+							return err
+						}
 						if err := b.BuildSrcImage(srcPath, imageName); err != nil {
 							return err
 						}
@@ -305,7 +311,6 @@ func NewPushCommand(p *config.KfParams, client apps.Client, pusher apps.Pusher, 
 
 				// Bind service if set
 				for _, serviceInstance := range app.Services {
-
 					binding, created, err := serviceBindingClient.GetOrCreate(
 						serviceInstance,
 						app.Name,


### PR DESCRIPTION
Previously, if a user pointed to a file instead of a directory, the
resulting source code container would be empty. This CL fixes that.

fixes #253