### PR TITLE
ci/concourse/pipeline: adds release job

### DIFF
--- a/ci/concourse/pipelines/kf-pipeline.yml
+++ b/ci/concourse/pipelines/kf-pipeline.yml
@@ -92,6 +92,14 @@ resources:
     start: 0:00
     stop: 1:00
     location: America/Los_Angeles
+- name: draft-github-release
+  type: github-release
+  source:
+    owner: google
+    repository: kf
+    access_token: *github_access_token
+    drafts: true
+    pre_release: true
 
 jobs:
 # builds the ci image for later steps/other pipelines
@@ -261,3 +269,58 @@ jobs:
       run:
         dir: kf-master
         path: hack/upload-release.sh
+
+# Cut a new release of kf
+# TODO: Consider semantic versioning resource:
+# https://github.com/concourse/semver-resource#gcs-driver
+# ATM, it seems like overkill and we should consider it when we are
+# releasing in a more automated way.
+- name: kf-release
+  plan:
+  - aggregate:
+    - get: kf-master
+      trigger: false
+  - task: create-release
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: *ci-image-source
+      params:
+        SERVICE_ACCOUNT_JSON: *release_service_account_json
+        GCP_PROJECT_ID: *gcp_project_id
+        KO_DOCKER_REPO: *ko_docker_release_repo
+        RELEASE_BUCKET: *release_bucket
+        CLI_RELEASE_BUCKET: *cli_release_bucket
+        VERSION_MAJOR: 0
+        VERSION_MINOR: 100
+        VERSION_PATCH: 0
+      inputs:
+      - name: kf-master
+      outputs:
+      - name: github-release
+      run:
+        dir: kf-master
+        path: sh
+        args:
+        - -exc
+        - |
+          # Build artifacts
+          ./hack/build-release.sh ../github-release
+
+          # Write release info
+          tag=$(echo "v${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+          echo "${tag}" > ../github-release/tag
+          echo "kf ${tag}" > ../github-release/name
+          echo "Draft notes need to be filled in manually" > ../github-release/body
+          echo "$(git rev-parse HEAD)" > ../github-release/commitish
+
+  - put: draft-github-release
+    params:
+      name: github-release/name
+      tag: github-release/tag
+      body: github-release/body
+      commitish: github-release/commitish
+      globs:
+      - github-release/release.yaml
+      - github-release/bin/*

--- a/ci/concourse/pipelines/kf-pipeline.yml
+++ b/ci/concourse/pipelines/kf-pipeline.yml
@@ -39,6 +39,11 @@ vars:
 - &cli_release_bucket ((cli_release_bucket))
 - &gcp_project_id ((gcp_project_id))
 
+# kf-release
+- &release_major_version ((release_major_version))
+- &release_minor_version ((release_minor_version))
+- &release_patch_version ((release_patch_version))
+
 # ---- end vars ----
 
 resource_types:
@@ -292,9 +297,9 @@ jobs:
         KO_DOCKER_REPO: *ko_docker_release_repo
         RELEASE_BUCKET: *release_bucket
         CLI_RELEASE_BUCKET: *cli_release_bucket
-        VERSION_MAJOR: 0
-        VERSION_MINOR: 100
-        VERSION_PATCH: 0
+        VERSION_MAJOR: *release_major_version
+        VERSION_MINOR: *release_minor_version
+        VERSION_PATCH: *release_patch_version
       inputs:
       - name: kf-master
       outputs:

--- a/hack/README.md
+++ b/hack/README.md
@@ -4,6 +4,7 @@ This directory contains several scripts useful in the development process of
 kf.
 
 - `build.sh` Build the kf CLI.
+- `build-release.sh` Build the release and CLI artifacts.
 - `checks-go-generate.sh` Runs `go generate ./...` and checks to see if
   anything changed. This is useful for enforcing commits be formatted.
 - `check-go-sum.sh` Ensures the `go.sum` file is correct.
@@ -12,8 +13,5 @@ kf.
   from running the integration tests.
 - `test.sh` Run all the tests including the integration tests.
 - `update-codegen.sh` Updates auto-generated client libraries.
-- `upload-buildpacks.sh` Uploads the sample stack and buildpacks to the
-  current GCP project's gcr.io. It then updates the current "buildpack"
-  ClusterBuildTemplate to point to the newly created builder.
-- `upload-buildpacks-stack.sh` Uploads new buildpacks stack images to the
-  current GCP project's gcr.io.
+- `upload-release.sh` Builds and uploads the release YAML and CLI artifacts
+  for the nightly builds.

--- a/hack/build-release.sh
+++ b/hack/build-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env sh
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eux
+
+if [ "$#" -ne 1 ]; then
+        echo "usage: $0 [OUTPUT PATH]"
+        exit 1
+fi
+
+output=$1
+
+export GO111MODULE=on
+export GOPROXY=https://proxy.golang.org
+export GOSUMDB=sum.golang.org
+
+# Change to the project root directory
+cd "${0%/*}"/..
+
+# ko resolve
+# This publishes the images to KO_DOCKER_REPO and writes the yaml to
+# stdout.
+ko resolve --filename config > ${output}/release.yaml
+
+###################
+# Generate kf CLI #
+###################
+
+mkdir ${output}/bin
+
+hash=$(git rev-parse HEAD)
+[ -z "$hash" ] && echo "failed to read hash" && exit 1
+
+# Build the binaries
+for os in $(echo linux darwin windows); do
+  destination=${output}/bin/kf-${os}
+  if [ ${os} = "windows" ]; then
+    # Windows only executes things with the .exe extension
+    destination=${destination}.exe
+  fi
+
+  # Build
+  GOOS=${os} go build -o ${destination} --ldflags "-X github.com/google/kf/pkg/kf/commands.Version=${hash}" ./cmd/kf
+done


### PR DESCRIPTION
This pipeline allows kf to deliver versions (e.g., 0.1). It will upload
a tag and release artifacts to github.

related to #168 

## Proposed Changes

* Adds release job to concourse pipeline
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added new job in pipeline
```
