### PR TITLE
fix grammar in manifest warning

### DIFF
--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -162,8 +162,8 @@ func (app *Application) Override(overrides *Application) error {
 	// not support it for now.
 	if app.MinScale != nil || app.MaxScale != nil {
 		fmt.Fprintf(os.Stderr, `
-WARNING! min-scale and max-scale is not a normal CF fields in a manifest.
-Therefore it is subject to change.
+WARNING! min-scale and max-scale are not normal CF fields in a manifest.
+Therefore they are subject to change.
 Please follow the thread in https://github.com/google/kf/issues/95
 for more info.
 `)


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes # n/a

## Proposed Changes

* Fixes grammar in warning message for auto-scaling fields in manifest

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
