### PR TITLE
Integration tests now use port 0 for proxy

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -71,8 +71,8 @@ func TestIntegration_Push_update(t *testing.T) {
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
 		)
 		defer kf.Delete(ctx, appName)
-		checkEchoApp(ctx, t, kf, appName, 8087)
-		checkHelloWorldApp(ctx, t, kf, appName, 8087)
+		checkEchoApp(ctx, t, kf, appName)
+		checkHelloWorldApp(ctx, t, kf, appName)
 	})
 }
 
@@ -91,7 +91,7 @@ func TestIntegration_Push_docker(t *testing.T) {
 			"--docker-image=gcr.io/kf-releases/echo-app",
 		)
 		defer kf.Delete(ctx, appName)
-		checkEchoApp(ctx, t, kf, appName, 8086)
+		checkEchoApp(ctx, t, kf, appName)
 	})
 }
 
@@ -118,7 +118,7 @@ func checkApp(
 	Logf(t, "hitting echo app to ensure its working...")
 
 	go kf.Proxy(ctx, appName)
-	assert(ctx, t, fmt.Sprintf("http://localhost:0"))
+	assert(ctx, t, "http://localhost:0")
 }
 
 func checkEchoApp(
@@ -185,7 +185,7 @@ func TestIntegration_StopStart(t *testing.T) {
 		go kf.Proxy(ctx, appName)
 
 		{
-			resp, respCancel := RetryPost(ctx, t, "http://localhost:8085", appTimeout, http.StatusOK, "testing")
+			resp, respCancel := RetryPost(ctx, t, "http://localhost:0", appTimeout, http.StatusOK, "testing")
 			defer resp.Body.Close()
 			defer respCancel()
 			Logf(t, "done hitting echo app to ensure it's working.")
@@ -197,7 +197,7 @@ func TestIntegration_StopStart(t *testing.T) {
 
 		{
 			Logf(t, "hitting echo app to ensure it's NOT working...")
-			resp, respCancel := RetryPost(ctx, t, "http://localhost:8085", appTimeout, http.StatusNotFound, "testing")
+			resp, respCancel := RetryPost(ctx, t, "http://localhost:0", appTimeout, http.StatusNotFound, "testing")
 			defer resp.Body.Close()
 			defer respCancel()
 			Logf(t, "done hitting echo app to ensure it's NOT working.")
@@ -209,7 +209,7 @@ func TestIntegration_StopStart(t *testing.T) {
 
 		{
 			Logf(t, "hitting echo app to ensure it's working...")
-			resp, respCancel := RetryPost(ctx, t, "http://localhost:8085", appTimeout, http.StatusOK, "testing")
+			resp, respCancel := RetryPost(ctx, t, "http://localhost:0", appTimeout, http.StatusOK, "testing")
 			defer resp.Body.Close()
 			defer respCancel()
 			Logf(t, "done hitting echo app to ensure it's working.")
@@ -407,7 +407,7 @@ func TestIntegration_Logs(t *testing.T) {
 		// than once because we can't guarantee much about logs.
 		expectedLogLine := fmt.Sprintf("testing-%d", time.Now().UnixNano())
 		for i := 0; i < 10; i++ {
-			resp, respCancel := RetryPost(ctx, t, "http://localhost:8083", appTimeout, http.StatusOK, expectedLogLine)
+			resp, respCancel := RetryPost(ctx, t, "http://localhost:0", appTimeout, http.StatusOK, expectedLogLine)
 			resp.Body.Close()
 			respCancel()
 		}
@@ -482,7 +482,7 @@ func checkVars(ctx context.Context, t *testing.T, kf *Kf, appName string, expect
 		// JSON. This checks to make sure everything is ACTUALLY being
 		// set from the app's perspective.
 		Logf(t, "hitting app %s to check the envs...", appName)
-		resp, respCancel := RetryPost(ctx, t, fmt.Sprintf("http://localhost:0"), appTimeout, http.StatusOK, "")
+		resp, respCancel := RetryPost(ctx, t, "http://localhost:0", appTimeout, http.StatusOK, "")
 		defer resp.Body.Close()
 		defer respCancel()
 		if resp.StatusCode != http.StatusOK {

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -692,7 +692,7 @@ func (k *Kf) Start(ctx context.Context, appName string) {
 }
 
 // Proxy starts a proxy for an application.
-func (k *Kf) Proxy(ctx context.Context, appName string, port int) {
+func (k *Kf) Proxy(ctx context.Context, appName string) {
 	k.t.Helper()
 	Logf(k.t, "running proxy for %q...", appName)
 	defer Logf(k.t, "done running proxy for %q.", appName)
@@ -701,7 +701,7 @@ func (k *Kf) Proxy(ctx context.Context, appName string, port int) {
 			"proxy",
 			"--namespace", SpaceFromContext(ctx),
 			appName,
-			fmt.Sprintf("--port=%d", port),
+			fmt.Sprintf("--port=%d", 0),
 		},
 	})
 	PanicOnError(ctx, k.t, fmt.Sprintf("proxy %q", appName), errs)


### PR DESCRIPTION
Fixes #441 

Until now:
The integration tests use fixed port numbers. This enables mistakes in the form of multiple integration tests using the same port and may cause issues if the ports specified are already in use.

Now:
All integration tests use 0 as the port number for the proxy. This is achieved through changing the signature {(ctx context.Context, appName string) -> (ctx context.Context, appName string, port int)} of the Proxy method( in testutil/integration.go) and instead always using the value 0. 
All calls from the integration tests using the method have been changed. Assert messages have also been updated.

Result:
Fixes #441 
locally all checks pass