### PR TITLE
fixes #608

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_bind-service.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_bind-service.md
@@ -24,6 +24,7 @@ kf bind-service APP_NAME SERVICE_INSTANCE [-c PARAMETERS_AS_JSON] [--binding-nam
 ### Options
 
 ```
+      --async                 Don't wait for the binding to be ready before returning
   -b, --binding-name string   Name to expose service instance to app process with (default: service instance name)
   -h, --help                  help for bind-service
 ```

--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -95,7 +95,7 @@ func (ac *appsClient) Restage(namespace, name string) error {
 
 // ConditionServiceBindingsReady returns true if service bindings are ready and
 // errors if the bindings failed.
-func ConditionServiceBindingsReady(app *v1alpha1.App, apiErr error) (bool, error) {
+func ConditionServiceBindingsReady(app *v1alpha1.App, apiErr error) (isFinal bool, err error) {
 	if apiErr != nil {
 		return true, apiErr
 	}
@@ -113,7 +113,9 @@ func ConditionServiceBindingsReady(app *v1alpha1.App, apiErr error) (bool, error
 		case cond.IsUnknown():
 			return false, nil
 
-		default: // false and any other status gets a failure
+		default:
+			// return true and a failrue assuming IsFalse and other statuses can't be
+			// recovered from because they violate the K8s spec
 			return true, fmt.Errorf("checking %s failed, status: %s message: %s reason: %s", cond.Type, cond.Status, cond.Message, cond.Reason)
 		}
 	}

--- a/pkg/kf/apps/client_test.go
+++ b/pkg/kf/apps/client_test.go
@@ -1,0 +1,107 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apps
+
+import (
+	"errors"
+	"testing"
+
+	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/testutil"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+)
+
+func TestConditionServiceBindingsReady(t *testing.T) {
+	cases := map[string]struct {
+		app    v1alpha1.App
+		apiErr error
+
+		expectDone bool
+		expectErr  error
+	}{
+		"api error": {
+			apiErr:     errors.New("api-error"),
+			expectErr:  errors.New("api-error"),
+			expectDone: true,
+		},
+		"mismatch generation": {
+			app: v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					Status: duckv1beta1.Status{
+						ObservedGeneration: 3,
+					},
+				},
+			},
+			expectDone: false,
+			expectErr:  nil,
+		},
+		"missing status": {
+			app: v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{},
+					},
+				},
+			},
+			expectDone: false,
+		},
+		"unknown status causes retry": {
+			app: v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{
+							{Type: v1alpha1.AppConditionServiceBindingsReady, Status: "Unknown"},
+						},
+					},
+				},
+			},
+			expectDone: false,
+		},
+		"good status completes without error": {
+			app: v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{
+							{Type: v1alpha1.AppConditionServiceBindingsReady, Status: "True"},
+						},
+					},
+				},
+			},
+			expectDone: true,
+		},
+		"bad status completes with error": {
+			app: v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					Status: duckv1beta1.Status{
+						Conditions: duckv1beta1.Conditions{
+							{Type: v1alpha1.AppConditionServiceBindingsReady, Status: "False", Message: "ShortMessage", Reason: "longer description"},
+						},
+					},
+				},
+			},
+			expectDone: true,
+			expectErr:  errors.New("checking ServiceBindingsReady failed, status: False message: ShortMessage reason: longer description"),
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actualDone, actualErr := ConditionServiceBindingsReady(&tc.app, tc.apiErr)
+
+			testutil.AssertErrorsEqual(t, tc.expectErr, actualErr)
+			testutil.AssertEqual(t, "done", tc.expectDone, actualDone)
+		})
+	}
+}

--- a/pkg/kf/cfutil/systemenvinjector_test.go
+++ b/pkg/kf/cfutil/systemenvinjector_test.go
@@ -48,10 +48,8 @@ var (
 
 	serviceBinding = &servicecatalogv1beta1.ServiceBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "my-binding",
-			Labels: map[string]string{
-				"kf-binding-name": "my-binding-name",
-			},
+			Name:   "my-binding",
+			Labels: app.ComponentLabels("my-binding-name"),
 		},
 		Spec: servicecatalogv1beta1.ServiceBindingSpec{
 			InstanceRef: servicecatalogv1beta1.LocalObjectReference{
@@ -82,7 +80,7 @@ func Test_GetVcapServices(t *testing.T) {
 
 				vcapService, err := systemEnvInjector.GetVcapService(app.Name, serviceBinding)
 				testutil.AssertNil(t, "error", err)
-				testutil.AssertEqual(t, "name", "my-binding", vcapService.Name)
+				testutil.AssertEqual(t, "name", "my-binding-name", vcapService.Name)
 				testutil.AssertEqual(t, "instance name", "my-instance", vcapService.InstanceName)
 				testutil.AssertEqual(t, "label", "my-class", vcapService.Label)
 				testutil.AssertEqual(t, "tags", []string{}, vcapService.Tags)

--- a/pkg/kf/cfutil/vcap.go
+++ b/pkg/kf/cfutil/vcap.go
@@ -15,15 +15,9 @@
 package cfutil
 
 import (
+	kfv1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	apiv1beta1 "github.com/poy/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-)
-
-const (
-	// BindingNameLabel is the label used on bindings to define what VCAP name the secret should be rooted under.
-	BindingNameLabel = "kf-binding-name"
-	// AppNameLabel is the label used on bindings to define which app the binding belongs to.
-	AppNameLabel = "kf-app-name"
 )
 
 // VcapServicesMap mimics CF's VCAP_SERVICES environment variable.
@@ -59,21 +53,12 @@ func NewVcapService(instance apiv1beta1.ServiceInstance, binding apiv1beta1.Serv
 	// being that it doesn't seem to be formally fully documented anywhere:
 	// https://github.com/cloudfoundry/cloud_controller_ng/blob/65a75e6c97f49756df96e437e253f033415b2db1/app/presenters/system_environment/service_binding_presenter.rb#L32
 	vs := VcapService{
-		BindingName:  binding.Labels[BindingNameLabel],
-		Name:         binding.Name,
+		BindingName:  binding.Labels[kfv1alpha1.ComponentLabel],
+		Name:         coalesce(binding.Labels[kfv1alpha1.ComponentLabel], binding.Name),
 		InstanceName: binding.Spec.InstanceRef.Name,
-		Label:        instance.Spec.ClusterServiceClassExternalName,
-		Plan:         instance.Spec.ClusterServicePlanExternalName,
+		Label:        coalesce(instance.Spec.ServiceClassExternalName, instance.Spec.ClusterServiceClassExternalName),
+		Plan:         coalesce(instance.Spec.ServicePlanExternalName, instance.Spec.ClusterServicePlanExternalName),
 		Credentials:  make(map[string]string),
-	}
-
-	// Make sure we can work with both ServiceClass and ClusterServiceClass
-	if instance.Spec.ServiceClassExternalName != "" {
-		vs.Label = instance.Spec.ServiceClassExternalName
-	}
-
-	if instance.Spec.ServicePlanExternalName != "" {
-		vs.Plan = instance.Spec.ServicePlanExternalName
 	}
 
 	// TODO(josephlewis42) we need to get tags from the (Cluster)ServiceClass
@@ -87,4 +72,14 @@ func NewVcapService(instance apiv1beta1.ServiceInstance, binding apiv1beta1.Serv
 	}
 
 	return vs
+}
+
+func coalesce(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+
+	return ""
 }

--- a/pkg/kf/cfutil/vcap.go
+++ b/pkg/kf/cfutil/vcap.go
@@ -54,7 +54,7 @@ func NewVcapService(instance apiv1beta1.ServiceInstance, binding apiv1beta1.Serv
 	// https://github.com/cloudfoundry/cloud_controller_ng/blob/65a75e6c97f49756df96e437e253f033415b2db1/app/presenters/system_environment/service_binding_presenter.rb#L32
 	vs := VcapService{
 		BindingName:  binding.Labels[kfv1alpha1.ComponentLabel],
-		Name:         coalesce(binding.Labels[kfv1alpha1.ComponentLabel], binding.Name),
+		Name:         coalesce(binding.Labels[kfv1alpha1.ComponentLabel], binding.Spec.InstanceRef.Name),
 		InstanceName: binding.Spec.InstanceRef.Name,
 		Label:        coalesce(instance.Spec.ServiceClassExternalName, instance.Spec.ClusterServiceClassExternalName),
 		Plan:         coalesce(instance.Spec.ServicePlanExternalName, instance.Spec.ClusterServicePlanExternalName),

--- a/pkg/kf/cfutil/vcap_test.go
+++ b/pkg/kf/cfutil/vcap_test.go
@@ -17,6 +17,7 @@ package cfutil_test
 import (
 	"fmt"
 
+	kfv1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/cfutil"
 	apiv1beta1 "github.com/poy/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ func ExampleNewVcapService() {
 	binding.Spec.InstanceRef.Name = "my-instance"
 	binding.Name = "my-binding"
 	binding.Labels = map[string]string{
-		cfutil.BindingNameLabel: "custom-binding-name",
+		kfv1alpha1.ComponentLabel: "custom-binding-name",
 	}
 
 	secret := corev1.Secret{}
@@ -65,7 +66,7 @@ func ExampleNewVcapService() {
 	fmt.Printf("Service: %v\n", vs.Label)
 	fmt.Printf("Plan: %v\n", vs.Plan)
 
-	// Output: Name: my-binding
+	// Output: Name: custom-binding-name
 	// InstanceName: my-instance
 	// BindingName: custom-binding-name
 	// Credentials: map[key1:value1 key2:value2]

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -77,7 +77,6 @@ func TestIntegration_VcapServices(t *testing.T) {
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"
-	//creds := `"credentials":{"password":"fake-pw","username":"fake-user"}` // fake service binding credentials provided by the mock broker
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
 			withServiceInstance(ctx, kf, func(ctx context.Context) {

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -127,8 +127,6 @@ func TestIntegration_VcapServices_customBindingName(t *testing.T) {
 					kf.BindService(ctx, appName, serviceInstanceName, "--binding-name", "my-binding")
 					defer kf.UnbindService(ctx, appName, serviceInstanceName) // cleanup
 
-					// Restart so that env vars are injected from the secret into app
-					// kf.Restart(ctx, AppFromContext(ctx))
 					vcs := extractVcapServices(ctx, t, kf)
 
 					expected := cfutil.VcapServicesMap{

--- a/pkg/kf/service-bindings/fake/fake_client_interface.go
+++ b/pkg/kf/service-bindings/fake/fake_client_interface.go
@@ -20,6 +20,7 @@
 package fake
 
 import (
+	context "context"
 	gomock "github.com/golang/mock/gomock"
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	service_bindings "github.com/google/kf/pkg/kf/service-bindings"
@@ -106,4 +107,18 @@ func (m *FakeClientInterface) List(arg0 ...service_bindings.ListOption) ([]v1bet
 func (mr *FakeClientInterfaceMockRecorder) List(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*FakeClientInterface)(nil).List), arg0...)
+}
+
+// WaitForBindings mocks base method
+func (m *FakeClientInterface) WaitForBindings(arg0 context.Context, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForBindings", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForBindings indicates an expected call of WaitForBindings
+func (mr *FakeClientInterfaceMockRecorder) WaitForBindings(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForBindings", reflect.TypeOf((*FakeClientInterface)(nil).WaitForBindings), arg0, arg1, arg2)
 }


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #608 

## Proposed Changes

* Use `kfv1alpha1.ComponentLabel` instead of the previously correct label to name services
* Added integration tests for vcap service format

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
