### PR TITLE
docs/ci: add CI to build and push static site

### DIFF
--- a/docs/kf.dev/ci/concourse/README.md
+++ b/docs/kf.dev/ci/concourse/README.md
@@ -1,0 +1,30 @@
+# Concourse CI
+
+# Pipelines
+
+The Concourse pipelines use YAML anchors to place all injected variables at the
+beginning of the document. This is done for clarity.
+
+[1]: ./pipelines/website-pipeline.yml
+## [website-pipeline.yml][1]
+
+Pipeline triggered by changes to the `docs/kf.dev` dir on the `master` branch.
+
+## Pipeline Variables
+[3]: https://concourse-ci.org/resources.html#resource-webhook-token
+
+The following variables should be stored in your credential manager.
+
+| Name                         | Description                                              | website-pipeline |
+| ---------------------------- | -------------------------------------------------------- | ---------------- |
+| ci_git_uri                   | Git URI for pulling this directory                       | ✅               |
+| ci_website_git_branch        | Git branch for pulling this directory. Preferably master | ✅               |
+| ci_website_image_uri         | Container image for pulling/pushing the build image      | ✅               |
+| website_firebase_token       | Authentication token for authenticating Firebase calls   | ✅               |
+| website_firebase_project     | Firebase project name/ID                                 | ✅               |
+| service_account_json         | Google Cloud Service Account Key for pushing build image | ✅               |
+
+# Images
+
+A custom container image is used throughout the pipelines. It contains all the
+binaries required by the different tasks. It can be built by [`website-pipeline`][1].

--- a/docs/kf.dev/ci/concourse/image/Dockerfile
+++ b/docs/kf.dev/ci/concourse/image/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+RUN apt update -y
+RUN apt-get install -y curl software-properties-common git
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get install -y nodejs
+
+# Docsy deps
+RUN npm install -g --no-save autoprefixer
+RUN npm install -g --no-save postcss-cli
+RUN npm install -g --no-save firebase-tools
+RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v0.56.3/hugo_extended_0.56.3_Linux-64bit.deb \
+  && dpkg -i hugo*.deb

--- a/docs/kf.dev/ci/concourse/pipelines/website-pipeline.yml
+++ b/docs/kf.dev/ci/concourse/pipelines/website-pipeline.yml
@@ -1,0 +1,86 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+# Store these in your credential manager.
+vars:
+
+# ci config vars
+- &ci_git_uri ((ci_git_uri))
+- &ci_git_branch ((ci_website_git_branch))
+- &ci_image_uri ((ci_website_image_uri))
+- &firebase_token ((website_firebase_token))
+- &firebase_project ((website_firebase_project))
+- &service_account_json ((service_account_json))
+# ---- end vars ----
+
+resources:
+- name: kf-docs-master
+  type: git
+  source:
+    uri: https://github.com/google/kf
+    branch: master
+    paths:
+    - docs/kf.dev
+- name: ci-image-src
+  type: git
+  source:
+    branch: *ci_git_branch
+    uri: *ci_git_uri
+    paths:
+    - docs/kf.dev/ci/concourse/image
+- name: ci-image
+  type: docker-image
+  source: &ci-image-source
+    repository: *ci_image_uri
+    username: _json_key
+    password: *service_account_json
+
+jobs:
+# builds the ci image for later steps/other pipelines
+- name: ci-image
+  plan:
+  - get: ci-image-src
+    trigger: true
+  - put: ci-image
+    params:
+      build: ci-image-src/docs/kf.dev/ci/concourse/image
+- name: website-publish
+  plan:
+  - get: kf-docs-master
+    trigger: true
+  - task: build-and-push
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: gcr.io/kf-source/website-ci-image
+          username: _json_key
+          password: *service_account_json
+      inputs:
+      - name: kf-docs-master
+      params:
+        FIREBASE_TOKEN: *firebase_token
+        FIREBASE_PROJECT: *firebase_project
+      run:
+        dir: kf-docs-master
+        path: sh
+        args:
+        - -exc
+        - |
+          # Build site with Hugo and deploy with Firebase
+          cd docs/kf.dev
+          export NODE_PATH=$NODE_PATH:`npm root -g`
+          hugo && firebase deploy --project $FIREBASE_PROJECT --token $FIREBASE_TOKEN


### PR DESCRIPTION
This change adds a Concourse pipeline for building and publishing the
kf.dev static site. The pipeline also includes a task for creating the
Docker image that the build/publish task uses.

Fixes #490 