### PR TITLE
update kf services output

### DIFF
--- a/pkg/kf/commands/services/helpers_test.go
+++ b/pkg/kf/commands/services/helpers_test.go
@@ -74,7 +74,6 @@ func runTest(t *testing.T, tc serviceTest, newCommand commandFactory) {
 	_, actualErr := cmd.ExecuteC()
 	if tc.ExpectedErr != nil || actualErr != nil {
 		testutil.AssertErrorsEqual(t, tc.ExpectedErr, actualErr)
-		return
 	}
 
 	testutil.AssertContainsAll(t, buf.String(), tc.ExpectedStrings)

--- a/pkg/kf/commands/services/services.go
+++ b/pkg/kf/commands/services/services.go
@@ -63,12 +63,10 @@ func NewListServicesCommand(
 				fmt.Fprintln(w, "Name\tService\tPlan\tBound Apps\tLast Operation\tBroker")
 				for _, instance := range instances.Items {
 					lastCond := services.LastStatusCondition(instance)
-					var brokerName string
-					brokerName, err = client.BrokerName(instance)
+					var brokerInfo string
+					brokerInfo, err = client.BrokerName(instance)
 					if err != nil {
-						// The error is captured via closure and returned
-						// outside the TabWriter func.
-						return
+						brokerInfo = fmt.Sprintf("error finding broker: %s", err)
 					}
 
 					fmt.Fprintf(
@@ -79,7 +77,7 @@ func NewListServicesCommand(
 						instance.Spec.ClusterServicePlanExternalName,  // Plan
 						strings.Join(ma[instance.Name], ", "),         // Bound Apps
 						lastCond.Reason,                               // Last Operation
-						brokerName,                                    // Broker
+						brokerInfo,                                    // Broker
 					)
 				}
 			})

--- a/pkg/kf/commands/services/services_test.go
+++ b/pkg/kf/commands/services/services_test.go
@@ -94,9 +94,13 @@ func TestNewServicesCommand(t *testing.T) {
 						*dummyServerInstance("service-2"),
 					}}
 					f.EXPECT().ListServices(gomock.Any()).Return(serviceList, nil)
-					f.EXPECT().BrokerName(gomock.Any()).Return("", errors.New("some-error"))
+					f.EXPECT().BrokerName(gomock.Any()).Return("", errors.New("some-error")).Times(2)
 				},
 				ExpectedErr: errors.New("some-error"),
+				ExpectedStrings: []string{
+					"service-1", "service-2", // service instances still displayed with error msg
+					"some-error",
+				},
 			},
 		},
 		"full result": {


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #597

## Proposed Changes

* Change kf services output to list all service instances. It will not immediately return an error (and miss listing other service instances) when a service instance is invalid

Previous output:
```
Name                 Service       Plan       Bound Apps  Last Operation           Broker
Error: class 'blah' not found in cluster scope
```

New output:
```
Name                 Service       Plan       Bound Apps  Last Operation                     Broker
myservice            blah          blahplan               ReferencesNonexistentServiceClass  error finding broker: class 'blah' not found in cluster scope
spring-music-db      postgresql    11-4-0     envs-app    ProvisionedSuccessfully            minibroker
```