### PR TITLE
Supports KUBECONFIG when initKubeConfig

### DIFF
--- a/pkg/kf/commands/config/config_test.go
+++ b/pkg/kf/commands/config/config_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -84,6 +85,40 @@ func ExampleWrite() {
 	}
 
 	// Output: Read namespace: my-namespace
+}
+
+func TestNewDefaultKfParams(t *testing.T) {
+	cases := map[string]struct {
+		configPathEnv string
+		expected      KfParams
+	}{
+		"KUBECONFIG set": {
+			configPathEnv: "kube-config.yml",
+			expected: KfParams{
+				KubeCfgFile: "kube-config.yml",
+			},
+		},
+		"KUBECONFIG not set": {
+			configPathEnv: "",
+			expected: KfParams{
+				KubeCfgFile: filepath.Join(homedir.HomeDir(), ".kube", "config"),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			if len(tc.configPathEnv) != 0 {
+				os.Setenv("KUBECONFIG", tc.configPathEnv)
+			} else {
+				os.Unsetenv("KUBECONFIG")
+			}
+			defaultConfig := NewDefaultKfParams()
+
+			testutil.AssertEqual(t, "config", &tc.expected, defaultConfig)
+		})
+	}
+
 }
 
 func TestLoad(t *testing.T) {


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #461

## Proposed Changes

* Supported `KUBECONFIG` env var as default kubeconfig


## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added `KUBECONFIG` env var as default kubeconfig
```
