### PR TITLE
Single-character flag needs only single leading '-'

### DIFF
--- a/pkg/kf/commands/apps/scale.go
+++ b/pkg/kf/commands/apps/scale.go
@@ -42,7 +42,7 @@ func NewScaleCommand(
 		Short: "Change or view the instance count for an app",
 		Example: `
   kf scale myapp # Displays current scaling
-  kf scale myapp --i 3 # Scale to exactly 3 instances
+  kf scale myapp -i 3 # Scale to exactly 3 instances
   kf scale myapp --instances 3 # Scale to exactly 3 instances
   kf scale myapp --min 3 # Autoscaler won't scale below 3 instances
   kf scale myapp --max 5 # Autoscaler won't scale above 5 instances


### PR DESCRIPTION
Minor issue/typo in the kf CLI utility internal help for the `scale` command.

## Proposed Changes

* Display only a single leading dash in the tool-internal help.

## Release Notes

```release-note
Fixed typo in the kf CLI utility internal help for the `scale` command.
```
