### PR TITLE
pkg/reconciler/route: recreate deleted VirtualServices

### DIFF
--- a/pkg/reconciler/app/resources/route.go
+++ b/pkg/reconciler/app/resources/route.go
@@ -70,6 +70,15 @@ func mustRequirement(key string, op selection.Operator, val string) labels.Requi
 }
 
 // MakeRouteSelector creates a labels.Selector for listing all the
+// corresponding Routes excluding Path.
+func MakeRouteSelectorNoPath(spec v1alpha1.RouteSpecFields) labels.Selector {
+	return labels.NewSelector().Add(
+		mustRequirement(v1alpha1.RouteHostname, selection.Equals, spec.Hostname),
+		mustRequirement(v1alpha1.RouteDomain, selection.Equals, spec.Domain),
+	)
+}
+
+// MakeRouteSelector creates a labels.Selector for listing all the
 // corresponding Routes.
 func MakeRouteSelector(spec v1alpha1.RouteSpecFields) labels.Selector {
 	return labels.NewSelector().Add(

--- a/pkg/reconciler/base.go
+++ b/pkg/reconciler/base.go
@@ -60,7 +60,9 @@ type Base struct {
 	// the expense of slightly greater verbosity.
 	Logger *zap.SugaredLogger
 
-	namespaceLister v1listers.NamespaceLister
+	// NamespaceLister allows us to list Namespaces. We use this to check for
+	// terminating namespaces.
+	NamespaceLister v1listers.NamespaceLister
 }
 
 // NewBase instantiates a new instance of Base implementing
@@ -81,7 +83,7 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 		ConfigMapWatcher: cmw,
 		Logger:           logger,
 
-		namespaceLister: nsInformer.Lister(),
+		NamespaceLister: nsInformer.Lister(),
 	}
 
 	return base
@@ -90,7 +92,7 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 // IsNamespaceTerminating returns true if the namespace is marked as terminating
 // and false if the state is unknown or not terminating.
 func (base *Base) IsNamespaceTerminating(namespace string) bool {
-	ns, err := base.namespaceLister.Get(namespace)
+	ns, err := base.NamespaceLister.Get(namespace)
 	if err != nil || ns == nil {
 		return false
 	}

--- a/pkg/reconciler/route/reconciler.go
+++ b/pkg/reconciler/route/reconciler.go
@@ -67,19 +67,19 @@ func (r *Reconciler) reconcileRoute(
 	name string,
 	logger *zap.SugaredLogger,
 ) (err error) {
-	var deleted bool
 	original, err := r.routeLister.
 		Routes(namespace).
 		Get(name)
 	switch {
 	case apierrs.IsNotFound(err):
 		logger.Errorf("Route %q no longer exists\n", name)
-		deleted = true
+		return nil
 
 	case err != nil:
 		return err
 
 	case original.GetDeletionTimestamp() != nil:
+		logger.Errorf("Route %q is being deleted\n", name)
 		return nil
 	}
 
@@ -92,7 +92,7 @@ func (r *Reconciler) reconcileRoute(
 	toReconcile := original.DeepCopy()
 
 	// Reconcile this copy of the route.
-	return r.ApplyChanges(ctx, toReconcile, deleted, logger)
+	return r.ApplyChanges(ctx, toReconcile, logger)
 }
 
 // ApplyChanges updates the linked resources in the cluster with the current
@@ -100,7 +100,6 @@ func (r *Reconciler) reconcileRoute(
 func (r *Reconciler) ApplyChanges(
 	ctx context.Context,
 	origRoute *v1alpha1.Route,
-	deleted bool,
 	logger *zap.SugaredLogger,
 ) error {
 	origRoute.SetDefaults(ctx)
@@ -134,10 +133,11 @@ func (r *Reconciler) ApplyChanges(
 			}
 		} else if err != nil {
 			return err
+		} else if actual.GetDeletionTimestamp() != nil {
+
 		} else if actual, err = r.reconcile(
 			desired,
 			actual,
-			deleted,
 			logger,
 		); err != nil {
 			return err
@@ -147,7 +147,11 @@ func (r *Reconciler) ApplyChanges(
 	return nil
 }
 
-func (r *Reconciler) reconcile(desired, actual *networking.VirtualService, deleted bool, logger *zap.SugaredLogger) (*networking.VirtualService, error) {
+func (r *Reconciler) reconcile(
+	desired *networking.VirtualService,
+	actual *networking.VirtualService,
+	logger *zap.SugaredLogger,
+) (*networking.VirtualService, error) {
 	// Check for differences, if none we don't need to reconcile.
 	semanticEqual := equality.Semantic.DeepEqual(desired.ObjectMeta.Labels, actual.ObjectMeta.Labels)
 	semanticEqual = semanticEqual && equality.Semantic.DeepEqual(desired.Spec, actual.Spec)
@@ -167,30 +171,19 @@ func (r *Reconciler) reconcile(desired, actual *networking.VirtualService, delet
 	existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
 	existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
 
-	if deleted {
-		existing.OwnerReferences = algorithms.Delete(
-			v1alpha1.OwnerReferences(existing.OwnerReferences),
-			v1alpha1.OwnerReferences(desired.OwnerReferences),
-		).(v1alpha1.OwnerReferences)
+	// Merge new OwnerReferences and HTTPRoutes
+	existing.OwnerReferences = algorithms.Merge(
+		v1alpha1.OwnerReferences(existing.OwnerReferences),
+		v1alpha1.OwnerReferences(desired.OwnerReferences),
+	).(v1alpha1.OwnerReferences)
 
-		existing.Spec.HTTP = algorithms.Delete(
-			v1alpha1.HTTPRoutes(existing.Spec.HTTP),
-			v1alpha1.HTTPRoutes(desired.Spec.HTTP),
-		).(v1alpha1.HTTPRoutes)
-	} else {
-		existing.OwnerReferences = algorithms.Merge(
-			v1alpha1.OwnerReferences(existing.OwnerReferences),
-			v1alpha1.OwnerReferences(desired.OwnerReferences),
-		).(v1alpha1.OwnerReferences)
+	existing.Spec.HTTP = algorithms.Merge(
+		v1alpha1.HTTPRoutes(existing.Spec.HTTP),
+		v1alpha1.HTTPRoutes(desired.Spec.HTTP),
+	).(v1alpha1.HTTPRoutes)
 
-		existing.Spec.HTTP = algorithms.Merge(
-			v1alpha1.HTTPRoutes(existing.Spec.HTTP),
-			v1alpha1.HTTPRoutes(desired.Spec.HTTP),
-		).(v1alpha1.HTTPRoutes)
-
-		// Sort by reverse to defer to the longest matchers.
-		sort.Sort(sort.Reverse(v1alpha1.HTTPRoutes(existing.Spec.HTTP)))
-	}
+	// Sort by reverse to defer to the longest matchers.
+	sort.Sort(sort.Reverse(v1alpha1.HTTPRoutes(existing.Spec.HTTP)))
 
 	return r.SharedClientSet.
 		Networking().

--- a/pkg/reconciler/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/route/resources/virtual_service_test.go
@@ -18,11 +18,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sort"
 	"testing"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
-	"github.com/google/kf/pkg/kf/algorithms"
 	"github.com/google/kf/pkg/kf/testutil"
 	"github.com/google/kf/pkg/reconciler/route/resources"
 	"github.com/knative/serving/pkg/network"
@@ -242,7 +240,15 @@ func TestMakeVirtualService(t *testing.T) {
 }
 
 func ExampleMakeVirtualService() {
-	vs1, err := resources.MakeVirtualService([]*v1alpha1.Route{
+	vs, err := resources.MakeVirtualService([]*v1alpha1.Route{
+		{
+			Spec: v1alpha1.RouteSpec{
+				RouteSpecFields: v1alpha1.RouteSpecFields{
+					Hostname: "some-host",
+					Domain:   "example.com/",
+				},
+			},
+		},
 		{
 			Spec: v1alpha1.RouteSpec{
 				RouteSpecFields: v1alpha1.RouteSpecFields{
@@ -252,12 +258,6 @@ func ExampleMakeVirtualService() {
 				},
 			},
 		},
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	vs2, err := resources.MakeVirtualService([]*v1alpha1.Route{
 		{
 			Spec: v1alpha1.RouteSpec{
 				RouteSpecFields: v1alpha1.RouteSpecFields{
@@ -272,18 +272,11 @@ func ExampleMakeVirtualService() {
 		panic(err)
 	}
 
-	r := algorithms.Merge(
-		v1alpha1.HTTPRoutes(vs1.Spec.HTTP),
-		v1alpha1.HTTPRoutes(vs2.Spec.HTTP),
-	).(v1alpha1.HTTPRoutes)
-
-	// Sort for display purposes
-	sort.Sort(r)
-
-	for i, h := range r {
+	for i, h := range vs.Spec.HTTP {
 		fmt.Printf("Regex %d: %s\n", i, h.Match[0].URI.Regex)
 	}
 
-	// Output: Regex 0: ^/some-path-1(/.*)?
-	// Regex 1: ^/some-path-2(/.*)?
+	// Output: Regex 0: ^(/.*)?
+	// Regex 1: ^/some-path-1(/.*)?
+	// Regex 2: ^/some-path-2(/.*)?
 }


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #521
Fixes #535 

## Proposed Changes

* Watch for VirtualService changes per namespace (instead of by controller)
* Don't manage the OwnerReferences for VirtualServices (let K8s do it) (#521)
* Ensure regexp path matcher doesn't have extra `/` (#535)

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fix how VirtualServices are watched in route controller
Fix how VirtualService OwnerReferences are managed
Fix how regexp path matchers are created
```
