### PR TITLE
ci: break unit and integration tests out

### DIFF
--- a/ci/concourse/pipelines/pr-pipeline.yml
+++ b/ci/concourse/pipelines/pr-pipeline.yml
@@ -198,7 +198,28 @@ jobs:
     trigger: true
   - get: ci-image
   - get: ci-src
-  - task: test
+  - task: unit-tests
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: *ci-image-source
+      inputs:
+      - name: src
+      - name: ci-src
+      params:
+        GOPROXY: *go_proxy
+        GOSUMDB: *go_sum_db
+      run:
+        dir: src
+        path: sh
+        args:
+        - -exc
+        - |
+          # Run unit tests
+          hack/unit-test.sh
+  - task: integration-tests
     timeout: 1h30m
     config:
       platform: linux
@@ -233,8 +254,8 @@ jobs:
             --project "$GCP_PROJECT_ID"
           /bin/echo 'y' | gcloud auth configure-docker
 
-          # Run all tests
-          RACE=false hack/test.sh
+          # Run integration tests
+          RACE=false hack/integration-test.sh
     on_failure: *on_failure
 - name: success
   plan:

--- a/ci/concourse/pipelines/pr-pipeline.yml
+++ b/ci/concourse/pipelines/pr-pipeline.yml
@@ -255,7 +255,7 @@ jobs:
           /bin/echo 'y' | gcloud auth configure-docker
 
           # Run integration tests
-          RACE=false hack/integration-test.sh
+          hack/integration-test.sh
     on_failure: *on_failure
 - name: success
   plan:

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Go to root dir
+cd $(git rev-parse --show-toplevel)
+
+if [ "${DOCKER_REGISTRY}" = "" ]; then
+  echo running integration tests
+  export DOCKER_REGISTRY="gcr.io/$(gcloud config get-value project)"
+fi
+
+# When running integration tests, we would like two things that simply running
+# go test -v ./... doesn't provide:
+# 1. Don't run each package in parallel - This puts quite a bit of burden on
+# the cluster and causes tests to flake.
+# 2. We want logs streaming the whole time, not just when the tests fails.
+#
+# Note: We also enforce that all integration tests have the naming convention
+# TestIntegration_XXX. Therefore we can single them out.
+for f in $(find . | grep integration_test.go); do
+  go test -v --timeout=30m $(dirname $f) --run TestIntegration_
+done

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -100,6 +100,7 @@ func TestIntegration_Push_docker(t *testing.T) {
 // stops it and ensures it can no longer reach the app. It then starts it and
 // tries posting to it again. It finally deletes the app.
 func TestIntegration_StopStart(t *testing.T) {
+	t.Skip("This test is slow and flaky")
 	t.Parallel()
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -100,7 +100,6 @@ func TestIntegration_Push_docker(t *testing.T) {
 // stops it and ensures it can no longer reach the app. It then starts it and
 // tries posting to it again. It finally deletes the app.
 func TestIntegration_StopStart(t *testing.T) {
-	t.Skip("This test is slow and flaky")
 	t.Parallel()
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -115,6 +115,7 @@ func TestIntegration_VcapServices(t *testing.T) {
 }
 
 func TestIntegration_VcapServices_customBindingName(t *testing.T) {
+	t.Skip("flaky - #634")
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Run unit and integration tests in separate tasks
* Run integration tests per package
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
