### PR TITLE
docs: Docsy is a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs/kf.dev/themes/themes/docsy"]
+	path = docs/kf.dev/themes/docsy
+	url = https://github.com/google/docsy.git

--- a/docs/kf.dev/.gitignore
+++ b/docs/kf.dev/.gitignore
@@ -1,4 +1,4 @@
-
+!vendor/
 public/
 resources/
 node_modules/


### PR DESCRIPTION
Previously, Docsy was a submodule but its own embedded submodules failed
because they were in a vendor/ directory that was excluded by our
.gitignore file. This change modifies the .gitignore to allow vendor/
dirs in the docs/ folder, and puts docsy back as a submodule.