### PR TITLE
hack: only run misspell on go files

### DIFF
--- a/hack/check-linters.sh
+++ b/hack/check-linters.sh
@@ -33,4 +33,4 @@ go vet ./...
 GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
 
 # ignore vendor directory
-find . -type f -name '*' | grep -v ./vendor/ | xargs -n1 -P 20 $(go env GOPATH)/bin/misspell -error
+find . -type f -name '*.go' | grep -v ./vendor/ | xargs -n1 -P 20 $(go env GOPATH)/bin/misspell -error


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes # n/a

## Proposed Changes

* Only run misspell linter on go files
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
