### PR TITLE
fixed #607

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle.go
@@ -118,6 +118,11 @@ func (status *AppStatus) PropagateKnativeServiceStatus(service *serving.Service)
 		return
 	}
 
+	if service.Status.ObservedGeneration != service.Generation {
+		status.manage().MarkUnknown(AppConditionKnativeServiceReady, "GenerationMismatch", "the Knative service needs to be synchronized")
+		return
+	}
+
 	cond := service.Status.GetCondition(apis.ConditionReady)
 
 	if PropagateCondition(status.manage(), AppConditionKnativeServiceReady, cond) {

--- a/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
@@ -353,6 +353,28 @@ func TestAppStatus_lifecycle(t *testing.T) {
 				AppConditionEnvVarSecretReady,
 			},
 		},
+		"out of sync": {
+			Init: func(status *AppStatus) {
+				status.MarkSpaceHealthy()
+				status.PropagateSourceStatus(happySource())
+				status.PropagateEnvVarSecretStatus(envVarSecret())
+				// out of sync
+				status.PropagateKnativeServiceStatus(&serving.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "some-service-name",
+						Generation: 42,
+					},
+				})
+			},
+			ExpectSucceeded: []apis.ConditionType{
+				AppConditionSpaceReady,
+				AppConditionSourceReady,
+				AppConditionEnvVarSecretReady,
+			},
+			ExpectOngoing: []apis.ConditionType{
+				AppConditionReady,
+			},
+		},
 		"space unhealthy": {
 			Init: func(status *AppStatus) {
 				status.MarkSpaceUnhealthy("Terminating", "Namespace is terminating")

--- a/pkg/kf/apps/log_tailer.go
+++ b/pkg/kf/apps/log_tailer.go
@@ -120,6 +120,11 @@ func (t *pushLogTailer) handleWatch() (bool, error) {
 			continue
 		}
 
+		// skip out of date apps
+		if app.Generation != app.Status.ObservedGeneration {
+			continue
+		}
+
 		done, err := t.handleUpdate(app)
 		if err != nil {
 			return true, err


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #607 

## Proposed Changes

* Makes the reconciler always update the ObservedGeneration on Apps in accordance with the Kubernetes controller guidlines
* Ensure Knative Serving updates aren't prematurely updated if there is a generation mismatch 

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
