### PR TITLE
Allow printing with k8s printers

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
@@ -26,7 +26,7 @@ kf app APP_NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for app
-  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|templatefile|template|jsonpath|jsonpath-file.
+  -o, --output string                 Output format. One of: go-template|go-template-file|json|jsonpath|jsonpath-file|name|template|templatefile|yaml.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
@@ -26,7 +26,7 @@ kf app APP_NAME [flags]
 ```
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
   -h, --help                          help for app
-  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file.
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|templatefile|template|jsonpath|jsonpath-file.
       --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_app.md
@@ -24,7 +24,10 @@ kf app APP_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for app
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+  -h, --help                          help for app
+  -o, --output string                 Output format. One of: json|yaml|name|template|go-template|go-template-file|templatefile|jsonpath|jsonpath-file.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	gotest.tools v2.2.0+incompatible // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
+	k8s.io/cli-runtime v0.0.0
 	k8s.io/client-go v2.0.0-alpha.0.0.20190226174127-78295b709ec6+incompatible
 	k8s.io/code-generator v0.0.0
 	k8s.io/kubernetes v1.15.0
@@ -83,3 +84,5 @@ exclude (
 	github.com/alecthomas/gometalinter v2.0.11+incompatible
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -84,5 +84,3 @@ exclude (
 	github.com/alecthomas/gometalinter v2.0.11+incompatible
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c
 )
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,7 @@ k8s.io/apiextensions-apiserver v0.0.0-20190528110544-fa58353d80f3/go.mod h1:Ixke
 k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc h1:7z9/6jKWBqkK9GI1RRB0B5fZcmkatLQ/nv8kysch24o=
 k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apiserver v0.0.0-20190528110248-2d60c3dee270/go.mod h1:6bqaTSOSJavUIXUtfaR9Os9JtTCm8ZqH2SUl2S60C4w=
+k8s.io/cli-runtime v0.0.0-20190528110732-ad79ea2fbc0f h1:109t8aUjeffUwR4lCjyQegW6pLg9cMZkC6URwH5uYhY=
 k8s.io/cli-runtime v0.0.0-20190528110732-ad79ea2fbc0f/go.mod h1:qWnH3/b8sp/l7EvlDh7ulDU3UWA4P4N1NFbEEP791tM=
 k8s.io/client-go v0.0.0-20190226174127-78295b709ec6 h1:EqyY1rPCSXiJjwNtNuj9MwuCKpbcbYyha4HTZ+EihE4=
 k8s.io/client-go v0.0.0-20190226174127-78295b709ec6/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=

--- a/pkg/kf/commands/apps/app.go
+++ b/pkg/kf/commands/apps/app.go
@@ -17,6 +17,8 @@ package apps
 import (
 	"fmt"
 	"io"
+	"sort"
+	"strings"
 
 	"github.com/google/kf/pkg/kf/apps"
 	"github.com/google/kf/pkg/kf/commands/completion"
@@ -100,6 +102,13 @@ func NewGetAppCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command
 	}
 
 	printFlags.AddFlags(cmd)
+
+	// Override output format to be sorted so our generated documents are deterministic
+	{
+		allowedFormats := printFlags.AllowedFormats()
+		sort.Strings(allowedFormats)
+		cmd.Flag("output").Usage = fmt.Sprintf("Output format. One of: %s.", strings.Join(allowedFormats, "|"))
+	}
 
 	completion.MarkArgCompletionSupported(cmd, completion.AppCompletion)
 

--- a/pkg/kf/commands/apps/app.go
+++ b/pkg/kf/commands/apps/app.go
@@ -44,6 +44,9 @@ func NewGetAppCommand(p *config.KfParams, appsClient apps.Client) *cobra.Command
 
 			appName := args[0]
 			w := cmd.OutOrStdout()
+
+			// Print status messages to stderr so stdout is syntatically valid output
+			// if the user wanted JSON, YAML, etc.
 			fmt.Fprintf(cmd.ErrOrStderr(), "Getting app %s in namespace: %s\n", appName, p.Namespace)
 
 			app, err := appsClient.Get(p.Namespace, appName)

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -29,6 +29,7 @@ import (
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/manifest"
 	. "github.com/google/kf/pkg/kf/testutil"
 )
@@ -499,10 +500,20 @@ func checkApp(
 ) {
 	// List the apps and make sure we have the correct route.
 	Logf(t, "ensuring app's route...")
-	apps := kf.Apps(ctx)
+	appJSON := kf.App(ctx, appName)
 
-	sort.Strings(apps[appName].URLs)
-	AssertEqual(t, "routes", expectedRoutes, apps[appName].URLs)
+	app := &v1alpha1.App{}
+	if err := json.Unmarshal([]byte(appJSON), app); err != nil {
+		t.Fatal("unmarshaling app:", err)
+	}
+
+	var urls []string
+	for _, route := range app.Spec.Routes {
+		urls = append(urls, route.String())
+	}
+
+	sort.Strings(urls)
+	AssertEqual(t, "routes", expectedRoutes, urls)
 	Logf(t, "done ensuring app's route.")
 
 	// Hit the app via the proxy. This makes sure the app is handling

--- a/pkg/kf/commands/apps/integration_test.go
+++ b/pkg/kf/commands/apps/integration_test.go
@@ -498,7 +498,7 @@ func checkApp(
 	proxyPort int,
 	assert func(ctx context.Context, t *testing.T, addr string),
 ) {
-	// List the apps and make sure we have the correct route.
+	// Get the app and make sure we have the correct route(s).
 	Logf(t, "ensuring app's route...")
 	appJSON := kf.App(ctx, appName)
 

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -133,8 +133,8 @@ type Kf struct {
 	binaryPath string
 }
 
-// KF returns a kf.
-func KF(t *testing.T, binaryPath string) *Kf {
+// NewKf creates a Kf for running tests with.
+func NewKf(t *testing.T, binaryPath string) *Kf {
 	return &Kf{
 		t:          t,
 		binaryPath: binaryPath,
@@ -182,7 +182,7 @@ func (k *Kf) kf(ctx context.Context, t *testing.T, cfg KfTestConfig) (KfTestOutp
 	}, errs
 }
 
-// RunSynchronous runs kf with the provided configuraiton and returns the
+// RunSynchronous runs kf with the provided configuration and returns the
 // results.
 func (k *Kf) RunSynchronous(ctx context.Context, cfg KfTestConfig) (stdout, stderr []byte, err error) {
 	k.t.Helper()
@@ -221,7 +221,7 @@ func RunKfTest(t *testing.T, test KfTest) {
 	RunIntegrationTest(t, func(ctx context.Context, t *testing.T) {
 		t.Helper()
 
-		kf := KF(t, kfPath)
+		kf := NewKf(t, kfPath)
 
 		// Create the space
 		spaceName := fmt.Sprintf("apps-integration-test-%d", time.Now().UnixNano())

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -16,7 +16,9 @@ package testutil
 
 import (
 	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -125,12 +127,26 @@ type KfTestOutput struct {
 	Done   <-chan struct{}
 }
 
-func kf(ctx context.Context, t *testing.T, binaryPath string, cfg KfTestConfig) (KfTestOutput, <-chan error) {
+// Kf provides a DSL for running integration tests.
+type Kf struct {
+	t          *testing.T
+	binaryPath string
+}
+
+// KF returns a kf.
+func KF(t *testing.T, binaryPath string) *Kf {
+	return &Kf{
+		t:          t,
+		binaryPath: binaryPath,
+	}
+}
+
+func (k *Kf) kf(ctx context.Context, t *testing.T, cfg KfTestConfig) (KfTestOutput, <-chan error) {
 	t.Helper()
 
 	Logf(t, "kf %s\n", strings.Join(cfg.Args, " "))
 
-	cmd := exec.CommandContext(ctx, binaryPath, cfg.Args...)
+	cmd := exec.CommandContext(ctx, k.binaryPath, cfg.Args...)
 	for name, value := range cfg.Env {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", name, value))
 	}
@@ -166,8 +182,26 @@ func kf(ctx context.Context, t *testing.T, binaryPath string, cfg KfTestConfig) 
 	}, errs
 }
 
-// KfInvoker will synchronously invoke `kf` with the given configuration.
-type KfInvoker func(context.Context, *testing.T, KfTestConfig) (KfTestOutput, <-chan error)
+// RunSynchronous runs kf with the provided configuraiton and returns the
+// results.
+func (k *Kf) RunSynchronous(ctx context.Context, cfg KfTestConfig) (stdout, stderr []byte, err error) {
+	k.t.Helper()
+	Logf(k.t, "kf %s\n", strings.Join(cfg.Args, " "))
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, k.binaryPath, cfg.Args...)
+	for name, value := range cfg.Env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", name, value))
+	}
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	err = cmd.Run()
+	stdout = stdoutBuf.Bytes()
+	stderr = stderrBuf.Bytes()
+	return
+}
 
 // KfTest is a test ran by RunKfTest.
 type KfTest func(ctx context.Context, t *testing.T, kf *Kf)
@@ -187,9 +221,7 @@ func RunKfTest(t *testing.T, test KfTest) {
 	RunIntegrationTest(t, func(ctx context.Context, t *testing.T) {
 		t.Helper()
 
-		kf := KF(t, func(ctx context.Context, t *testing.T, cfg KfTestConfig) (KfTestOutput, <-chan error) {
-			return kf(ctx, t, kfPath, cfg)
-		})
+		kf := KF(t, kfPath)
 
 		// Create the space
 		spaceName := fmt.Sprintf("apps-integration-test-%d", time.Now().UnixNano())
@@ -477,20 +509,6 @@ func RetryPost(
 	}
 }
 
-// Kf provides a DSL for running integration tests.
-type Kf struct {
-	t  *testing.T
-	kf KfInvoker
-}
-
-// KF returns a kf.
-func KF(t *testing.T, kf KfInvoker) *Kf {
-	return &Kf{
-		t:  t,
-		kf: kf,
-	}
-}
-
 // CreateQuota creates a resourcequota.
 func (k *Kf) CreateQuota(ctx context.Context, quotaName string, extraArgs ...string) ([]string, error) {
 	k.t.Helper()
@@ -669,6 +687,33 @@ func (k *Kf) Apps(ctx context.Context) map[string]AppInfo {
 	}
 
 	return results
+}
+
+// App gets a single app by name and returns its JSON representation.
+func (k *Kf) App(ctx context.Context, name string) json.RawMessage {
+	k.t.Helper()
+
+	Logf(k.t, "getting app %s", name)
+	defer Logf(k.t, "done getting app %s", name)
+
+	stdout, _, err := k.RunSynchronous(ctx, KfTestConfig{
+		Args: []string{
+			"app",
+			"--namespace", SpaceFromContext(ctx),
+			"-o", "json",
+			name,
+		},
+	})
+
+	if err != nil {
+		k.t.Fatal(err)
+	}
+
+	if !json.Valid(stdout) {
+		k.t.Fatal("App JSON was invalid:", string(stdout))
+	}
+
+	return stdout
 }
 
 // Delete deletes an application.

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -433,6 +433,7 @@ Module: google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19
 Module: google.golang.org/grpc v1.19.0
 Module: k8s.io/api v0.0.0-20190528110122-9ad12a4af326 (imported as k8s.io/api v0.0.0)
 Module: k8s.io/apimachinery v0.0.0-20190221084156-01f179d85dbc (imported as k8s.io/apimachinery v0.0.0)
+Module: k8s.io/cli-runtime v0.0.0-20190528110732-ad79ea2fbc0f (imported as k8s.io/cli-runtime v0.0.0)
 Module: k8s.io/client-go v0.0.0-20190226174127-78295b709ec6 (imported as k8s.io/client-go v2.0.0-alpha.0.0.20190226174127-78295b709ec6+incompatible)
 Module: k8s.io/code-generator v0.0.0-20181128191024-b1289fc74931 (imported as k8s.io/code-generator v0.0.0)
 Module: k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30


### PR DESCRIPTION
Adds the ability to print output with k8s printers and replaces the route check in integration tests to use the JSON output because the raw output is causing #653 to fail.