### PR TITLE
Fix reconciler logs

### DIFF
--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -38,7 +38,7 @@ import (
 
 // NewController creates a new controller capable of reconciling Kf Routes.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := logging.FromContext(ctx)
+	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "apps.kf.dev")
 
 	// Get informers off context
 	knativeServiceInformer := kserviceinformer.Get(ctx)
@@ -56,7 +56,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                  reconciler.NewBase(ctx, "app-controller", cmw),
+		Base:                  reconciler.NewBase(ctx, "app-controller", cmw, logger),
 		serviceCatalogClient:  serviceCatalogClient,
 		knativeServiceLister:  knativeServiceInformer.Lister(),
 		knativeRevisionLister: knativeRevisionInformer.Lister(),

--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -33,12 +33,11 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	secretinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/secret"
-	"knative.dev/pkg/logging"
 )
 
 // NewController creates a new controller capable of reconciling Kf Routes.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "apps.kf.dev")
+	logger := reconciler.NewControllerLogger(ctx, "apps.kf.dev")
 
 	// Get informers off context
 	knativeServiceInformer := kserviceinformer.Get(ctx)
@@ -56,7 +55,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                  reconciler.NewBase(ctx, "app-controller", cmw, logger),
+		Base:                  reconciler.NewBase(ctx, cmw),
 		serviceCatalogClient:  serviceCatalogClient,
 		knativeServiceLister:  knativeServiceInformer.Lister(),
 		knativeRevisionLister: knativeRevisionInformer.Lister(),
@@ -72,7 +71,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	impl := controller.NewImpl(c, logger, "Apps")
 
-	c.Logger.Info("Setting up event handlers")
+	logger.Info("Setting up event handlers")
 
 	// Watch for changes in sub-resources so we can sync accordingly
 	appInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/app/reconciler.go
+++ b/pkg/reconciler/app/reconciler.go
@@ -77,7 +77,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	return r.reconcileApp(ctx, namespace, name)
+	return r.reconcileApp(
+		logging.WithLogger(ctx,
+			logging.FromContext(ctx).With("namespace", namespace)),
+		namespace,
+		name,
+	)
 }
 
 func (r *Reconciler) reconcileApp(ctx context.Context, namespace, name string) (err error) {

--- a/pkg/reconciler/base.go
+++ b/pkg/reconciler/base.go
@@ -32,7 +32,6 @@ import (
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/injection/clients/kubeclient"
 	namespaceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/namespace"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 )
 
@@ -67,11 +66,7 @@ type Base struct {
 
 // NewBase instantiates a new instance of Base implementing
 // the common & boilerplate code between our reconcilers.
-func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watcher) *Base {
-	logger := logging.FromContext(ctx).
-		Named(controllerAgentName).
-		With(zap.String(logkey.ControllerType, controllerAgentName))
-
+func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watcher, logger *zap.SugaredLogger) *Base {
 	kubeClient := kubeclient.Get(ctx)
 	nsInformer := namespaceinformer.Get(ctx)
 
@@ -87,6 +82,12 @@ func NewBase(ctx context.Context, controllerAgentName string, cmw configmap.Watc
 	}
 
 	return base
+}
+
+func NewKfLogger(logger *zap.SugaredLogger, resource string) *zap.SugaredLogger {
+	return logger.
+		Named(resource).
+		With(logkey.ControllerType, resource)
 }
 
 // IsNamespaceTerminating returns true if the namespace is marked as terminating

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -32,7 +32,7 @@ import (
 
 // NewController creates a new controller capable of reconciling Kf Routes.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := logging.FromContext(ctx)
+	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "routes.kf.dev")
 
 	// Get informers off context
 	vsInformer := virtualserviceinformer.Get(ctx)
@@ -40,7 +40,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                 reconciler.NewBase(ctx, "route-controller", cmw),
+		Base:                 reconciler.NewBase(ctx, "route-controller", cmw, logger),
 		routeLister:          routeInformer.Lister(),
 		virtualServiceLister: vsInformer.Lister(),
 	}

--- a/pkg/reconciler/route/reconciler.go
+++ b/pkg/reconciler/route/reconciler.go
@@ -55,7 +55,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		return err
 	}
 
-	return r.reconcileRoute(ctx, namespace, name)
+	return r.reconcileRoute(
+		logging.WithLogger(ctx,
+			logging.FromContext(ctx).With("namespace", namespace)),
+		namespace,
+		name,
+	)
 }
 
 func (r *Reconciler) reconcileRoute(

--- a/pkg/reconciler/source/controller.go
+++ b/pkg/reconciler/source/controller.go
@@ -25,12 +25,11 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	controller "knative.dev/pkg/controller"
-	logging "knative.dev/pkg/logging"
 )
 
 // NewController creates a new controller capable of reconciling Kf sources.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "sources.kf.dev")
+	logger := reconciler.NewControllerLogger(ctx, "sources.kf.dev")
 
 	// Get informers off context
 	sourceInformer := sourceinformer.Get(ctx)
@@ -39,7 +38,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:         reconciler.NewBase(ctx, "source-controller", cmw, logger),
+		Base:         reconciler.NewBase(ctx, cmw),
 		sourceLister: sourceInformer.Lister(),
 		buildLister:  buildInformer.Lister(),
 		buildClient:  buildClient.BuildV1alpha1(),
@@ -47,7 +46,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	impl := controller.NewImpl(c, logger, "sources")
 
-	c.Logger.Info("Setting up event handlers")
+	logger.Info("Setting up event handlers")
 
 	// Watch for changes in sub-resources so we can sync accordingly
 	sourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/source/controller.go
+++ b/pkg/reconciler/source/controller.go
@@ -30,7 +30,7 @@ import (
 
 // NewController creates a new controller capable of reconciling Kf sources.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := logging.FromContext(ctx)
+	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "sources.kf.dev")
 
 	// Get informers off context
 	sourceInformer := sourceinformer.Get(ctx)
@@ -39,7 +39,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:         reconciler.NewBase(ctx, "source-controller", cmw),
+		Base:         reconciler.NewBase(ctx, "source-controller", cmw, logger),
 		sourceLister: sourceInformer.Lister(),
 		buildLister:  buildInformer.Lister(),
 		buildClient:  buildClient.BuildV1alpha1(),

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -31,7 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
-	logging "knative.dev/pkg/logging"
+	"knative.dev/pkg/logging"
 )
 
 // Reconciler reconciles an source object with the K8s cluster.
@@ -50,11 +50,25 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 
 // Reconcile is called by Kubernetes.
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
-	logger := logging.FromContext(ctx)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}
+
+	return r.reconcileSource(
+		logging.WithLogger(ctx,
+			logging.FromContext(ctx).With("namespace", namespace)),
+		namespace,
+		name,
+	)
+}
+
+func (r *Reconciler) reconcileSource(
+	ctx context.Context,
+	namespace string,
+	name string,
+) (err error) {
+	logger := logging.FromContext(ctx)
 
 	original, err := r.sourceLister.Sources(namespace).Get(name)
 	switch {

--- a/pkg/reconciler/space/controller.go
+++ b/pkg/reconciler/space/controller.go
@@ -31,12 +31,11 @@ import (
 
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	"knative.dev/pkg/logging"
 )
 
 // NewController creates a new controller capable of reconciling Kf Spaces.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "spaces.kf.dev")
+	logger := reconciler.NewControllerLogger(ctx, "spaces.kf.dev")
 
 	// Get informers off context
 	nsInformer := namespaceinformer.Get(ctx)
@@ -47,7 +46,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                reconciler.NewBase(ctx, "space-controller", cmw, logger),
+		Base:                reconciler.NewBase(ctx, cmw),
 		spaceLister:         spaceInformer.Lister(),
 		namespaceLister:     nsInformer.Lister(),
 		roleLister:          roleInformer.Lister(),
@@ -57,7 +56,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	impl := controller.NewImpl(c, logger, "Spaces")
 
-	c.Logger.Info("Setting up event handlers")
+	logger.Info("Setting up event handlers")
 	// Watch for changes in sub-resources so we can sync accordingly
 	spaceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 

--- a/pkg/reconciler/space/controller.go
+++ b/pkg/reconciler/space/controller.go
@@ -36,7 +36,7 @@ import (
 
 // NewController creates a new controller capable of reconciling Kf Spaces.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := logging.FromContext(ctx)
+	logger := reconciler.NewKfLogger(logging.FromContext(ctx), "spaces.kf.dev")
 
 	// Get informers off context
 	nsInformer := namespaceinformer.Get(ctx)
@@ -47,7 +47,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                reconciler.NewBase(ctx, "space-controller", cmw),
+		Base:                reconciler.NewBase(ctx, "space-controller", cmw, logger),
 		spaceLister:         spaceInformer.Lister(),
 		namespaceLister:     nsInformer.Lister(),
 		roleLister:          roleInformer.Lister(),


### PR DESCRIPTION
<!-- Include the issue number below -->

## Proposed Changes

* remove logger from reconciler Base
* always get logger form the context
* make some log lines debug instead of info

This PR fixes a few errors in the way we are handling logs on the controller.
For controllers: the context given at creation time is not the same context as the one at run time. So instead of creating a logger ans saving it to the reconciler base, the logger should always be created from the current context. This fixes missing logs, plus it adds the knative traceid to all of our logs. 

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Updated kf controller logs
```
