### PR TITLE
added service tags

### DIFF
--- a/pkg/kf/cfutil/fake/fake_systemenvinjector.go
+++ b/pkg/kf/cfutil/fake/fake_systemenvinjector.go
@@ -66,6 +66,21 @@ func (mr *FakeSystemEnvInjectorMockRecorder) ComputeSystemEnv(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeSystemEnv", reflect.TypeOf((*FakeSystemEnvInjector)(nil).ComputeSystemEnv), arg0, arg1)
 }
 
+// GetClassFromInstance mocks base method
+func (m *FakeSystemEnvInjector) GetClassFromInstance(arg0 *v1beta1.ServiceInstance) (*v1beta1.CommonServiceClassSpec, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClassFromInstance", arg0)
+	ret0, _ := ret[0].(*v1beta1.CommonServiceClassSpec)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClassFromInstance indicates an expected call of GetClassFromInstance
+func (mr *FakeSystemEnvInjectorMockRecorder) GetClassFromInstance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClassFromInstance", reflect.TypeOf((*FakeSystemEnvInjector)(nil).GetClassFromInstance), arg0)
+}
+
 // GetVcapService mocks base method
 func (m *FakeSystemEnvInjector) GetVcapService(arg0 string, arg1 *v1beta1.ServiceBinding) (cfutil.VcapService, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kf/cfutil/vcap.go
+++ b/pkg/kf/cfutil/vcap.go
@@ -17,6 +17,7 @@ package cfutil
 import (
 	kfv1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	apiv1beta1 "github.com/poy/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	servicecatalogv1beta1 "github.com/poy/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -48,7 +49,7 @@ type VcapService struct {
 
 // NewVcapService creates a new VcapService given a binding and associated
 // secret.
-func NewVcapService(instance apiv1beta1.ServiceInstance, binding apiv1beta1.ServiceBinding, secret *corev1.Secret) VcapService {
+func NewVcapService(class servicecatalogv1beta1.CommonServiceClassSpec, instance apiv1beta1.ServiceInstance, binding apiv1beta1.ServiceBinding, secret *corev1.Secret) VcapService {
 	// See the cloud-controller-ng source for how this is supposed to be built
 	// being that it doesn't seem to be formally fully documented anywhere:
 	// https://github.com/cloudfoundry/cloud_controller_ng/blob/65a75e6c97f49756df96e437e253f033415b2db1/app/presenters/system_environment/service_binding_presenter.rb#L32
@@ -58,12 +59,9 @@ func NewVcapService(instance apiv1beta1.ServiceInstance, binding apiv1beta1.Serv
 		InstanceName: binding.Spec.InstanceRef.Name,
 		Label:        coalesce(instance.Spec.ServiceClassExternalName, instance.Spec.ClusterServiceClassExternalName),
 		Plan:         coalesce(instance.Spec.ServicePlanExternalName, instance.Spec.ClusterServicePlanExternalName),
+		Tags:         class.Tags,
 		Credentials:  make(map[string]string),
 	}
-
-	// TODO(josephlewis42) we need to get tags from the (Cluster)ServiceClass
-	// this could be aided by the BindingParentHierarchy function in the
-	// service catalog SDK.
 
 	// Credentials are stored by the service catalog in a flat map, the data
 	// values are just strings.

--- a/pkg/kf/cfutil/vcap_test.go
+++ b/pkg/kf/cfutil/vcap_test.go
@@ -57,7 +57,11 @@ func ExampleNewVcapService() {
 		"key2": []byte("value2"),
 	}
 
-	vs := cfutil.NewVcapService(instance, binding, &secret)
+	class := apiv1beta1.CommonServiceClassSpec{
+		Tags: []string{"mysql"},
+	}
+
+	vs := cfutil.NewVcapService(class, instance, binding, &secret)
 
 	fmt.Printf("Name: %s\n", vs.Name)
 	fmt.Printf("InstanceName: %s\n", vs.InstanceName)
@@ -65,6 +69,7 @@ func ExampleNewVcapService() {
 	fmt.Printf("Credentials: %v\n", vs.Credentials)
 	fmt.Printf("Service: %v\n", vs.Label)
 	fmt.Printf("Plan: %v\n", vs.Plan)
+	fmt.Printf("Tags: %v\n", vs.Tags)
 
 	// Output: Name: custom-binding-name
 	// InstanceName: my-instance
@@ -72,4 +77,5 @@ func ExampleNewVcapService() {
 	// Credentials: map[key1:value1 key2:value2]
 	// Service: my-service
 	// Plan: my-service-plan
+	// Tags: [mysql]
 }

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -96,7 +96,7 @@ func TestIntegration_VcapServices(t *testing.T) {
 									InstanceName: ServiceInstanceFromContext(ctx),
 									Name:         ServiceInstanceFromContext(ctx),
 									Label:        ServiceClassFromContext(ctx),
-									Tags:         []string(nil),
+									Tags:         []string{"fake-tag"},
 									Plan:         ServicePlanFromContext(ctx),
 									Credentials: map[string]string{
 										"password": "fake-pw",
@@ -137,7 +137,7 @@ func TestIntegration_VcapServices_customBindingName(t *testing.T) {
 								InstanceName: ServiceInstanceFromContext(ctx),
 								Name:         "my-binding",
 								Label:        ServiceClassFromContext(ctx),
-								Tags:         []string(nil),
+								Tags:         []string{"fake-tag"},
 								Plan:         ServicePlanFromContext(ctx),
 								Credentials: map[string]string{
 									"password": "fake-pw",

--- a/samples/apps/service-broker/go.mod
+++ b/samples/apps/service-broker/go.mod
@@ -1,3 +1,5 @@
 module github.com/google/kf/samples/apps/service-broker
 
 go 1.12
+
+require github.com/gorilla/mux v1.7.3

--- a/samples/apps/service-broker/go.sum
+++ b/samples/apps/service-broker/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/samples/apps/service-broker/main.go
+++ b/samples/apps/service-broker/main.go
@@ -32,6 +32,7 @@ const (
 				"id": "fake-service-id",
 				"description": "a fake service",
 				"bindable": true,
+				"tags": ["fake-tag"],
 				"plans": [
 					{
 						"id": "fake-plan-id",


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #637 

## Proposed Changes

* Added support for inserting tags from service instances into VCAP_SERVICES

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added support for inserting tags from service instances into `VCAP_SERVICES`
```
