### PR TITLE
pkg/kf/commands/service-bindings: tip user to restart app

### DIFF
--- a/pkg/kf/commands/service-bindings/bind-service.go
+++ b/pkg/kf/commands/service-bindings/bind-service.go
@@ -15,6 +15,8 @@
 package servicebindings
 
 import (
+	"fmt"
+
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	servicebindings "github.com/google/kf/pkg/kf/service-bindings"
@@ -62,6 +64,8 @@ func NewBindServiceCommand(p *config.KfParams, client servicebindings.ClientInte
 			if err != nil {
 				return err
 			}
+
+			fmt.Fprintf(cmd.OutOrStderr(), "Use 'kf restart %s' to ensure your changes take effect\n", appName)
 
 			return nil
 		},


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #569

## Proposed Changes

* Display tip to user to restart the app after binding a service
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added tip to bind-service command
```
