### PR TITLE
pkg/kf/testutil: prefix failure messages with test name

### DIFF
--- a/pkg/kf/doctor/diagnostic.go
+++ b/pkg/kf/doctor/diagnostic.go
@@ -84,6 +84,11 @@ func (d *Diagnostic) GatedRun(name string, f func(d *Diagnostic)) {
 	d.Run(name, f)
 }
 
+// Name returns the name of the Diagnostic.
+func (d *Diagnostic) Name() string {
+	return d.name
+}
+
 // Fatal is equivalent to Log followed by FailNow.
 func (d *Diagnostic) Fatal(args ...interface{}) {
 	d.Log(args...)

--- a/pkg/kf/testutil/assertions.go
+++ b/pkg/kf/testutil/assertions.go
@@ -30,6 +30,7 @@ import (
 type Failable interface {
 	Helper()
 	Fatalf(format string, args ...interface{})
+	Name() string
 }
 
 // Assert causes a test to fail if the two values are not DeepEqual to
@@ -48,7 +49,7 @@ func AssertEqual(t Failable, fieldName string, expected, actual interface{}) {
 
 	fail := func() {
 		t.Helper()
-		t.Fatalf("expected %s to be equal expected: %#v actual: %#v", fieldName, expected, actual)
+		t.Fatalf("%s: expected %s to be equal expected: %#v actual: %#v", t.Name(), fieldName, expected, actual)
 	}
 
 	v1, v2 := reflect.ValueOf(expected), reflect.ValueOf(actual)
@@ -75,7 +76,7 @@ func AssertRegexp(t Failable, fieldName, pattern, actual string) {
 	t.Helper()
 
 	if !regexp.MustCompile(pattern).MatchString(actual) {
-		t.Fatalf("expected %s to match pattern: %s actual: %s", fieldName, pattern, actual)
+		t.Fatalf("%s: expected %s to match pattern: %s actual: %s", t.Name(), fieldName, pattern, actual)
 	}
 }
 
@@ -84,7 +85,7 @@ func AssertErrorsEqual(t Failable, expected, actual error) {
 	t.Helper()
 
 	if fmt.Sprint(expected) != fmt.Sprint(actual) {
-		t.Fatalf("wanted err: %v, got: %v", expected, actual)
+		t.Fatalf("%s: wanted err: %v, got: %v", t.Name(), expected, actual)
 	}
 }
 
@@ -109,7 +110,7 @@ func AssertContainsAll(t Failable, haystack string, needles []string) {
 	}
 
 	if len(missing) > 0 {
-		t.Fatalf("expected the values %v to be in %q but %v were missing", needles, haystack, missing)
+		t.Fatalf("%s: expected the values %v to be in %q but %v were missing", t.Name(), needles, haystack, missing)
 	}
 }
 
@@ -118,7 +119,7 @@ func AssertNil(t Failable, name string, value interface{}) {
 	t.Helper()
 
 	if value != nil {
-		t.Fatalf("expected %s to be nil but got: %v", name, value)
+		t.Fatalf("%s: expected %s to be nil but got: %v", t.Name(), name, value)
 	}
 }
 
@@ -127,7 +128,7 @@ func AssertNotNil(t Failable, name string, value interface{}) {
 	t.Helper()
 
 	if value == nil {
-		t.Fatalf("expected %s not to be nil", name)
+		t.Fatalf("%s: expected %s not to be nil", t.Name(), name)
 	}
 }
 
@@ -138,11 +139,11 @@ func AssertKeyWithValue(t Failable, m map[interface{}]interface{}, key, value in
 
 	a, ok := m[key]
 	if !ok {
-		t.Fatalf("expected %v to have key %v", m, key)
+		t.Fatalf("%s: expected %v to have key %v", t.Name(), m, key)
 	}
 
 	if !reflect.DeepEqual(value, a) {
-		t.Fatalf("expected %v to have key %v with value %v", m, key, value)
+		t.Fatalf("%s: expected %v to have key %v with value %v", t.Name(), m, key, value)
 	}
 }
 
@@ -154,6 +155,6 @@ func AssertJSONEqual(t Failable, expected, actual string) {
 	AssertNil(t, "actual JSON", json.Unmarshal([]byte(expected), &am))
 
 	if !reflect.DeepEqual(em, am) {
-		t.Fatalf("expected %q to equal %q", actual, expected)
+		t.Fatalf("%s: expected %q to equal %q", t.Name(), actual, expected)
 	}
 }


### PR DESCRIPTION
We tend to use table tests which means the assertion is being applied to
several different tests. This CL helps with quickly finding the failing
test

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Adds `Name()` method to `testutil.Failable`
* Adds `Name()` method to `doctor.Diagnostic`
* Adds `t.Name()` as prefix to failure messages.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
