### PR TITLE
pkg/kf/commands/config: lazily return kube config errors

### DIFF
--- a/pkg/kf/commands/config/config.go
+++ b/pkg/kf/commands/config/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -266,7 +267,11 @@ func getRestConfig(p *KfParams) *rest.Config {
 	clientCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
 	restCfg, err := clientCfg.ClientConfig()
 	if err != nil {
-		log.Fatalf("failed to build clientcmd: %s", err)
+		return &rest.Config{
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return nil, fmt.Errorf("failed to build clientcmd: %s", err)
+			},
+		}
 	}
 
 	return restCfg


### PR DESCRIPTION
Before this CL, if a user does not have a $HOME/.kube/config, commands
like `kf version` and `kf install` would still fail.

This CL fixes that by returning a `rest.Config` that has a `Dial`
function that will always return an error if the config failed to load.

fixes #504

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Only return config error if the kube config is used
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changes when a kube config error is returned
Fixed kube config being required for commands like version and install
```
