### PR TITLE
added support for the legacy buildpack field

### DIFF
--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -201,7 +201,7 @@ for more info.
 	return nil
 }
 
-// Buildpack joings toegether the buildpacks in order as a CSV to be compatible
+// Buildpack joins together the buildpacks in order as a CSV to be compatible
 // with buildpacks v3. If no buildpacks are specified, the legacy buildpack
 // field is checked.
 func (app *Application) Buildpack() string {

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -30,17 +30,18 @@ import (
 
 // Application is a configuration for a single 12-factor-app.
 type Application struct {
-	Name       string            `json:"name,omitempty"`
-	Path       string            `json:"path,omitempty"`
-	Buildpacks []string          `json:"buildpacks,omitempty"`
-	Stack      string            `json:"stack,omitempty"`
-	Docker     AppDockerImage    `json:"docker,omitempty"`
-	Env        map[string]string `json:"env,omitempty"`
-	Services   []string          `json:"services,omitempty"`
-	DiskQuota  string            `json:"disk_quota,omitempty"`
-	Memory     string            `json:"memory,omitempty"`
-	CPU        string            `json:"cpu,omitempty"`
-	Instances  *int              `json:"instances,omitempty"`
+	Name            string            `json:"name,omitempty"`
+	Path            string            `json:"path,omitempty"`
+	LegacyBuildpack string            `json:"buildpack,omitempty"`
+	Buildpacks      []string          `json:"buildpacks,omitempty"`
+	Stack           string            `json:"stack,omitempty"`
+	Docker          AppDockerImage    `json:"docker,omitempty"`
+	Env             map[string]string `json:"env,omitempty"`
+	Services        []string          `json:"services,omitempty"`
+	DiskQuota       string            `json:"disk_quota,omitempty"`
+	Memory          string            `json:"memory,omitempty"`
+	CPU             string            `json:"cpu,omitempty"`
+	Instances       *int              `json:"instances,omitempty"`
 
 	// TODO(#95): These aren't CF proper. How do we expose these in the
 	// manifest?
@@ -201,7 +202,12 @@ for more info.
 }
 
 // Buildpack joings toegether the buildpacks in order as a CSV to be compatible
-// with buildpacks v3.
+// with buildpacks v3. If no buildpacks are specified, the legacy buildpack
+// field is checked.
 func (app *Application) Buildpack() string {
-	return strings.Join(app.Buildpacks, ",")
+	if len(app.Buildpacks) > 0 {
+		return strings.Join(app.Buildpacks, ",")
+	}
+
+	return app.LegacyBuildpack
 }

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -63,6 +63,23 @@ applications:
 				},
 			},
 		},
+		"legacy-buildpack": {
+			fileContent: `---
+applications:
+- name: MY-APP
+  stack: cflinuxfs3
+  buildpack: java
+`,
+			expected: &manifest.Manifest{
+				Applications: []manifest.Application{
+					{
+						Name:            "MY-APP",
+						Stack:           "cflinuxfs3",
+						LegacyBuildpack: "java",
+					},
+				},
+			},
+		},
 		"docker": {
 			fileContent: `---
 applications:
@@ -188,12 +205,16 @@ func TestOverride(t *testing.T) {
 
 func ExampleApplication_Buildpack() {
 	app := manifest.Application{}
+	app.LegacyBuildpack = "hidden-legacy-buildpack"
+	fmt.Println("Legacy:", app.Buildpack())
+
 	app.Buildpacks = []string{"java"}
 	fmt.Println("One:", app.Buildpack())
 
 	app.Buildpacks = []string{"maven", "java"}
 	fmt.Println("Two:", app.Buildpack())
 
-	// Output: One: java
+	// Output: Legacy: hidden-legacy-buildpack
+	// One: java
 	// Two: maven,java
 }


### PR DESCRIPTION
<!-- Include the issue number below -->
Part of #656 

## Proposed Changes

* Added support for the legacy `buildpack` manifest field

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added support for the legacy `buildpack` manifest field
```
