### PR TITLE
revert GKE version for docs and installer

### DIFF
--- a/docs/install/gke.md
+++ b/docs/install/gke.md
@@ -58,7 +58,7 @@ gcloud compute networks create $CLUSTER_NAME --project $PROJECT_ID
 gcloud beta container clusters create $CLUSTER_NAME \
   --zone $ZONE \
   --no-enable-basic-auth \
-  --cluster-version "1.13.7-gke.8" \
+  --cluster-version "1.13.6-gke.13" \
   --machine-type "n1-standard-1" \
   --image-type "COS" \
   --disk-type "pd-standard" \

--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	gkeClusterVersion     = "1.13.7-gke.8"
+	gkeClusterVersion     = "1.13.6-gke.13"
 	machineType           = "n1-standard-4"
 	imageType             = "COS"
 	diskType              = "pd-standard"


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes # 473

## Proposed Changes

* Changes gke installer to use 1.13.6-gke.13 (from 1.13.7-gke.8)
* Changes gke docs to use 1.13.6-gke.13 (from 1.13.7-gke.8)

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
- Changed available GKE compatibility
```
