### PR TITLE
pkg/kf/internal/tools: adds command-generator

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/debug/_index.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/debug/_index.md
@@ -1,0 +1,19 @@
+
+---
+title: "debug"
+linkTitle: "debug"
+weight: 10
+---
+
+### Usage
+kf debug 
+### Description
+
+Show debugging information useful for filing a bug report
+
+### Examples
+
+    kf debug
+
+
+

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/target/_index.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/target/_index.md
@@ -1,0 +1,26 @@
+
+---
+title: "target"
+linkTitle: "target"
+weight: 10
+---
+
+### Usage
+kf target 
+### Description
+
+Set or view the targeted space
+
+### Examples
+
+    kf target
+
+    kf target -s myspace
+
+### Flags
+
+##### -s, --space <_string_>
+Target the given space.
+
+
+

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/version/_index.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/version/_index.md
@@ -1,0 +1,19 @@
+
+---
+title: "version"
+linkTitle: "version"
+weight: 10
+---
+
+### Usage
+kf version 
+### Description
+
+Display the CLI version
+
+### Examples
+
+    kf version
+
+
+

--- a/pkg/kf/commands/commands.yaml
+++ b/pkg/kf/commands/commands.yaml
@@ -1,0 +1,25 @@
+# Used with pkg/kf/internal/tools/
+---
+package: commands
+commands:
+- name: debug
+  short: Show debugging information useful for filing a bug report
+  examples:
+  - kf debug
+  markdownPath: ../../../docs/kf.dev/content/en/docs/general-info/kf-cli/commands/debug/_index.md
+- name: target
+  short: Set or view the targeted space
+  examples:
+  - kf target
+  - kf target -s myspace
+  markdownPath: ../../../docs/kf.dev/content/en/docs/general-info/kf-cli/commands/target/_index.md
+  flags:
+  - long: space
+    type: string
+    shorthand: s
+    usage: Target the given space.
+- name: version
+  short: Display the CLI version
+  examples:
+  - kf version
+  markdownPath: ../../../docs/kf.dev/content/en/docs/general-info/kf-cli/commands/version/_index.md

--- a/pkg/kf/commands/debug.go
+++ b/pkg/kf/commands/debug.go
@@ -26,20 +26,14 @@ import (
 
 // NewDebugCommand creates a command that prints debugging information.
 func NewDebugCommand(p *config.KfParams) *cobra.Command {
-	return &cobra.Command{
-		Use:     "debug",
-		Short:   "Show debugging information useful for filing a bug report",
-		Example: `  kf debug`,
-		Args:    cobra.ExactArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			w := cmd.OutOrStdout()
+	return newDebug(func(d debug, cmd *cobra.Command, args []string) error {
+		w := cmd.OutOrStdout()
 
-			debugRuntime(w)
-			debugKfParams(w, p)
+		debugRuntime(w)
+		debugKfParams(w, p)
 
-			return nil
-		},
-	}
+		return nil
+	})
 }
 
 func debugKfParams(w io.Writer, p *config.KfParams) {

--- a/pkg/kf/commands/doc.go
+++ b/pkg/kf/commands/doc.go
@@ -14,25 +14,4 @@
 
 package commands
 
-import (
-	"fmt"
-
-	"github.com/google/kf/pkg/kf/commands/config"
-	"github.com/spf13/cobra"
-)
-
-// NewTargetCommand creates a command that can set the default space.
-func NewTargetCommand(p *config.KfParams) *cobra.Command {
-	return newTarget(func(t target, cmd *cobra.Command, args []string) error {
-		if space, _ := t.Space(); space != "" {
-			p.Namespace = space
-			if err := config.Write(p.Config, p); err != nil {
-				return err
-			}
-		}
-
-		fmt.Fprintln(cmd.OutOrStdout(), "Current space is:", p.Namespace)
-
-		return nil
-	})
-}
+//go:generate go run ../internal/tools/command-generator/command-generator.go commands.yaml zz_generated.commands.go

--- a/pkg/kf/commands/version.go
+++ b/pkg/kf/commands/version.go
@@ -21,17 +21,11 @@ import (
 )
 
 // NewVersionCommand returns a command that displays the version.
-func NewVersionCommand(version, goos string) *cobra.Command {
-	return &cobra.Command{
-		Use:     "version",
-		Short:   "Display the CLI version",
-		Example: `  kf version`,
-		Args:    cobra.ExactArgs(0),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(cmd.OutOrStdout(), "kf version", version, goos)
-			return nil
-		},
-	}
+func NewVersionCommand(versionStr, goos string) *cobra.Command {
+	return newVersion(func(v version, cmd *cobra.Command, args []string) error {
+		fmt.Fprintln(cmd.OutOrStdout(), "kf version", versionStr, goos)
+		return nil
+	})
 }
 
 // Version is filled in via ldflags.

--- a/pkg/kf/commands/zz_generated.commands.go
+++ b/pkg/kf/commands/zz_generated.commands.go
@@ -1,0 +1,111 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file was generated with command-generator.go, DO NOT EDIT IT.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type debug struct {
+}
+
+func newDebug(run func(x debug, cmd *cobra.Command, args []string) error) *cobra.Command {
+	x := debug{}
+	cmd := &cobra.Command{
+		Use:     "debug ",
+		Short:   "Show debugging information useful for filing a bug report",
+		Long:    "",
+		Example: "  kf debug",
+		Aliases: []string{},
+		Args:    cobra.RangeArgs(0, 0),
+	}
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return run(x, cmd, args)
+	}
+
+	return cmd
+}
+
+type target struct {
+	// space stores the value for "--space"
+	space string
+	// spaceIsSet is set to true if the user sets the flag
+	spaceIsSet bool
+}
+
+// Space returns the value for "--space" and if the user set it.
+func (f *target) Space() (string, bool) {
+	return f.space, f.spaceIsSet
+}
+
+func newTarget(run func(x target, cmd *cobra.Command, args []string) error) *cobra.Command {
+	x := target{}
+	cmd := &cobra.Command{
+		Use:     "target ",
+		Short:   "Set or view the targeted space",
+		Long:    "",
+		Example: "  kf target\n  kf target -s myspace",
+		Aliases: []string{},
+		Args:    cobra.RangeArgs(0, 0),
+	}
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		// Space returns the value for "--space" and if the user set it.
+
+		x.spaceIsSet = cmd.Flags().Changed("space")
+
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return run(x, cmd, args)
+	}
+
+	// Space returns the value for "--space" and if the user set it.
+	cmd.Flags().StringVarP(
+		&x.space,
+		"space",
+		"s",
+		"",
+		"Target the given space.",
+	)
+
+	return cmd
+}
+
+type version struct {
+}
+
+func newVersion(run func(x version, cmd *cobra.Command, args []string) error) *cobra.Command {
+	x := version{}
+	cmd := &cobra.Command{
+		Use:     "version ",
+		Short:   "Display the CLI version",
+		Long:    "",
+		Example: "  kf version",
+		Aliases: []string{},
+		Args:    cobra.RangeArgs(0, 0),
+	}
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return run(x, cmd, args)
+	}
+
+	return cmd
+}

--- a/pkg/kf/internal/tools/command-generator/command-generator.go
+++ b/pkg/kf/internal/tools/command-generator/command-generator.go
@@ -1,0 +1,439 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/format"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/google/kf/pkg/kf/internal/tools/generator"
+	"gopkg.in/yaml.v2"
+)
+
+type CommandFile struct {
+	License string            `yaml:"license"`
+	Package string            `yaml:"package"`
+	Imports map[string]string `yaml:"imports"`
+
+	Commands []Command `yaml:"commands"`
+}
+
+type Command struct {
+	Name     string   `yaml:"name"`
+	Short    string   `yaml:"short"`
+	Long     string   `yaml:"long"`
+	Aliases  []string `yaml:"aliases"`
+	Examples []string `yaml:"examples"`
+
+	IncludeManifest bool   `yaml:"includeManifest"`
+	MarkdownPath    string `yaml:"markdownPath"`
+
+	Args  []Arg  `yaml:"args"`
+	Flags []Flag `yaml:"flags"`
+}
+
+func (c Command) Unexported() string {
+	return generator.UnexportedName(camelCase(c.Name))
+}
+
+func (c Command) Exported() string {
+	return generator.ExportedName(camelCase(c.Name))
+}
+
+func (c Command) Use() string {
+	args := []string{}
+	for _, arg := range c.Args {
+		name := strings.ToUpper(arg.Name)
+		if arg.Optional {
+			name = fmt.Sprintf("[%s]", name)
+		}
+		args = append(args, name)
+	}
+
+	return c.Name + " " + strings.Join(args, " ")
+}
+
+// IndentedExample puts 2 spaces before each line of an example. This is
+// necessary because every other element (e.g., usage, flags), are indented,
+// but the example (if its multilined) is not.
+func (c Command) IndentedExample() string {
+	for i := range c.Examples {
+		c.Examples[i] = "  " + c.Examples[i]
+	}
+	return strings.Join(c.Examples, "\n")
+}
+
+func (c Command) AliasStringArray() string {
+	var x []string
+	for _, a := range c.Aliases {
+		x = append(x, fmt.Sprintf("%q", a))
+	}
+	return fmt.Sprintf("[]string { %s }", strings.Join(x, ","))
+}
+
+func (c Command) ArgNRange() string {
+	var (
+		required      int
+		foundOptional bool
+	)
+	for _, arg := range c.Args {
+		if arg.Optional {
+			foundOptional = true
+			continue
+		}
+		// Assert that optional args are after required.
+		if foundOptional {
+			log.Fatalf("%s is a REQUIRED arg, however it is after an OPTIONAL arg. This is invalid.", arg.Name)
+		}
+
+		required++
+	}
+	return fmt.Sprintf("%d, %d", required, len(c.Args))
+}
+
+type Arg struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	Optional    bool   `yaml:"optional"`
+
+	// UpperName is set by Name.
+	UpperName string `yaml:"-"`
+}
+
+type Flag struct {
+	Long      string `yaml:"long"`
+	Type      string `yaml:"type"`
+	Shorthand string `yaml:"shorthand"`
+	Default   string `yaml:"default"`
+	Usage     string `yaml:"usage"`
+}
+
+func (f Flag) Exported() string {
+	return generator.ExportedName(camelCase(f.Long))
+}
+
+func (f Flag) Unexported() string {
+	return generator.UnexportedName(camelCase(f.Long))
+}
+
+func (f Flag) CobraFuncName() string {
+	return generator.ExportedName(f.Type) + "VarP"
+}
+
+func (f Flag) ManifestStructTag() string {
+	return fmt.Sprintf("`yaml:%q`", generator.UnexportedName(camelCase(f.Long)))
+}
+
+func (f Flag) DefaultValue() (value string) {
+	defer func() {
+		// We need strings to be wrapped in quotes
+		if f.Type != "string" {
+			return
+		}
+
+		value = fmt.Sprintf("%q", value)
+	}()
+
+	if f.Default != "" {
+		return f.Default
+	}
+
+	switch f.Type {
+	case "int64", "int", "float64":
+		return "0"
+	case "string":
+		return ""
+	case "bool":
+		return "false"
+	default:
+		panic("unkown type " + f.Type)
+	}
+}
+
+func (f Flag) MarkdownTitle() string {
+	switch {
+	case f.Long != "" && f.Shorthand != "":
+		return fmt.Sprintf("##### -%s, --%s <_%s_>", f.Shorthand, f.Long, f.Type)
+	case f.Long != "":
+		return fmt.Sprintf("##### --%s <_%s_>", f.Long, f.Type)
+	case f.Shorthand != "":
+		return fmt.Sprintf("##### -%s <_%s_>", f.Shorthand, f.Type)
+	default:
+		panic("Long and Short not set")
+	}
+}
+
+func (f Flag) MarkdownDefault() string {
+	if f.Default != "" {
+		if f.Type == "string" {
+			return fmt.Sprintf("%s (default=%q)", f.Usage, f.Default)
+		}
+		return fmt.Sprintf("%s (default=%s)", f.Usage, f.Default)
+	}
+
+	return fmt.Sprintf("%s", f.Usage)
+}
+
+func main() {
+	log.SetPrefix("command-generator ")
+	flag.Parse()
+	args := flag.Args()
+	if flag.NArg() != 2 {
+		log.Fatalln("use: command-generator.go /path/to/commands.yml output-file.go")
+	}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	commandPath := args[0]
+	commandOut := filepath.Join(wd, args[1])
+
+	log.Printf("building %s from %s\n", commandOut, commandPath)
+
+	buildCommandFile(
+		commandPath,
+		commandOut,
+		readCommandFile(commandPath),
+	)
+}
+
+func readCommandFile(commandPath string) *CommandFile {
+	contents, err := ioutil.ReadFile(commandPath)
+	if err != nil {
+		log.Fatalln("could not read contents", err)
+	}
+
+	cf := &CommandFile{Imports: map[string]string{
+		"github.com/spf13/cobra": "",
+	}}
+	if err := yaml.Unmarshal(contents, cf); err != nil {
+		log.Fatalf("failed to unmarshal YAML: %s", err)
+	}
+
+	return cf
+}
+
+func buildCommandFile(commandPath, commandOut string, cf *CommandFile) {
+	headerTemplate := template.Must(template.New("").Funcs(generator.TemplateFuncs()).Parse(`
+{{genlicense}}
+
+{{gennotice "command-generator.go"}}
+
+package {{.Package}}
+
+{{genimports .Imports}}
+`))
+
+	typeTemplate := template.Must(template.New("").Parse(`
+type {{.Unexported}} struct{
+  {{ range $idx, $flag := .Flags}}// {{$flag.Unexported}} stores the value for "--{{$flag.Long}}"
+  {{$flag.Unexported}} {{$flag.Type}}
+  // {{$flag.Unexported}}IsSet is set to true if the user sets the flag
+  {{$flag.Unexported}}IsSet bool
+  {{ end }}
+}
+{{ range $idx, $flag := .Flags}}// {{$flag.Exported}} returns the value for "--{{$flag.Long}}" and if the user set it.
+func (f *{{$.Unexported}}) {{$flag.Exported}}() ({{$flag.Type}}, bool) {
+  return f.{{$flag.Unexported}}, f.{{$flag.Unexported}}IsSet
+}
+{{ end }}
+`))
+
+	newCommandTemplate := template.Must(template.New("").Parse(`
+func new{{.Exported}}(run func(x {{.Unexported}}, cmd *cobra.Command, args []string) error) *cobra.Command {
+  x := {{.Unexported}}{}
+  cmd := &cobra.Command{
+    Use: {{ printf "%q" .Use }},
+    Short: {{ printf "%q" .Short }},
+    Long: {{ printf "%q" .Long }},
+    Example: {{ printf "%q" .IndentedExample }},
+	Aliases: {{ .AliasStringArray }},
+	Args: cobra.RangeArgs({{.ArgNRange}}),
+  }
+  cmd.PreRun = func(cmd *cobra.Command, args []string) {
+    {{ range $idx, $flag := .Flags}}// {{$flag.Exported}} returns the value for "--{{$flag.Long}}" and if the user set it.
+
+    x.{{$flag.Unexported}}IsSet = cmd.Flags().Changed("{{$flag.Long}}")
+    {{ end }}
+  }
+  cmd.RunE = func(cmd *cobra.Command, args []string) error {
+    return run(x, cmd, args)
+  }
+
+{{ range $idx, $flag := .Flags}}// {{$flag.Exported}} returns the value for "--{{$flag.Long}}" and if the user set it.
+  cmd.Flags().{{$flag.CobraFuncName}}(
+    &x.{{$flag.Unexported}},
+	"{{$flag.Long}}",
+	"{{$flag.Shorthand}}",
+	{{$flag.DefaultValue}},
+	"{{$flag.Usage}}",
+  )
+{{ end }}
+
+  return cmd
+}
+`))
+
+	manifestTypeTemplate := template.Must(template.New("").Parse(`
+{{ if .IncludeManifest }}
+type Manifest{{.Exported}} struct{
+  {{ range $idx, $flag := .Flags}}// {{$flag.Unexported}} stores the value for "{{$flag.Exported}}"
+  {{$flag.Exported}} {{$flag.Type}} {{$flag.ManifestStructTag}}
+  {{ end }}
+}
+{{ end }}
+`))
+
+	buf := &bytes.Buffer{}
+
+	// Write headers
+	if err := headerTemplate.Execute(buf, cf); err != nil {
+		log.Fatalln(err)
+	}
+	buf.WriteString("\n")
+
+	// Write templates for each command
+	for _, command := range cf.Commands {
+		templs := []*template.Template{
+			typeTemplate,
+			newCommandTemplate,
+			manifestTypeTemplate,
+		}
+
+		for _, templ := range templs {
+			if err := templ.Execute(buf, command); err != nil {
+				log.Fatalln(err)
+			}
+			buf.WriteString("\n")
+		}
+		writeMarkdown(commandPath, command)
+	}
+
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		log.Fatalf("failed to format code: %s", err)
+	}
+
+	f, err := os.Create(commandOut)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer f.Close()
+	if _, err := f.Write(formatted); err != nil {
+		log.Fatalf("failed to write to %s: %s", commandOut, err)
+	}
+}
+
+func camelCase(flagName string) string {
+	flagNameSpaces := strings.ReplaceAll(flagName, "-", " ")
+	flagNameTitled := strings.Title(flagNameSpaces)
+	return strings.ReplaceAll(flagNameTitled, " ", "")
+}
+
+func writeMarkdown(commandPath string, cmd Command) {
+	if cmd.MarkdownPath == "" {
+		return
+	}
+
+	if !filepath.IsAbs(cmd.MarkdownPath) {
+		cmd.MarkdownPath = filepath.Join(
+			filepath.Dir(commandPath),
+			cmd.MarkdownPath,
+		)
+	}
+
+	headerTemplate := template.Must(template.New("").Funcs(generator.TemplateFuncs()).Parse(`
+---
+title: "{{ .Name }}"
+linkTitle: "{{ .Name }}"
+weight: 10
+---
+
+### Usage
+kf {{ .Use }}
+
+### Description
+{{- if ne .Long "" }}
+{{ .Long }}
+{{ else if ne .Short "" }}
+{{ .Short }}
+{{ else }}
+_No Description_
+{{ end }}
+{{ if (len .Aliases) gt 0 -}}
+### Aliases
+{{ range $idx, $alias := .Aliases }}
+* {{ $alias }}
+{{ end }}
+{{ end }}
+{{- if (len .Examples) gt 0 -}}
+### Examples
+{{ range $idx, $example:= .Examples }}
+  {{ $example }}
+{{ end }}
+{{ end }}
+{{- if (len .Args) gt 0 -}}
+### Positional Arguments
+{{ range $idx, $arg := .Args }}
+##### {{ $arg.Name }}
+{{ if $arg.Optional }}{{printf "%s (OPTIONAL)" $arg.Description}}{{else}}{{printf "%s (REQUIRED)" $arg.Description}}{{end}}
+{{ end }}
+{{ end }}
+{{- if (len .Flags) gt 0 -}}
+### Flags
+{{ range $idx, $flag := .Flags }}
+{{ $flag.MarkdownTitle }}
+{{ $flag.MarkdownDefault }}
+{{ end }}
+{{ end }}
+`))
+
+	buf := &bytes.Buffer{}
+
+	// Write templates for each command
+	templs := []*template.Template{
+		headerTemplate,
+	}
+
+	for _, templ := range templs {
+		if err := templ.Execute(buf, cmd); err != nil {
+			log.Fatalln(err)
+		}
+		buf.WriteString("\n")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cmd.MarkdownPath), 0777|os.ModeDir); err != nil {
+		log.Fatalln(err)
+	}
+
+	f, err := os.Create(cmd.MarkdownPath)
+	if err != nil {
+		log.Fatalf("failed to create %s: %s", cmd.MarkdownPath, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		log.Fatalf("failed to write to %s: %s", cmd.MarkdownPath, err)
+	}
+}

--- a/pkg/kf/internal/tools/command-generator/gentest/commands.yaml
+++ b/pkg/kf/internal/tools/command-generator/gentest/commands.yaml
@@ -1,0 +1,47 @@
+# This file is used to test the command-generator
+
+package: gentest
+commands:
+- name: test-command
+  short: some-short
+  long: some-long
+  aliases: [some-alias]
+  examples:
+  - first-example
+  - second-example
+  includeManifest: true
+  markdownPath: gendocs/markdown.md
+  args:
+  - name: arg_nonoptional
+    description: "arg_nonoptional desc"
+  - name: other_arg_nonoptional
+    description: "other_arg_nonoptional desc"
+  - name: arg_optional
+    description: "arg_optional desc"
+    optional: true
+  flags:
+  - long: flag-int64
+    type: int64
+    shorthand: a
+    default: 99
+    usage: "some int64 thing"
+  - long: flag-int
+    type: int
+    shorthand: b
+    default: 100
+    usage: "some int thing"
+  - long: flag-float64
+    type: float64
+    shorthand: c
+    default: 101.0
+    usage: "some float64 thing"
+  - long: flag-string
+    type: string
+    shorthand: d
+    default: "one hundred and two"
+    usage: "some string thing"
+  - long: flag-bool
+    type: bool
+    shorthand: e
+    default: true
+    usage: "some bool thing"

--- a/pkg/kf/internal/tools/command-generator/gentest/commands_test.go
+++ b/pkg/kf/internal/tools/command-generator/gentest/commands_test.go
@@ -1,0 +1,216 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gentest
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/google/kf/pkg/kf/testutil"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+//go:generate ./generate-test-output.sh
+
+func TestNewCommand_Meta(t *testing.T) {
+	t.Parallel()
+	cmd := newTestCommand(func(tc testCommand, cmd *cobra.Command, args []string) error {
+		return nil
+	})
+	testutil.AssertEqual(t, "Use", "test-command ARG_NONOPTIONAL OTHER_ARG_NONOPTIONAL [ARG_OPTIONAL]", cmd.Use)
+	testutil.AssertEqual(t, "Short", "some-short", cmd.Short)
+	testutil.AssertEqual(t, "Long", "some-long", cmd.Long)
+	testutil.AssertEqual(t, "Example", []string{"  first-example", "  second-example"}, strings.Split(cmd.Example, "\n"))
+	testutil.AssertEqual(t, "Aliases", []string{"some-alias"}, cmd.Aliases)
+}
+
+func TestNewCommand_Args(t *testing.T) {
+	t.Parallel()
+	cmd := newTestCommand(func(tc testCommand, cmd *cobra.Command, args []string) error {
+		return nil
+	})
+	testutil.AssertErrorsEqual(t, errors.New("accepts between 2 and 3 arg(s), received 0"), cmd.Execute())
+}
+
+func TestNewCommand_Flags(t *testing.T) {
+	t.Parallel()
+	cmd := newTestCommand(func(tc testCommand, cmd *cobra.Command, args []string) error {
+		// Int64
+		{
+			x, ok := tc.FlagInt64()
+			testutil.AssertEqual(t, "flag-int64", int64(199), x)
+			testutil.AssertEqual(t, "flag-int64 is set", true, ok)
+		}
+		// Int
+		{
+			x, ok := tc.FlagInt()
+			testutil.AssertEqual(t, "flag-int", 1100, x)
+			testutil.AssertEqual(t, "flag-int is set", true, ok)
+		}
+		// Float64
+		{
+			x, ok := tc.FlagFloat64()
+			testutil.AssertEqual(t, "flag-float64", 1101.0, x)
+			testutil.AssertEqual(t, "flag-float64 is set", true, ok)
+		}
+		// String
+		{
+			x, ok := tc.FlagString()
+			testutil.AssertEqual(t, "flag-string", "one thousand one hundred and two", x)
+			testutil.AssertEqual(t, "flag-string is set", true, ok)
+		}
+		// Bool
+		{
+			x, ok := tc.FlagBool()
+			testutil.AssertEqual(t, "flag-bool", false, x)
+			testutil.AssertEqual(t, "flag-bool is set", true, ok)
+		}
+
+		return nil
+	})
+	cmd.SetArgs([]string{
+		"--flag-int64=199",
+		"--flag-int=1100",
+		"--flag-float64=1101.0",
+		"--flag-string=one thousand one hundred and two",
+		"--flag-bool=false",
+		"some-arg-1",
+		"some-arg-2",
+	})
+	testutil.AssertNil(t, "err", cmd.Execute())
+}
+
+func TestNewCommand_Defaults(t *testing.T) {
+	t.Parallel()
+	cmd := newTestCommand(func(tc testCommand, cmd *cobra.Command, args []string) error {
+		// Int64
+		{
+			x, ok := tc.FlagInt64()
+			testutil.AssertEqual(t, "flag-int64", int64(99), x)
+			testutil.AssertEqual(t, "flag-int64 is set", false, ok)
+		}
+		// Int
+		{
+			x, ok := tc.FlagInt()
+			testutil.AssertEqual(t, "flag-int", 100, x)
+			testutil.AssertEqual(t, "flag-int is set", false, ok)
+		}
+		// Float64
+		{
+			x, ok := tc.FlagFloat64()
+			testutil.AssertEqual(t, "flag-float64", 101.0, x)
+			testutil.AssertEqual(t, "flag-float64 is set", false, ok)
+		}
+		// String
+		{
+			x, ok := tc.FlagString()
+			testutil.AssertEqual(t, "flag-string", "one hundred and two", x)
+			testutil.AssertEqual(t, "flag-string is set", false, ok)
+		}
+		// Bool
+		{
+			x, ok := tc.FlagBool()
+			testutil.AssertEqual(t, "flag-bool", true, x)
+			testutil.AssertEqual(t, "flag-bool is set", false, ok)
+		}
+
+		return nil
+	})
+	cmd.SetArgs([]string{
+		"some-arg-1",
+		"some-arg-2",
+	})
+	testutil.AssertNil(t, "err", cmd.Execute())
+}
+
+func TestManifest(t *testing.T) {
+	t.Parallel()
+	var m ManifestTestCommand
+	testutil.AssertNil(t, "err", yaml.Unmarshal([]byte(`
+flagInt64: 99
+flagInt: 100
+flagFloat64: 101.0
+flagString: one hundred and two
+flagBool: true
+`), &m))
+
+	testutil.AssertEqual(t, "flagInt64", int64(99), m.FlagInt64)
+	testutil.AssertEqual(t, "flagInt", 100, m.FlagInt)
+	testutil.AssertEqual(t, "flagFloat64", 101.0, m.FlagFloat64)
+	testutil.AssertEqual(t, "flagString", "one hundred and two", m.FlagString)
+	testutil.AssertEqual(t, "flagBool", true, m.FlagBool)
+}
+
+func ExampleMarkdown() {
+	data, err := ioutil.ReadFile("gendocs/markdown.md")
+	fmt.Println("error is:", err)
+	fmt.Println(string(data))
+
+	// Output: error is: <nil>
+	//
+	// ---
+	// title: "test-command"
+	// linkTitle: "test-command"
+	// weight: 10
+	// ---
+	//
+	// ### Usage
+	// kf test-command ARG_NONOPTIONAL OTHER_ARG_NONOPTIONAL [ARG_OPTIONAL]
+	//
+	// ### Description
+	// some-long
+	//
+	// ### Aliases
+	//
+	// * some-alias
+	//
+	// ### Examples
+	//
+	//     first-example
+	//
+	//     second-example
+	//
+	// ### Positional Arguments
+	//
+	// ##### arg_nonoptional
+	// arg_nonoptional desc (REQUIRED)
+	//
+	// ##### other_arg_nonoptional
+	// other_arg_nonoptional desc (REQUIRED)
+	//
+	// ##### arg_optional
+	// arg_optional desc (OPTIONAL)
+	//
+	// ### Flags
+	//
+	// ##### -a, --flag-int64 <_int64_>
+	// some int64 thing (default=99)
+	//
+	// ##### -b, --flag-int <_int_>
+	// some int thing (default=100)
+	//
+	// ##### -c, --flag-float64 <_float64_>
+	// some float64 thing (default=101.0)
+	//
+	// ##### -d, --flag-string <_string_>
+	// some string thing (default="one hundred and two")
+	//
+	// ##### -e, --flag-bool <_bool_>
+	// some bool thing (default=true)
+}

--- a/pkg/kf/internal/tools/command-generator/gentest/gendocs/markdown.md
+++ b/pkg/kf/internal/tools/command-generator/gentest/gendocs/markdown.md
@@ -1,0 +1,53 @@
+
+---
+title: "test-command"
+linkTitle: "test-command"
+weight: 10
+---
+
+### Usage
+kf test-command ARG_NONOPTIONAL OTHER_ARG_NONOPTIONAL [ARG_OPTIONAL]
+
+### Description
+some-long
+
+### Aliases
+
+* some-alias
+
+### Examples
+
+    first-example
+
+    second-example
+
+### Positional Arguments
+
+##### arg_nonoptional
+arg_nonoptional desc (REQUIRED)
+
+##### other_arg_nonoptional
+other_arg_nonoptional desc (REQUIRED)
+
+##### arg_optional
+arg_optional desc (OPTIONAL)
+
+### Flags
+
+##### -a, --flag-int64 <_int64_>
+some int64 thing (default=99)
+
+##### -b, --flag-int <_int_>
+some int thing (default=100)
+
+##### -c, --flag-float64 <_float64_>
+some float64 thing (default=101.0)
+
+##### -d, --flag-string <_string_>
+some string thing (default="one hundred and two")
+
+##### -e, --flag-bool <_bool_>
+some bool thing (default=true)
+
+
+

--- a/pkg/kf/internal/tools/command-generator/gentest/generate-test-output.sh
+++ b/pkg/kf/internal/tools/command-generator/gentest/generate-test-output.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Change to the scripts directory
+cd "${0%/*}"
+
+# Remove the directory so we can ensure the tool will create directories
+rm -rf ./gendocs
+
+go run ../command-generator.go commands.yaml zz_generated.commands.go

--- a/pkg/kf/internal/tools/command-generator/gentest/zz_generated.commands.go
+++ b/pkg/kf/internal/tools/command-generator/gentest/zz_generated.commands.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file was generated with command-generator.go, DO NOT EDIT IT.
+
+package gentest
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type testCommand struct {
+	// flagInt64 stores the value for "--flag-int64"
+	flagInt64 int64
+	// flagInt64IsSet is set to true if the user sets the flag
+	flagInt64IsSet bool
+	// flagInt stores the value for "--flag-int"
+	flagInt int
+	// flagIntIsSet is set to true if the user sets the flag
+	flagIntIsSet bool
+	// flagFloat64 stores the value for "--flag-float64"
+	flagFloat64 float64
+	// flagFloat64IsSet is set to true if the user sets the flag
+	flagFloat64IsSet bool
+	// flagString stores the value for "--flag-string"
+	flagString string
+	// flagStringIsSet is set to true if the user sets the flag
+	flagStringIsSet bool
+	// flagBool stores the value for "--flag-bool"
+	flagBool bool
+	// flagBoolIsSet is set to true if the user sets the flag
+	flagBoolIsSet bool
+}
+
+// FlagInt64 returns the value for "--flag-int64" and if the user set it.
+func (f *testCommand) FlagInt64() (int64, bool) {
+	return f.flagInt64, f.flagInt64IsSet
+}
+
+// FlagInt returns the value for "--flag-int" and if the user set it.
+func (f *testCommand) FlagInt() (int, bool) {
+	return f.flagInt, f.flagIntIsSet
+}
+
+// FlagFloat64 returns the value for "--flag-float64" and if the user set it.
+func (f *testCommand) FlagFloat64() (float64, bool) {
+	return f.flagFloat64, f.flagFloat64IsSet
+}
+
+// FlagString returns the value for "--flag-string" and if the user set it.
+func (f *testCommand) FlagString() (string, bool) {
+	return f.flagString, f.flagStringIsSet
+}
+
+// FlagBool returns the value for "--flag-bool" and if the user set it.
+func (f *testCommand) FlagBool() (bool, bool) {
+	return f.flagBool, f.flagBoolIsSet
+}
+
+func newTestCommand(run func(x testCommand, cmd *cobra.Command, args []string) error) *cobra.Command {
+	x := testCommand{}
+	cmd := &cobra.Command{
+		Use:     "test-command ARG_NONOPTIONAL OTHER_ARG_NONOPTIONAL [ARG_OPTIONAL]",
+		Short:   "some-short",
+		Long:    "some-long",
+		Example: "  first-example\n  second-example",
+		Aliases: []string{"some-alias"},
+		Args:    cobra.RangeArgs(2, 3),
+	}
+	cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		// FlagInt64 returns the value for "--flag-int64" and if the user set it.
+
+		x.flagInt64IsSet = cmd.Flags().Changed("flag-int64")
+		// FlagInt returns the value for "--flag-int" and if the user set it.
+
+		x.flagIntIsSet = cmd.Flags().Changed("flag-int")
+		// FlagFloat64 returns the value for "--flag-float64" and if the user set it.
+
+		x.flagFloat64IsSet = cmd.Flags().Changed("flag-float64")
+		// FlagString returns the value for "--flag-string" and if the user set it.
+
+		x.flagStringIsSet = cmd.Flags().Changed("flag-string")
+		// FlagBool returns the value for "--flag-bool" and if the user set it.
+
+		x.flagBoolIsSet = cmd.Flags().Changed("flag-bool")
+
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return run(x, cmd, args)
+	}
+
+	// FlagInt64 returns the value for "--flag-int64" and if the user set it.
+	cmd.Flags().Int64VarP(
+		&x.flagInt64,
+		"flag-int64",
+		"a",
+		99,
+		"some int64 thing",
+	)
+	// FlagInt returns the value for "--flag-int" and if the user set it.
+	cmd.Flags().IntVarP(
+		&x.flagInt,
+		"flag-int",
+		"b",
+		100,
+		"some int thing",
+	)
+	// FlagFloat64 returns the value for "--flag-float64" and if the user set it.
+	cmd.Flags().Float64VarP(
+		&x.flagFloat64,
+		"flag-float64",
+		"c",
+		101.0,
+		"some float64 thing",
+	)
+	// FlagString returns the value for "--flag-string" and if the user set it.
+	cmd.Flags().StringVarP(
+		&x.flagString,
+		"flag-string",
+		"d",
+		"one hundred and two",
+		"some string thing",
+	)
+	// FlagBool returns the value for "--flag-bool" and if the user set it.
+	cmd.Flags().BoolVarP(
+		&x.flagBool,
+		"flag-bool",
+		"e",
+		true,
+		"some bool thing",
+	)
+
+	return cmd
+}
+
+type ManifestTestCommand struct {
+	// flagInt64 stores the value for "FlagInt64"
+	FlagInt64 int64 `yaml:"flagInt64"`
+	// flagInt stores the value for "FlagInt"
+	FlagInt int `yaml:"flagInt"`
+	// flagFloat64 stores the value for "FlagFloat64"
+	FlagFloat64 float64 `yaml:"flagFloat64"`
+	// flagString stores the value for "FlagString"
+	FlagString string `yaml:"flagString"`
+	// flagBool stores the value for "FlagBool"
+	FlagBool bool `yaml:"flagBool"`
+}

--- a/pkg/kf/internal/tools/generator/gen.go
+++ b/pkg/kf/internal/tools/generator/gen.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 	"text/template"
 	"time"
 )
@@ -86,4 +87,20 @@ func TemplateFuncs() template.FuncMap {
 		"genimports": GenImports,
 		"gennotice":  GenNotice,
 	}
+}
+
+// ExportedName returns a type/func name that will be exported.
+func ExportedName(name string) string {
+	if len(name) == 0 {
+		return ""
+	}
+	return strings.ToUpper(string(name[0])) + name[1:]
+}
+
+// UnexportedName returns a type/func name that will not be exported.
+func UnexportedName(name string) string {
+	if len(name) == 0 {
+		return ""
+	}
+	return strings.ToLower(string(name[0])) + name[1:]
 }

--- a/pkg/kf/internal/tools/generator/gen_test.go
+++ b/pkg/kf/internal/tools/generator/gen_test.go
@@ -59,3 +59,23 @@ func ExampleGenLicense() {
 	// Output: license contains year? true
 	// license contains apache text? true
 }
+
+func ExampleExportedName() {
+	fmt.Println("Starts with upper:", ExportedName("SomeType"))
+	fmt.Println("Starts with lower:", ExportedName("someType"))
+	fmt.Println("Empty:", ExportedName(""))
+
+	// Output: Starts with upper: SomeType
+	// Starts with lower: SomeType
+	// Empty:
+}
+
+func ExampleUnexportedName() {
+	fmt.Println("Starts with upper:", UnexportedName("SomeType"))
+	fmt.Println("Starts with lower:", UnexportedName("someType"))
+	fmt.Println("Empty:", UnexportedName(""))
+
+	// Output: Starts with upper: someType
+	// Starts with lower: someType
+	// Empty:
+}

--- a/pkg/kf/internal/tools/option-builder/option-builder.go
+++ b/pkg/kf/internal/tools/option-builder/option-builder.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"text/template"
 
 	"github.com/google/kf/pkg/kf/internal/tools/generator"
@@ -100,7 +99,7 @@ func main() {
 		})
 
 		// Don't export the config name.
-		cfg.ConfigName = strings.ToLower(string(cfg.Name[0])) + cfg.Name[1:]
+		cfg.ConfigName = generator.UnexportedName(cfg.Name)
 
 		configs = append(configs, cfg)
 	}


### PR DESCRIPTION
command-generator generates `cobra.Command`s, and markdown from YAML.
This helps standardize the commands along with generating docs for the
commands.

This CL only implements the `version`, `target`, and `debug` commands.

fixes #337

## Proposed Changes

* Add generator for commands and markdown
* 
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added generated docs for `debug`, `target` and `version` commands.
```
