### PR TITLE
docs: Document "Customizing Buildpacks"

### DIFF
--- a/docs/kf.dev/content/en/docs/operators/customizing-buildpacks/_index.md
+++ b/docs/kf.dev/content/en/docs/operators/customizing-buildpacks/_index.md
@@ -1,0 +1,201 @@
+---
+title: "Customizing Buildpacks"
+linkTitle: "Customizing Buildpacks"
+weight: 20 
+description: >
+  Learn how to customize the buildpacks that are available to your developers.
+---
+
+[cnb]: https://buildpacks.io
+[api]: https://github.com/buildpack/spec
+[Cloud Native Buildpacks][cnb] are used by Kf to turn an application's source code into a runnable image. Cloud Native Buildpacks use the latest [Buildpack API v3][api] and companies including Pivotal and Heroku are actively adding v3 support to existing buildpacks.
+
+## Kf and Buildpacks
+[builders]: https://buildpacks.io/docs/using-pack/working-with-builders/
+Kf uses [builders][builders] to bundle individual buildpacks into a single
+image. Each Kf space has an associated builder image. You can view the builder image for a
+space with the `kf space` command. For a space named "buildpack-docs" you would
+run:
+
+```sh
+$ kf space buildpack-docs
+
+Metadata:
+  Name:                buildpack-docs
+  Creation Timestamp:  2019-08-20 10:00:07 -0700 PDT
+  Age:                 170m
+  Generation:          1
+  UID:                 f6361a3c-c36b-11e9-b037-42010a8e00de
+  Labels:
+    app.kubernetes.io/managed-by=kf
+
+Status:
+  Ready:
+    Ready:  True
+    Time:   2019-08-20 10:00:07 -0700 PDT
+  Conditions:
+    Type                Status  Updated  Message  Reason
+    AuditorRoleReady    True    170m
+    DeveloperRoleReady  True    170m
+    LimitRangeReady     True    170m
+    NamespaceReady      True    170m
+    ResourceQuotaReady  True    170m
+
+Security:
+  Developers can read logs?  true
+
+Build:
+  Builder Image:       "gcr.io/kf-releases/buildpack-builder:latest"
+  Container Registry:  "gcr.io/kf-install-instructions"
+  Environment: <empty>
+
+Execution:
+  Environment: <empty>
+  Domains:
+    Name          Default?
+    evanbrown.io  true
+```
+
+Under the `Build` section, the `Builder Image` property is the name of the builder image that contains the buildpacks that will be available in the space. You can list those buildpacks with `kf buildpacks`:
+
+```sh
+$ kf buildpacks
+
+Getting buildpacks in space: buildpack-docs
+NAME                               POSITION VERSION              LATEST
+org.cloudfoundry.archiveexpanding  0        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.openjdk           1        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.buildsystem       2        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.jvmapplication    3        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.springboot        4        1.0.0-RC01           true
+org.cloudfoundry.tomcat            5        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.procfile          6        1.0.0-BUILD-SNAPSHOT true
+org.cloudfoundry.googlestackdriver 7        1.0.0-BUILD-SNAPSHOT true
+io.buildpacks.samples.nodejs       8        0.0.1                true
+io.buildpacks.samples.go           9        0.0.1                true
+```
+
+## Customizing Buildpacks
+You can customize the buildpacks that are available to your developers by creating your own builder image with exactly the buildpacks they should have access to. You can also use builder images published by other authors.
+
+### Use a third-party builder image
+[pack]: https://buildpacks.io/docs/install-pack/
+A list of published builder images is available from the [Buildpack CLI `pack`][pack]. As of this writing, `pack suggest-builders` outputs:
+
+```sh
+$ pack suggest-builders
+
+Suggested builders:
+
+        Heroku:            heroku/buildpacks               heroku-18 base image with official Heroku buildpacks        
+        Cloud Foundry:     cloudfoundry/cnb:bionic         Bionic base image; run `pack inspect-builder <builder>` to see the supported buildpacks
+        Cloud Foundry:     cloudfoundry/cnb:cflinuxfs3     Cflinuxfs3 base image; run `pack inspect-builder <builder>` to see the supported buildpacks
+
+Tip: Learn more about a specific builder with:
+
+        pack inspect-builder [builder image]
+```
+
+We can inspect the Heroku builder to see the buildpacks included in its image:
+
+```sh
+$ pack inspect-builder heroku/buildpacks
+
+Inspecting builder: heroku/buildpacks
+
+Remote
+------
+
+Stack: heroku-18
+
+Lifecycle Version: 0.2.1
+
+Run Images:
+  heroku/pack:18
+
+Buildpacks:
+  ID                     VERSION           LATEST
+  heroku/java            0.13              true
+  heroku/ruby            0.0.1             true
+  heroku/procfile        0.2               true
+  heroku/python          v0.0.5.0.1        true
+  heroku/gradle          v0.0.5.0.1        true
+  heroku/php             v0.0.5.0.1        true
+  heroku/go              v0.0.5.0.1        true
+  heroku/nodejs          v0.0.5.0.1        true
+
+Detection Order:
+  Group #1:
+    heroku/ruby@latest
+    heroku/procfile@latest    (optional)
+  Group #2:
+    heroku/python@latest
+    heroku/procfile@latest    (optional)
+  Group #3:
+    heroku/java@latest
+  Group #4:
+    heroku/gradle@latest
+  Group #5:
+    heroku/php@latest
+    heroku/procfile@latest    (optional)
+  Group #6:
+    heroku/go@latest
+    heroku/procfile@latest    (optional)
+  Group #7:
+    heroku/nodejs@latest
+
+Local
+-----
+
+Not present
+```
+
+To modify an existing Kf space named "buildpack-docs" to use the builder image published by Heroku, use the `kf config-space` command:
+
+```sh
+$ kf config-space set-buildpack-builder buildpack-docs heroku/buildpacks
+
+Space Diff (-old +new):
+  &v1alpha1.Space{
+        TypeMeta:   v1.TypeMeta{},
+        ObjectMeta: v1.ObjectMeta{Name: "buildpack-docs", SelfLink: "/apis/kf.dev/v1alpha1/spaces/buildpack-docs", UID: "f6361a3c-c36b-11e9-b037-42010a8e00de", ResourceVersion: "969896", Generation: 1, CreationTimestamp: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}, Labels: map[string]string{"app.kubernetes.io/managed-by": "kf"}},
+        Spec: v1alpha1.SpaceSpec{
+                Security: v1alpha1.SpaceSpecSecurity{EnableDeveloperLogsAccess: true},
+                BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
+-                       BuilderImage:      "gcr.io/kf-releases/buildpack-builder:latest",
++                       BuilderImage:      "heroku/buildpacks",
+                        ContainerRegistry: "gcr.io/kf-install-instructions",
+                        Env:               nil,
+                },
+                Execution:      v1alpha1.SpaceSpecExecution{Domains: []v1alpha1.SpaceDomain{{Domain: "evanbrown.io", Default: true}}},
+                ResourceLimits: v1alpha1.SpaceSpecResourceLimits{},
+        },
+        Status: v1alpha1.SpaceStatus{Status: v1beta1.Status{Conditions: v1beta1.Conditions{{Type: "AuditorRoleReady", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}, {Type: "DeveloperRoleReady", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}, {Type: "LimitRangeReady", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}, {Type: "NamespaceReady", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}, {Type: "Ready", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}, {Type: "ResourceQuotaReady", Status: "True", LastTransitionTime: apis.VolatileTime{Inner: v1.Time{Time: s"2019-08-20 10:00:07 -0700 PDT"}}}}}},
+  }
+```
+
+This will output a "Space diff", highlighting what changed in the space. You can view the buildpacks made available to your space by the `heroku/buildpacks` image by running `kf buildpacks`:
+
+```sh
+$ kf buildpacks
+
+ng buildpacks in space: buildpack-docs
+NAME            POSITION VERSION    LATEST
+heroku/java     0        0.13       true
+heroku/ruby     1        0.0.1      true
+heroku/procfile 2        0.2        true
+heroku/python   3        v0.0.5.0.1 true
+heroku/gradle   4        v0.0.5.0.1 true
+heroku/php      5        v0.0.5.0.1 true
+heroku/go       6        v0.0.5.0.1 true
+heroku/nodejs   7        v0.0.5.0.1 true
+```
+
+### Create your own builder image
+[create-builder]: https://buildpacks.io/docs/using-pack/working-with-builders/
+The [Buildpack CLI `pack`][pack] is used to create your own builder image. You can follow `pack`'s [Working with builders using `create-builder`][create-builder] documentation to create your own builder image. Once created, push it to a container registry and use the `kf config-space` command to configure your Kf space to use the new builder image:
+
+```sh
+kf config-space set-buildpack-builder your-space gcr.io/your-project/your-builder
+```
+


### PR DESCRIPTION
This change adds the "Customizing Buildpacks" guide to the operators
section of the docs website.