### PR TITLE
pkg/reconciler/app/resources: Set values to match ksvc defaults

### DIFF
--- a/pkg/reconciler/app/resources/knativeservice.go
+++ b/pkg/reconciler/app/resources/knativeservice.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
+	"knative.dev/pkg/ptr"
 )
 
 // KnativeServiceName gets the name of a Knative Service given the route.
@@ -98,9 +99,18 @@ func MakeKnativeService(
 					},
 					Spec: serving.RevisionSpec{
 						RevisionSpec: servingv1beta1.RevisionSpec{
-							PodSpec: *podSpec,
+							TimeoutSeconds: ptr.Int64(300),
+							PodSpec:        *podSpec,
 						},
 					},
+				},
+			},
+			RouteSpec: serving.RouteSpec{
+				Traffic: []serving.TrafficTarget{
+					{TrafficTarget: servingv1beta1.TrafficTarget{
+						LatestRevision: ptr.Bool(true),
+						Percent:        100,
+					}},
 				},
 			},
 		},


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #618 

## Proposed Changes

* Adds knative service values to match Knative's defaults
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed bug where reconciler would do two rounds for each new knative service.
```
