### PR TITLE
Fix services cmd and add issue numbers to skipped int tests

### DIFF
--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestIntegration_Marketplace(t *testing.T) {
+	t.Skip("#599")
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
@@ -39,6 +40,7 @@ func TestIntegration_Marketplace(t *testing.T) {
 }
 
 func TestIntegration_Services(t *testing.T) {
+	t.Skip("#599")
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
@@ -52,6 +54,7 @@ func TestIntegration_Services(t *testing.T) {
 }
 
 func TestIntegration_Bindings(t *testing.T) {
+	t.Skip("#599")
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"
@@ -71,6 +74,7 @@ func TestIntegration_Bindings(t *testing.T) {
 }
 
 func TestIntegration_VcapServices(t *testing.T) {
+	t.Skip("#654")
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"
@@ -111,6 +115,7 @@ func TestIntegration_VcapServices(t *testing.T) {
 }
 
 func TestIntegration_VcapServices_customBindingName(t *testing.T) {
+	t.Skip("#654")
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -76,9 +76,6 @@ func TestIntegration_VcapServices(t *testing.T) {
 	appPath := "./samples/apps/envs"
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
-
-			// TODO: cut this out when create-service-broker is synchronous
-			time.Sleep(10 * time.Second)
 			withServiceInstance(ctx, kf, func(ctx context.Context) {
 				withApp(ctx, t, kf, appName, appPath, false, func(ctx context.Context) {
 					// Assert VCAP_SERVICES is blank
@@ -119,9 +116,6 @@ func TestIntegration_VcapServices_customBindingName(t *testing.T) {
 	appPath := "./samples/apps/envs"
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
-
-			// TODO: cut this out when create-service-broker is synchronous
-			time.Sleep(10 * time.Second)
 			withServiceInstance(ctx, kf, func(ctx context.Context) {
 				withApp(ctx, t, kf, appName, appPath, false, func(ctx context.Context) {
 					serviceInstanceName := ServiceInstanceFromContext(ctx)
@@ -190,9 +184,9 @@ func withServiceBroker(ctx context.Context, t *testing.T, kf *Kf, callback func(
 		// Register the mock service broker to service catalog, and then clean it up.
 		kf.CreateServiceBroker(ctx, brokerName, internalBrokerUrl(brokerAppName, SpaceFromContext(ctx)), "--space-scoped")
 
-		// Temporary solution to allow service broker registration to complete.
-		// TODO: Add flag to run the command synchronously.
-		time.Sleep(2 * time.Second)
+		// TODO: cut this out when create-service-broker is synchronous
+		time.Sleep(10 * time.Second)
+
 		defer kf.DeleteServiceBroker(ctx, brokerName, "--space-scoped", "--force")
 
 		ctx = ContextWithBroker(ctx, brokerName)
@@ -207,6 +201,10 @@ func withServiceInstance(ctx context.Context, kf *Kf, callback func(newCtx conte
 	brokerName := BrokerFromContext(ctx)
 
 	kf.CreateService(ctx, serviceClass, servicePlan, serviceInstanceName, "-b", brokerName)
+
+	// TODO: cut this out when create-service is synchronous
+	time.Sleep(5 * time.Second)
+
 	defer kf.DeleteService(ctx, serviceInstanceName)
 
 	ctx = ContextWithServiceClass(ctx, serviceClass)

--- a/pkg/kf/commands/service-bindings/integration_test.go
+++ b/pkg/kf/commands/service-bindings/integration_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestIntegration_Marketplace(t *testing.T) {
-	t.Skip()
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
@@ -40,7 +39,6 @@ func TestIntegration_Marketplace(t *testing.T) {
 }
 
 func TestIntegration_Services(t *testing.T) {
-	t.Skip()
 	checkClusterStatus(t)
 	RunKfTest(t, func(ctx context.Context, t *testing.T, kf *Kf) {
 		withServiceBroker(ctx, t, kf, func(ctx context.Context) {
@@ -54,7 +52,6 @@ func TestIntegration_Services(t *testing.T) {
 }
 
 func TestIntegration_Bindings(t *testing.T) {
-	t.Skip()
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"
@@ -74,7 +71,6 @@ func TestIntegration_Bindings(t *testing.T) {
 }
 
 func TestIntegration_VcapServices(t *testing.T) {
-	t.Skip("re-enable me when namespaced brokers are added")
 	checkClusterStatus(t)
 	appName := fmt.Sprintf("integration-binding-app-%d", time.Now().UnixNano())
 	appPath := "./samples/apps/envs"

--- a/pkg/kf/commands/services/services.go
+++ b/pkg/kf/commands/services/services.go
@@ -69,15 +69,23 @@ func NewListServicesCommand(
 						brokerInfo = fmt.Sprintf("error finding broker: %s", err)
 					}
 
+					className := instance.Spec.ClusterServiceClassExternalName
+					planName := instance.Spec.ClusterServicePlanExternalName
+
+					if instance.Spec.ServiceClassRef != nil {
+						className = instance.Spec.ServiceClassExternalName
+						planName = instance.Spec.ServicePlanExternalName
+					}
+
 					fmt.Fprintf(
 						w,
 						"%s\t%s\t%s\t%s\t%s\t%s\n",
-						instance.Name, // Name
-						instance.Spec.ClusterServiceClassExternalName, // Service
-						instance.Spec.ClusterServicePlanExternalName,  // Plan
-						strings.Join(ma[instance.Name], ", "),         // Bound Apps
-						lastCond.Reason,                               // Last Operation
-						brokerInfo,                                    // Broker
+						instance.Name,                         // Name
+						className,                             // Service
+						planName,                              // Plan
+						strings.Join(ma[instance.Name], ", "), // Bound Apps
+						lastCond.Reason,                       // Last Operation
+						brokerInfo,                            // Broker
 					)
 				}
 			})

--- a/pkg/kf/services/services.go
+++ b/pkg/kf/services/services.go
@@ -123,9 +123,20 @@ func (c *Client) BrokerName(service v1beta1.ServiceInstance, opts ...BrokerNameO
 	cfg := BrokerNameOptionDefaults().Extend(opts).toConfig()
 	svcat := c.createSvcatClient(cfg.Namespace)
 
-	class, err := svcat.RetrieveClassByName(service.Spec.ClusterServiceClassExternalName, servicecatalog.ScopeOptions{
+	scope := servicecatalog.ScopeOptions{
 		Scope: servicecatalog.ClusterScope,
-	})
+	}
+	className := service.Spec.ClusterServiceClassExternalName
+
+	if service.Spec.ServiceClassRef != nil {
+		scope = servicecatalog.ScopeOptions{
+			Namespace: service.GetNamespace(),
+			Scope:     servicecatalog.NamespaceScope,
+		}
+		className = service.Spec.ServiceClassExternalName
+	}
+
+	class, err := svcat.RetrieveClassByName(className, scope)
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Proposed Changes

* Update `services` command to properly get broker, class, and plan name (found by running int tests locally)
* Add relevant issue numbers in skipped service-bindings integration test (flaky but passed locally)


## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
