### PR TITLE
made restage return logs

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_restage.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_restage.md
@@ -24,7 +24,8 @@ kf restage APP_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for restage
+      --async   Don't wait for the restage to finish before returning.
+  -h, --help    help for restage
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -92,8 +92,7 @@ func (ac *appsClient) Restage(namespace, name string) (app *v1alpha1.App, err er
 
 	app.Spec.Source.UpdateRequests++
 
-	app, err = ac.coreClient.Update(namespace, app)
-	return
+	return ac.coreClient.Update(namespace, app)
 }
 
 // ConditionServiceBindingsReady returns true if service bindings are ready and

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -119,6 +119,20 @@ func (mr *FakeClientMockRecorder) DeployLogs(arg0, arg1, arg2, arg3, arg4 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLogs", reflect.TypeOf((*FakeClient)(nil).DeployLogs), arg0, arg1, arg2, arg3, arg4)
 }
 
+// DeployLogsForApp mocks base method
+func (m *FakeClient) DeployLogsForApp(arg0 io.Writer, arg1 *v1alpha1.App) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeployLogsForApp", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeployLogsForApp indicates an expected call of DeployLogsForApp
+func (mr *FakeClientMockRecorder) DeployLogsForApp(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeployLogsForApp", reflect.TypeOf((*FakeClient)(nil).DeployLogsForApp), arg0, arg1)
+}
+
 // Get mocks base method
 func (m *FakeClient) Get(arg0, arg1 string, arg2 ...apps.GetOption) (*v1alpha1.App, error) {
 	m.ctrl.T.Helper()
@@ -160,11 +174,12 @@ func (mr *FakeClientMockRecorder) List(arg0 interface{}, arg1 ...interface{}) *g
 }
 
 // Restage mocks base method
-func (m *FakeClient) Restage(arg0, arg1 string) error {
+func (m *FakeClient) Restage(arg0, arg1 string) (*v1alpha1.App, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Restage", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*v1alpha1.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Restage indicates an expected call of Restage

--- a/pkg/kf/apps/log_tailer.go
+++ b/pkg/kf/apps/log_tailer.go
@@ -70,6 +70,12 @@ func newPushLogTailer(
 	return t
 }
 
+// DeployLogsForApp gets the deployment logs for an application. It blocks until
+// the operation has completed.
+func (a *appsClient) DeployLogsForApp(out io.Writer, app *v1alpha1.App) error {
+	return a.DeployLogs(out, app.Name, app.ResourceVersion, app.Namespace, app.Spec.Instances.Stopped)
+}
+
 // DeployLogs writes the logs for the deploy step for the resourceVersion
 // to out. It blocks until the operation has completed.
 func (a *appsClient) DeployLogs(

--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -126,13 +126,7 @@ func (p *pusher) Push(appName string, opts ...PushOption) error {
 		return fmt.Errorf("failed to push app: %s", err)
 	}
 
-	if err := p.appsClient.DeployLogs(
-		cfg.Output,
-		appName,
-		resultingApp.ResourceVersion,
-		app.Namespace,
-		cfg.NoStart,
-	); err != nil {
+	if err := p.appsClient.DeployLogsForApp(cfg.Output, resultingApp); err != nil {
 		return err
 	}
 

--- a/pkg/kf/commands/apps/restage_test.go
+++ b/pkg/kf/commands/apps/restage_test.go
@@ -40,6 +40,7 @@ func TestRestage(t *testing.T) {
 			Args:      []string{"my-app"},
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Restage("default", "my-app")
+				fake.EXPECT().DeployLogsForApp(gomock.Any(), gomock.Any())
 			},
 		},
 		"no app name": {
@@ -54,7 +55,24 @@ func TestRestage(t *testing.T) {
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().
 					Restage(gomock.Any(), gomock.Any()).
-					Return(errors.New("some-error"))
+					Return(nil, errors.New("some-error"))
+			},
+		},
+		"restages app async": {
+			Namespace: "default",
+			Args:      []string{"my-app"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Restage("default", "my-app")
+				fake.EXPECT().DeployLogsForApp(gomock.Any(), gomock.Any())
+			},
+		},
+		"restages app deployment fail": {
+			Namespace:   "default",
+			Args:        []string{"my-app"},
+			ExpectedErr: errors.New("failed to restage app: some-log-error"),
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Restage("default", "my-app")
+				fake.EXPECT().DeployLogsForApp(gomock.Any(), gomock.Any()).Return(errors.New("some-log-error"))
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #636 

## Proposed Changes

* Adds log tailing to restage
* Refactors the Restage client command to also return the app so that the deploy logs can get the needed info
* Refactors DeployLogs to add another command that will retrieve all info needed off an app to be used by both push and restage (maybe also restart in the future?)

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added log tailing to the `restage` command
```
