### PR TITLE
added cluster URL display to app and apps

### DIFF
--- a/pkg/kf/apps/kfapp.go
+++ b/pkg/kf/apps/kfapp.go
@@ -243,6 +243,18 @@ func (k *KfApp) GetServiceBindings() []v1alpha1.AppSpecServiceBinding {
 	return k.Spec.ServiceBindings
 }
 
+// GetClusterURL gets the internal address of the app or the empty string if
+// unset.
+func (k *KfApp) GetClusterURL() string {
+	clusterURL := ""
+
+	if k.Status.Address != nil && k.Status.Address.URL != nil {
+		clusterURL = k.Status.Address.URL.String()
+	}
+
+	return clusterURL
+}
+
 // ToApp casts this alias back into an App.
 func (k *KfApp) ToApp() *v1alpha1.App {
 	app := v1alpha1.App(*k)

--- a/pkg/kf/apps/kfapp_test.go
+++ b/pkg/kf/apps/kfapp_test.go
@@ -25,6 +25,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 )
 
 func ExampleKfApp() {
@@ -226,4 +229,20 @@ func ExampleKfApp_GetCPU() {
 	fmt.Println((*getCPU).String())
 
 	// Output: 100m
+}
+
+func ExampleKfApp_GetClusterURL() {
+	app := NewKfApp()
+	app.Status.Address = &duckv1alpha1.Addressable{
+		Addressable: duckv1beta1.Addressable{
+			URL: &apis.URL{
+				Host:   "app-a.some-namespace.svc.cluster.local",
+				Scheme: "http",
+			},
+		},
+	}
+
+	fmt.Println(app.GetClusterURL())
+
+	// Output: http://app-a.some-namespace.svc.cluster.local
 }

--- a/pkg/kf/commands/apps/app.go
+++ b/pkg/kf/commands/apps/app.go
@@ -68,13 +68,13 @@ func NewGetAppCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command
 				status := app.Status
 
 				fmt.Fprintf(w, "Image:\t%s\n", status.Image)
-				if url := status.URL; url != nil {
-					fmt.Fprintf(w, "Host:\t%s\n", url.Host)
-				}
 
 				kfApp := apps.NewFromApp(app)
+				fmt.Fprintf(w, "Cluster URL\t%s\n", kfApp.GetClusterURL())
+
 				describe.HealthCheck(w, kfApp.GetHealthCheck())
 				describe.EnvVars(w, kfApp.GetEnvVars())
+				describe.RouteSpecFieldsList(w, app.Spec.Routes)
 			})
 			fmt.Fprintln(w)
 

--- a/pkg/kf/commands/apps/apps.go
+++ b/pkg/kf/commands/apps/apps.go
@@ -44,14 +44,14 @@ func NewAppsCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command {
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Getting apps in space %s\n\n", p.Namespace)
 
-			apps, err := appsClient.List(p.Namespace)
+			applist, err := appsClient.List(p.Namespace)
 			if err != nil {
 				return err
 			}
 
 			describe.TabbedWriter(cmd.OutOrStdout(), func(w io.Writer) {
-				fmt.Fprintln(w, "Name\tRequested State\tInstances\tMemory\tDisk\tURLs")
-				for _, app := range apps {
+				fmt.Fprintln(w, "Name\tRequested State\tInstances\tMemory\tDisk\tURLs\tCluster URL")
+				for _, app := range applist {
 
 					// Requested State
 					requestedState := "started"
@@ -111,13 +111,16 @@ func NewAppsCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command {
 						continue
 					}
 
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					kfApp := apps.NewFromApp(&app)
+
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 						app.Name,
 						requestedState,
 						instances,
 						memory,
 						disk,
 						strings.Join(urls, ", "),
+						kfApp.GetClusterURL(),
 					)
 				}
 			})

--- a/pkg/kf/describe/describe.go
+++ b/pkg/kf/describe/describe.go
@@ -304,3 +304,24 @@ func ServiceInstance(w io.Writer, service *v1beta1.ServiceInstance) {
 		fmt.Fprintf(w, "Status:\t%s\n", cond.Reason)
 	})
 }
+
+// RouteSpecFieldsList prints a list of routes
+func RouteSpecFieldsList(w io.Writer, routes []kfv1alpha1.RouteSpecFields) {
+	SectionWriter(w, "Routes", func(w io.Writer) {
+		if routes == nil {
+			return
+		}
+
+		TabbedWriter(w, func(w io.Writer) {
+			fmt.Fprintln(w, "Hostname\tDomain\tPath\tURL")
+
+			for _, route := range routes {
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+					route.Hostname,
+					route.Domain,
+					route.Path,
+					route.String())
+			}
+		})
+	})
+}


### PR DESCRIPTION
<!-- Include the issue number below -->
Part of #556

## Proposed Changes

* Added display of cluster internal address to app and apps command.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added display of cluster internal address to app and apps command .
```
