### PR TITLE
pkg/reconciler/app: handle when app is stopped

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle.go
@@ -113,6 +113,11 @@ func (status *AppStatus) PropagateSourceStatus(source *Source) {
 // PropagateKnativeServiceStatus updates the Knative service status to reflect
 // the underlying service.
 func (status *AppStatus) PropagateKnativeServiceStatus(service *serving.Service) {
+	// Stopped apps don't have a Knative service
+	if service == nil {
+		return
+	}
+
 	cond := service.Status.GetCondition(apis.ConditionReady)
 
 	if PropagateCondition(status.manage(), AppConditionKnativeServiceReady, cond) {

--- a/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
@@ -336,6 +336,21 @@ func TestAppStatus_lifecycle(t *testing.T) {
 				AppConditionKnativeServiceReady,
 			},
 		},
+		"stopped app": {
+			Init: func(status *AppStatus) {
+				status.MarkSpaceHealthy()
+				status.PropagateSourceStatus(happySource())
+				status.PropagateEnvVarSecretStatus(envVarSecret())
+				// Nil Knative service because a stopped app doesn't have a
+				// Knative service.
+				status.PropagateKnativeServiceStatus(nil)
+			},
+			ExpectSucceeded: []apis.ConditionType{
+				AppConditionSpaceReady,
+				AppConditionSourceReady,
+				AppConditionEnvVarSecretReady,
+			},
+		},
 		"space unhealthy": {
 			Init: func(status *AppStatus) {
 				status.MarkSpaceUnhealthy("Terminating", "Namespace is terminating")


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #544

## Proposed Changes

* App reconciler doesn't an error if the app is stopped
* Mark app status as Unknown when app is stopped
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed bug where stopped apps cause app reconciler to return error (#544)
```
