### PR TITLE
Fix labels dismatch for `kf bindings`

### DIFF
--- a/pkg/kf/commands/service-bindings/bindings.go
+++ b/pkg/kf/commands/service-bindings/bindings.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 
+	kfv1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/commands/config"
 	"github.com/google/kf/pkg/kf/commands/utils"
 	"github.com/google/kf/pkg/kf/describe"
@@ -72,8 +73,8 @@ func NewListBindingsCommand(p *config.KfParams, client servicebindings.ClientInt
 							reason = cond.Reason
 						}
 					}
-					app := b.Labels[servicebindings.AppNameLabel]
-					bindingName := b.Labels[servicebindings.BindingNameLabel]
+					app := b.Labels[kfv1alpha1.NameLabel]
+					bindingName := b.Labels[kfv1alpha1.ComponentLabel]
 
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s", b.Name, app, bindingName, b.Spec.InstanceRef.Name, b.Spec.SecretName, status, reason)
 					fmt.Fprintln(w)

--- a/pkg/kf/service-bindings/client.go
+++ b/pkg/kf/service-bindings/client.go
@@ -28,13 +28,6 @@ import (
 
 //go:generate go run ../internal/tools/option-builder/option-builder.go options.yml options.go
 
-const (
-	// BindingNameLabel is the label used on bindings to define what VCAP name the secret should be rooted under.
-	BindingNameLabel = "kf-binding-name"
-	// AppNameLabel is the label used on bindings to define which app the binding belongs to.
-	AppNameLabel = "kf-app-name"
-)
-
 // ClientInterface is a client capable of interacting with service catalog services
 // and mapping the CF to Kubernetes concepts.
 type ClientInterface interface {
@@ -130,7 +123,7 @@ func (c *Client) List(opts ...ListOption) ([]servicecatalogv1beta1.ServiceBindin
 
 		// NOTE: this _could_ be done with a label selector, but we'll do it here
 		// to reduce the cognitive overhead of filtering in multiple locations.
-		if filterByAppName && binding.Labels[AppNameLabel] != cfg.AppName {
+		if filterByAppName && binding.Labels[v1alpha1.NameLabel] != cfg.AppName {
 			continue
 		}
 

--- a/pkg/kf/service-bindings/client_test.go
+++ b/pkg/kf/service-bindings/client_test.go
@@ -195,11 +195,11 @@ func TestClient_List(t *testing.T) {
 			Run: func(t *testing.T, deps fakeDependencies, client servicebindings.ClientInterface) {
 				mybinding := servicecatalogv1beta1.ServiceBinding{}
 				mybinding.Name = "bound-to-my-app"
-				mybinding.Labels = map[string]string{servicebindings.AppNameLabel: "my-app"}
+				mybinding.Labels = map[string]string{kfv1alpha1.NameLabel: "my-app"}
 
 				otherbinding := servicecatalogv1beta1.ServiceBinding{}
 				otherbinding.Name = "bound-to-other-app"
-				otherbinding.Labels = map[string]string{servicebindings.AppNameLabel: "other-app"}
+				otherbinding.Labels = map[string]string{kfv1alpha1.NameLabel: "other-app"}
 
 				deps.apiserver.EXPECT().
 					List(gomock.Any(), "default", gomock.Any(), gomock.Any()).


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #576

## Proposed Changes

* Use Kubernetes recommended labels to track binding apps and services
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed  blank app and service name in `kf bindings`
```
