### PR TITLE
pkg/kf/commands/apps: fix StopStart integration tests

### DIFF
--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -101,18 +101,14 @@ func TestIntegration_Push_docker(t *testing.T) {
 // tries posting to it again. It finally deletes the app.
 func TestIntegration_StopStart(t *testing.T) {
 	t.Parallel()
-	t.Skip("#445")
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		appName := fmt.Sprintf("integration-push-%d", time.Now().UnixNano())
-
-		kf.Target(ctx, "default")
 
 		// Push an app and then clean it up. This pushes the echo app which
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", DockerRegistry(),
 		)
 		defer kf.Delete(ctx, appName)
 
@@ -152,7 +148,7 @@ func TestIntegration_StopStart(t *testing.T) {
 
 		{
 			Logf(t, "hitting echo app to ensure it's working...")
-			resp, respCancel := RetryPost(ctx, t, "http://localhost:8085", appTimeout, http.StatusOK, "testing")
+			resp, respCancel := RetryPost(ctx, t, "http://localhost:8085", 5*time.Minute, http.StatusOK, "testing")
 			defer resp.Body.Close()
 			defer respCancel()
 			Logf(t, "done hitting echo app to ensure it's working.")
@@ -179,7 +175,6 @@ func TestIntegration_Push_manifest(t *testing.T) {
 		// Push an app with a manifest file.
 		kf.Push(ctx, appName,
 			"--path", appPath,
-			"--container-registry", DockerRegistry(),
 			"--manifest", newManifestFile,
 		)
 		defer kf.Delete(ctx, appName)
@@ -240,7 +235,6 @@ func TestIntegration_Delete(t *testing.T) {
 		// simplies replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", DockerRegistry(),
 		)
 
 		// This is only in place for cleanup if the test fails.
@@ -278,7 +272,6 @@ func TestIntegration_Envs(t *testing.T) {
 		// variables (ENV1 and ENV2).
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/envs"),
-			"--container-registry", DockerRegistry(),
 			"--env", "ENV1=VALUE1",
 			"--env=ENV2=VALUE2",
 		)
@@ -319,7 +312,6 @@ func TestIntegration_Logs(t *testing.T) {
 		// replies with the same body that was posted.
 		kf.Push(ctx, appName,
 			"--path", filepath.Join(RootDir(ctx, t), "./samples/apps/echo"),
-			"--container-registry", DockerRegistry(),
 		)
 		defer kf.Delete(ctx, appName)
 

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -443,13 +443,13 @@ func RetryPost(
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			Logf(t, "failed to post (retrying...): %s", err)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 			continue
 		}
 
 		if resp.StatusCode != expectedStatusCode {
 			Logf(t, "got %d, wanted %d (retrying...)", resp.StatusCode, expectedStatusCode)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 			continue
 		}
 


### PR DESCRIPTION
fixes #445

- don't `kf target` in tests
- use the space's container registry
- RetryPost doesn't attack the app as frequently
## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
