### PR TITLE
Remove options string retroactively. Fixes #211.

### DIFF
--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/doctor"
+	"github.com/google/kf/pkg/kf/commands/utils"
 	pkgdoctor "github.com/google/kf/pkg/kf/doctor"
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
@@ -167,6 +168,9 @@ func NewKfCommand() *cobra.Command {
 	// This will add the rest to a group under "Other Commands".
 	groups.Add(rootCmd)
 	templates.ActsAsRootCommand(rootCmd, nil, groups...)
+
+	// Fix the usage string containing options
+	utils.FixOptionsInUsageFunc(rootCmd)
 
 	return rootCmd
 }

--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/kf/pkg/kf/algorithms"
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/quotas"
+	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/spaces"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -65,6 +66,7 @@ func NewConfigSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 		cmd.AddCommand(qc)
 	}
 
+	utils.FixOptionsInUsageFunc(cmd)
 	return cmd
 }
 


### PR DESCRIPTION
The template package we use does not let us adjust the internal formatting.
I was unable to find a way to disable options via the exposed settings.
However, we can capture cobra command output...and remove the troubled text.

In the future, we should move away from using this library altogether, especially
since it no longer exists in kubectl master