### PR TITLE
pkg/apis/kf/v1alpha1: default EnableDeveloperLogsAccess to true

### DIFF
--- a/pkg/apis/kf/v1alpha1/space_defaults.go
+++ b/pkg/apis/kf/v1alpha1/space_defaults.go
@@ -46,7 +46,8 @@ func (k *SpaceSpec) SetDefaults(ctx context.Context, name string) {
 
 // SetDefaults implements apis.Defaultable
 func (k *SpaceSpecSecurity) SetDefaults(ctx context.Context) {
-	// XXX: currently no defaults to set
+	// TODO(#458): We eventually want this to be configurable.
+	k.EnableDeveloperLogsAccess = true
 }
 
 // SetDefaults implements apis.Defaultable

--- a/pkg/apis/kf/v1alpha1/space_defaults_test.go
+++ b/pkg/apis/kf/v1alpha1/space_defaults_test.go
@@ -65,4 +65,16 @@ func ExampleSpaceSpecExecution_SetDefaults_dedupe() {
 	fmt.Println(strings.Join(domainNames, ", "))
 
 	// Output: *example.com, other-example.com
+
+}
+func ExampleSpaceSpecSecurity_SetDefaults_dedupe() {
+	space := Space{}
+	space.Spec.Security = SpaceSpecSecurity{
+		EnableDeveloperLogsAccess: false,
+	}
+	space.SetDefaults(context.Background())
+
+	fmt.Println("EnableDeveloperLogsAccess:", space.Spec.Security.EnableDeveloperLogsAccess)
+
+	// Output: EnableDeveloperLogsAccess: true
 }


### PR DESCRIPTION
We aren't currently enforcing log access, so we should always show the
developer has access.

related to #458

## Proposed Changes

* Default `space.Spec.Security.EnableDeveloperLogsAccess` to true
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added default to `space.Spec.Security.EnableDeveloperLogsAccess`
```
