### PR TITLE
Install: register gcloud as a Docker credential

### DIFF
--- a/docs/install/gke.md
+++ b/docs/install/gke.md
@@ -19,6 +19,7 @@ commands will need to be adjusted for use in a Windows environment.
 1. Authorize `gcloud`:
    ```sh
    gcloud auth login
+   gcloud auth configure-docker
    ```
 
 ### Setup environment variables


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes # None

```
$ kf push logspinner --path /tmp/loggregator-tools
[source upload] Uploading /tmp/loggregator-tools to image gcr.io/******/src-space-bw43veqo1l94-logspinner:1565254531116773000
Error: Error publishing image: UNAUTHORIZED: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```

## Proposed Changes

* Add install step for docker credential
