### PR TITLE
do not base64 decode vcap services

### DIFF
--- a/pkg/kf/commands/service-bindings/vcap_services.go
+++ b/pkg/kf/commands/service-bindings/vcap_services.go
@@ -15,7 +15,6 @@
 package servicebindings
 
 import (
-	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -58,12 +57,7 @@ func NewVcapServicesCommand(
 				return errors.New("VCAP_SERVICES does not exist")
 			}
 
-			decoded, err := base64.StdEncoding.DecodeString(string(vcapServices))
-			if err != nil {
-				return err
-			}
-
-			fmt.Fprintln(cmd.OutOrStdout(), string(decoded))
+			fmt.Fprintln(cmd.OutOrStdout(), string(vcapServices))
 			return nil
 		},
 	}

--- a/pkg/kf/commands/service-bindings/vcap_services_test.go
+++ b/pkg/kf/commands/service-bindings/vcap_services_test.go
@@ -16,7 +16,9 @@ package servicebindings_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/kf/pkg/kf/commands/config"
@@ -24,7 +26,6 @@ import (
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/testutil"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 )
 
@@ -37,17 +38,29 @@ func TestNewVcapServicesCommand(t *testing.T) {
 		ExpectedStrings []string
 	}
 
-	data := []byte(`{"some":"services"}`)
+	secretSerialized := `{
+    "apiVersion": "v1",
+    "data": {
+        "VCAP_SERVICES": "eyJzb21lIjoic2VydmljZXMifQ=="
+    },
+    "kind": "Secret",
+    "metadata": {
+        "labels": {
+            "app.kubernetes.io/component": "secret",
+            "app.kubernetes.io/managed-by": "kf",
+            "app.kubernetes.io/name": "APP_NAME"
+        },
+        "name": "kf-injected-envs-APP_NAME",
+        "namespace": "custom-ns"
+    },
+    "type": "Opaque"
+}
+	`
 
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kf-injected-envs-APP_NAME",
-			Namespace: "custom-ns",
-		},
-		Data: map[string][]byte{
-			"VCAP_SERVICES": []byte(data),
-		},
-	}
+	var secret *corev1.Secret
+	err := json.Unmarshal([]byte(secretSerialized), &secret)
+	fmt.Println(secret.Name)
+	testutil.AssertNil(t, "err", err)
 	k8sclient := k8sfake.NewSimpleClientset(secret)
 
 	cases := map[string]serviceTest{

--- a/pkg/kf/commands/service-bindings/vcap_services_test.go
+++ b/pkg/kf/commands/service-bindings/vcap_services_test.go
@@ -16,7 +16,6 @@ package servicebindings_test
 
 import (
 	"bytes"
-	"encoding/base64"
 	"errors"
 	"testing"
 
@@ -39,7 +38,6 @@ func TestNewVcapServicesCommand(t *testing.T) {
 	}
 
 	data := []byte(`{"some":"services"}`)
-	encodedData := base64.StdEncoding.EncodeToString(data)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -47,7 +45,7 @@ func TestNewVcapServicesCommand(t *testing.T) {
 			Namespace: "custom-ns",
 		},
 		Data: map[string][]byte{
-			"VCAP_SERVICES": []byte(encodedData),
+			"VCAP_SERVICES": []byte(data),
 		},
 	}
 	k8sclient := k8sfake.NewSimpleClientset(secret)


### PR DESCRIPTION
<!-- Include the issue number below -->

## Proposed Changes

*
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed vcap-service double decoding secrets
```
