### PR TITLE
moved to using k8s yaml parser everywhere

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	go.opencensus.io v0.22.0 // indirect
 	go.uber.org/zap v1.9.1
 	google.golang.org/appengine v1.5.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2
 	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 
 	"github.com/google/kf/pkg/kf/manifest"
 	. "github.com/google/kf/pkg/kf/testutil"

--- a/pkg/kf/commands/config/config.go
+++ b/pkg/kf/commands/config/config.go
@@ -35,7 +35,6 @@ import (
 	svcatclient "github.com/poy/service-catalog/pkg/client/clientset_generated/clientset"
 	"github.com/poy/service-catalog/pkg/svcat"
 	servicecatalog "github.com/poy/service-catalog/pkg/svcat/service-catalog"
-	"gopkg.in/yaml.v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
@@ -43,27 +42,28 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/yaml"
 )
 
 // KfParams stores everything needed to interact with the user and Knative.
 type KfParams struct {
 	// Config holds the path to the configuration.
 	// This field isn't serialized when the config is saved.
-	Config string `yaml:"-"`
+	Config string `json:"-"`
 
 	// Namespace holds the namespace kf should connect to by default.
-	Namespace string `yaml:"space"`
+	Namespace string `json:"space"`
 
 	// KubeCfgFile holds the path to the kubeconfig.
-	KubeCfgFile string `yaml:"kubeconfig"`
+	KubeCfgFile string `json:"kubeconfig"`
 
 	// LogHTTP enables HTTP tracing for all Kubernetes calls.
-	LogHTTP bool `yaml:"logHTTP"`
+	LogHTTP bool `json:"logHTTP"`
 
 	// TargetSpace caches the space specified by Namespace to prevent it from
 	// being computed multiple times.
 	// Prefer using GetSpaceOrDefault instead of accessing this value directly.
-	TargetSpace *v1alpha1.Space `yaml:"-"`
+	TargetSpace *v1alpha1.Space `json:"-"`
 }
 
 // GetTargetSpaceOrDefault gets the space specified by Namespace or a default

--- a/pkg/kf/describe/describe.go
+++ b/pkg/kf/describe/describe.go
@@ -23,11 +23,11 @@ import (
 	kfv1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/services"
 	"github.com/poy/service-catalog/pkg/apis/servicecatalog/v1beta1"
-	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"sigs.k8s.io/yaml"
 )
 
 // EnvVars prints out environment variables.

--- a/pkg/kf/internal/tools/clientgen/client.go
+++ b/pkg/kf/internal/tools/clientgen/client.go
@@ -23,35 +23,35 @@ import (
 
 type ClientParams struct {
 	// Package is the package the client will be generated in.
-	Package string `yaml:"package"`
+	Package string `json:"package"`
 
 	// Imports is used for imports into the client.
-	Imports map[string]string `yaml:"imports"`
+	Imports map[string]string `json:"imports"`
 
 	// Kubernetes holds information about the backing API.
 	Kubernetes struct {
 		// Kind is the kind of the resource.
-		Kind string `yaml:"kind"`
+		Kind string `json:"kind"`
 		// Version is the version of the resource kf supports.
-		Version string `yaml:"version"`
+		Version string `json:"version"`
 		// Namespaced indicates whether this object is namespaced or global.
-		Namespaced bool `yaml:"namespaced"`
+		Namespaced bool `json:"namespaced"`
 		// Plural contains the pluralizataion of kind. If blank, default of Kind+"s"
 		// is assumed.
-		Plural string `yaml:"plural"`
-	} `yaml:"kubernetes"`
+		Plural string `json:"plural"`
+	} `json:"kubernetes"`
 
 	// CF contains information about this resource from a CF side.
 	CF struct {
 		// The name of the CF type.
-		Name string `yaml:"name"`
-	} `yaml:"cf"`
+		Name string `json:"name"`
+	} `json:"cf"`
 
 	// Type is the Go type of the resource. This MUST be imported using Imports.
-	Type string `yaml:"type"`
+	Type string `json:"type"`
 
 	// ClientType is the Go type of the Kubernetes client. This MUST be imported using Imports.
-	ClientType string `yaml:"clientType"`
+	ClientType string `json:"clientType"`
 }
 
 func (f *ClientParams) Render() ([]byte, error) {

--- a/pkg/kf/internal/tools/clientgen/genclient.go
+++ b/pkg/kf/internal/tools/clientgen/genclient.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/google/kf/pkg/kf/internal/tools/clientgen"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 func main() {

--- a/pkg/kf/internal/tools/option-builder/option-builder.go
+++ b/pkg/kf/internal/tools/option-builder/option-builder.go
@@ -29,31 +29,31 @@ import (
 	"text/template"
 
 	"github.com/google/kf/pkg/kf/internal/tools/generator"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 type Option struct {
-	Name        string  `yaml:"name"`
-	Type        string  `yaml:"type"`
-	Description string  `yaml:"description"`
-	Default     *string `yaml:"default"`
+	Name        string  `json:"name"`
+	Type        string  `json:"type"`
+	Description string  `json:"description"`
+	Default     *string `json:"default"`
 }
 
 type OptionsConfig struct {
-	Name    string   `yaml:"name"`
-	Options []Option `yaml:"options"`
+	Name    string   `json:"name"`
+	Options []Option `json:"options"`
 
 	// ConfigName is set by Name. It is modified to ensure its not exported.
-	ConfigName string `yaml:"-"`
+	ConfigName string `json:"-"`
 }
 
 type OptionsFile struct {
-	License string            `yaml:"license"`
-	Package string            `yaml:"package"`
-	Imports map[string]string `yaml:"imports"`
+	License string            `json:"license"`
+	Package string            `json:"package"`
+	Imports map[string]string `json:"imports"`
 
-	CommonOptions []Option        `yaml:"common"`
-	Configs       []OptionsConfig `yaml:"configs"`
+	CommonOptions []Option        `json:"common"`
+	Configs       []OptionsConfig `json:"configs"`
 }
 
 func main() {
@@ -94,7 +94,7 @@ func main() {
 	var configs []OptionsConfig
 	for _, cfg := range of.Configs {
 		// Mix in the common options and sort by name.
-		cfg.Options = append(of.CommonOptions, cfg.Options...)
+		cfg.Options = append(cfg.Options, of.CommonOptions...)
 		sort.Slice(cfg.Options, func(i, j int) bool {
 			return cfg.Options[i].Name < cfg.Options[j].Name
 		})

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -25,57 +25,57 @@ import (
 
 	"github.com/google/kf/pkg/internal/envutil"
 	"github.com/imdario/mergo"
-	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/yaml"
 )
 
 // Application is a configuration for a single 12-factor-app.
 type Application struct {
-	Name       string            `yaml:"name,omitempty"`
-	Path       string            `yaml:"path,omitempty"`
-	Buildpacks []string          `yaml:"buildpacks,omitempty"`
-	Docker     AppDockerImage    `yaml:"docker,omitempty"`
-	Env        map[string]string `yaml:"env,omitempty"`
-	Services   []string          `yaml:"services,omitempty"`
-	DiskQuota  string            `yaml:"disk_quota,omitempty"`
-	Memory     string            `yaml:"memory,omitempty"`
-	CPU        string            `yaml:"cpu,omitempty"`
-	Instances  *int              `yaml:"instances,omitempty"`
+	Name       string            `json:"name,omitempty"`
+	Path       string            `json:"path,omitempty"`
+	Buildpacks []string          `json:"buildpacks,omitempty"`
+	Docker     AppDockerImage    `json:"docker,omitempty"`
+	Env        map[string]string `json:"env,omitempty"`
+	Services   []string          `json:"services,omitempty"`
+	DiskQuota  string            `json:"disk_quota,omitempty"`
+	Memory     string            `json:"memory,omitempty"`
+	CPU        string            `json:"cpu,omitempty"`
+	Instances  *int              `json:"instances,omitempty"`
 
 	// TODO(#95): These aren't CF proper. How do we expose these in the
 	// manifest?
-	MinScale *int `yaml:"min-scale,omitempty"`
-	MaxScale *int `yaml:"max-scale,omitempty"`
+	MinScale *int `json:"min-scale,omitempty"`
+	MaxScale *int `json:"max-scale,omitempty"`
 
-	Routes      []Route `yaml:"routes,omitempty"`
-	NoRoute     *bool   `yaml:"no-route,omitempty"`
-	RandomRoute *bool   `yaml:"random-route,omitempty"`
+	Routes      []Route `json:"routes,omitempty"`
+	NoRoute     *bool   `json:"no-route,omitempty"`
+	RandomRoute *bool   `json:"random-route,omitempty"`
 
 	// HealthCheckTimeout holds the health check timeout.
 	// Note the serialized field is just timeout.
-	HealthCheckTimeout int `yaml:"timeout,omitempty"`
+	HealthCheckTimeout int `json:"timeout,omitempty"`
 
 	// HealthCheckType holds the type of health check that will be performed to
 	// determine if the app is alive. Either port or http, blank means port.
-	HealthCheckType string `yaml:"health-check-type,omitempty"`
+	HealthCheckType string `json:"health-check-type,omitempty"`
 
 	// HealthCheckHTTPEndpoint holds the HTTP endpoint that will receive the
 	// get requests to determine liveness if HealthCheckType is http.
-	HealthCheckHTTPEndpoint string `yaml:"health-check-http-endpoint,omitempty"`
+	HealthCheckHTTPEndpoint string `json:"health-check-http-endpoint,omitempty"`
 }
 
 // AppDockerImage is the struct for docker configuration.
 type AppDockerImage struct {
-	Image string `yaml:"image,omitempty"`
+	Image string `json:"image,omitempty"`
 }
 
 // Route is a route name (including hostname, domain, and path) for an application.
 type Route struct {
-	Route string `yaml:"route,omitempty"`
+	Route string `json:"route,omitempty"`
 }
 
 // Manifest is an application's configuration.
 type Manifest struct {
-	Applications []Application `yaml:"applications"`
+	Applications []Application `json:"applications"`
 }
 
 // NewFromFile creates a Manifest from a manifest file.


### PR DESCRIPTION
<!-- Include the issue number below -->
#463 

## Proposed Changes

* Use K8s YAML parser everywhere

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changed default YAML parser to be `sigs.k8s.io/yaml`
```
