### PR TITLE
removed unused generator options

### DIFF
--- a/pkg/kf/apps/client.go
+++ b/pkg/kf/apps/client.go
@@ -45,19 +45,17 @@ func NewClient(
 	return &appsClient{
 		coreClient: coreClient{
 			kclient: kclient,
-			upsertMutate: MutatorList{
-				func(app *v1alpha1.App) error {
-					// Dedupe Routes
-					// TODO(https://github.com/knative/pkg/issues/542): Route
-					// already exists and the webhook can't dedupe for us.
-					app.Spec.Routes = []v1alpha1.RouteSpecFields(
-						algorithms.Dedupe(
-							v1alpha1.RouteSpecFieldsSlice(app.Spec.Routes),
-						).(v1alpha1.RouteSpecFieldsSlice),
-					)
+			upsertMutate: func(app *v1alpha1.App) error {
+				// Dedupe Routes
+				// TODO(https://github.com/knative/pkg/issues/542): Route
+				// already exists and the webhook can't dedupe for us.
+				app.Spec.Routes = []v1alpha1.RouteSpecFields(
+					algorithms.Dedupe(
+						v1alpha1.RouteSpecFieldsSlice(app.Spec.Routes),
+					).(v1alpha1.RouteSpecFieldsSlice),
+				)
 
-					return nil
-				},
+				return nil
 			},
 		},
 		sourcesClient: sourcesClient,

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -51,19 +51,6 @@ const (
 // Predicate is a boolean function for a v1alpha1.App.
 type Predicate func(*v1alpha1.App) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *v1alpha1.App) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes v1alpha1.App.
 type Mutator func(*v1alpha1.App) error
 
@@ -117,51 +104,6 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *v1alpha1.App) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *v1alpha1.App) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *v1alpha1.App) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *v1alpha1.App) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Client
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,15 +126,15 @@ type Client interface {
 
 type coreClient struct {
 	kclient      cv1alpha1.AppsGetter
-	upsertMutate MutatorList
+	upsertMutate Mutator
 }
 
 func (core *coreClient) preprocessUpsert(obj *v1alpha1.App) error {
-	if err := core.upsertMutate.Apply(obj); err != nil {
-		return err
+	if core.upsertMutate == nil {
+		return nil
 	}
 
-	return nil
+	return core.upsertMutate(obj)
 }
 
 // Create inserts the given v1alpha1.App into the cluster.
@@ -263,10 +205,6 @@ func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
 		resp.PropagationPolicy = &propigationPolicy
 	}
 
-	if cfg.DeleteImmediately {
-		resp.GracePeriodSeconds = new(int64)
-	}
-
 	return &resp
 }
 
@@ -280,16 +218,16 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1alpha1.A
 		return nil, fmt.Errorf("couldn't list Apps: %v", err)
 	}
 
-	return List(res.Items).Filter(AllPredicate(cfg.filters...)), nil
+	if cfg.filter == nil {
+		return res.Items, nil
+	}
+
+	return List(res.Items).Filter(cfg.filter), nil
 }
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
 		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
-	}
-
-	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return

--- a/pkg/kf/apps/zz_generated.clientoptions.go
+++ b/pkg/kf/apps/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 

--- a/pkg/kf/commands/routes/delete_route.go
+++ b/pkg/kf/commands/routes/delete_route.go
@@ -63,14 +63,12 @@ func NewDeleteRouteCommand(
 			// routes with the proper labels first, then use their apps.
 			apps, err := a.List(
 				p.Namespace,
-				apps.WithListFilters([]apps.Predicate{
-					func(app *v1alpha1.App) bool {
-						return algorithms.Search(
-							0,
-							v1alpha1.RouteSpecFieldsSlice{route},
-							v1alpha1.RouteSpecFieldsSlice(app.Spec.Routes),
-						)
-					},
+				apps.WithListFilter(func(app *v1alpha1.App) bool {
+					return algorithms.Search(
+						0,
+						v1alpha1.RouteSpecFieldsSlice{route},
+						v1alpha1.RouteSpecFieldsSlice(app.Spec.Routes),
+					)
 				}),
 			)
 			if err != nil {

--- a/pkg/kf/internal/tools/clientgen/common-options.yml
+++ b/pkg/kf/internal/tools/clientgen/common-options.yml
@@ -29,17 +29,11 @@ configs:
   - name: ForegroundDeletion
     type: bool
     description: If the resource should be deleted in the foreground.
-  - name: DeleteImmediately
-    type: bool
-    description: If the resource should be deleted immediately.
 - name: List
   options:
-  - name: labelSelector
-    type: "map[string]string"
-    description: A label selector.
   - name: fieldSelector
     type: "map[string]string"
     description: A selector on the resource's fields.
-  - name: filters
-    type: "[]Predicate"
-    description: Additional filters to apply.
+  - name: filter
+    type: "Predicate"
+    description: Filter to apply.

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -51,19 +51,6 @@ const (
 // Predicate is a boolean function for a v1.Secret.
 type Predicate func(*v1.Secret) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *v1.Secret) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes v1.Secret.
 type Mutator func(*v1.Secret) error
 
@@ -117,51 +104,6 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *v1.Secret) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *v1.Secret) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *v1.Secret) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *v1.Secret) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Client
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,15 +126,15 @@ type Client interface {
 
 type coreClient struct {
 	kclient      cv1.SecretsGetter
-	upsertMutate MutatorList
+	upsertMutate Mutator
 }
 
 func (core *coreClient) preprocessUpsert(obj *v1.Secret) error {
-	if err := core.upsertMutate.Apply(obj); err != nil {
-		return err
+	if core.upsertMutate == nil {
+		return nil
 	}
 
-	return nil
+	return core.upsertMutate(obj)
 }
 
 // Create inserts the given v1.Secret into the cluster.
@@ -263,10 +205,6 @@ func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
 		resp.PropagationPolicy = &propigationPolicy
 	}
 
-	if cfg.DeleteImmediately {
-		resp.GracePeriodSeconds = new(int64)
-	}
-
 	return &resp
 }
 
@@ -280,16 +218,16 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1.Secret,
 		return nil, fmt.Errorf("couldn't list OperatorConfigs: %v", err)
 	}
 
-	return List(res.Items).Filter(AllPredicate(cfg.filters...)), nil
+	if cfg.filter == nil {
+		return res.Items, nil
+	}
+
+	return List(res.Items).Filter(cfg.filter), nil
 }
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
 		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
-	}
-
-	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.clientoptions.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 

--- a/pkg/kf/internal/tools/clientgen/tmplfunctional.go
+++ b/pkg/kf/internal/tools/clientgen/tmplfunctional.go
@@ -37,19 +37,6 @@ const (
 // Predicate is a boolean function for a {{.Type}}.
 type Predicate func(*{{.Type}}) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *{{.Type}}) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes {{.Type}}.
 type Mutator func(*{{.Type}}) error
 
@@ -103,48 +90,4 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *{{.Type}}) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *{{.Type}}) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *{{.Type}}) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *{{.Type}}) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
 `))

--- a/pkg/kf/routeclaims/client.go
+++ b/pkg/kf/routeclaims/client.go
@@ -25,7 +25,6 @@ type ClientExtension interface {
 // NewClient creates a new RouteClaim client.
 func NewClient(kclient kf.KfV1alpha1Interface) Client {
 	return &coreClient{
-		kclient:      kclient,
-		upsertMutate: MutatorList{},
+		kclient: kclient,
 	}
 }

--- a/pkg/kf/routeclaims/zz_generated.client.go
+++ b/pkg/kf/routeclaims/zz_generated.client.go
@@ -51,19 +51,6 @@ const (
 // Predicate is a boolean function for a v1alpha1.RouteClaim.
 type Predicate func(*v1alpha1.RouteClaim) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *v1alpha1.RouteClaim) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes v1alpha1.RouteClaim.
 type Mutator func(*v1alpha1.RouteClaim) error
 
@@ -117,51 +104,6 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *v1alpha1.RouteClaim) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *v1alpha1.RouteClaim) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *v1alpha1.RouteClaim) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *v1alpha1.RouteClaim) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Client
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,15 +126,15 @@ type Client interface {
 
 type coreClient struct {
 	kclient      cv1alpha1.RouteClaimsGetter
-	upsertMutate MutatorList
+	upsertMutate Mutator
 }
 
 func (core *coreClient) preprocessUpsert(obj *v1alpha1.RouteClaim) error {
-	if err := core.upsertMutate.Apply(obj); err != nil {
-		return err
+	if core.upsertMutate == nil {
+		return nil
 	}
 
-	return nil
+	return core.upsertMutate(obj)
 }
 
 // Create inserts the given v1alpha1.RouteClaim into the cluster.
@@ -263,10 +205,6 @@ func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
 		resp.PropagationPolicy = &propigationPolicy
 	}
 
-	if cfg.DeleteImmediately {
-		resp.GracePeriodSeconds = new(int64)
-	}
-
 	return &resp
 }
 
@@ -280,16 +218,16 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1alpha1.R
 		return nil, fmt.Errorf("couldn't list RouteClaims: %v", err)
 	}
 
-	return List(res.Items).Filter(AllPredicate(cfg.filters...)), nil
+	if cfg.filter == nil {
+		return res.Items, nil
+	}
+
+	return List(res.Items).Filter(cfg.filter), nil
 }
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
 		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
-	}
-
-	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return

--- a/pkg/kf/routeclaims/zz_generated.clientoptions.go
+++ b/pkg/kf/routeclaims/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 

--- a/pkg/kf/routes/client.go
+++ b/pkg/kf/routes/client.go
@@ -25,7 +25,6 @@ type ClientExtension interface {
 // NewClient creates a new route client.
 func NewClient(kclient kf.KfV1alpha1Interface) Client {
 	return &coreClient{
-		kclient:      kclient,
-		upsertMutate: MutatorList{},
+		kclient: kclient,
 	}
 }

--- a/pkg/kf/routes/zz_generated.clientoptions.go
+++ b/pkg/kf/routes/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 

--- a/pkg/kf/sources/client.go
+++ b/pkg/kf/sources/client.go
@@ -44,8 +44,7 @@ type sourcesClient struct {
 func NewClient(kclient cv1alpha1.SourcesGetter, buildTailer BuildTailer) Client {
 	return &sourcesClient{
 		coreClient: coreClient{
-			kclient:      kclient,
-			upsertMutate: MutatorList{},
+			kclient: kclient,
 		},
 		buildTailer: buildTailer,
 	}

--- a/pkg/kf/sources/zz_generated.client.go
+++ b/pkg/kf/sources/zz_generated.client.go
@@ -51,19 +51,6 @@ const (
 // Predicate is a boolean function for a v1alpha1.Source.
 type Predicate func(*v1alpha1.Source) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *v1alpha1.Source) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes v1alpha1.Source.
 type Mutator func(*v1alpha1.Source) error
 
@@ -117,51 +104,6 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *v1alpha1.Source) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *v1alpha1.Source) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *v1alpha1.Source) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *v1alpha1.Source) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Client
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,15 +126,15 @@ type Client interface {
 
 type coreClient struct {
 	kclient      cv1alpha1.SourcesGetter
-	upsertMutate MutatorList
+	upsertMutate Mutator
 }
 
 func (core *coreClient) preprocessUpsert(obj *v1alpha1.Source) error {
-	if err := core.upsertMutate.Apply(obj); err != nil {
-		return err
+	if core.upsertMutate == nil {
+		return nil
 	}
 
-	return nil
+	return core.upsertMutate(obj)
 }
 
 // Create inserts the given v1alpha1.Source into the cluster.
@@ -263,10 +205,6 @@ func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
 		resp.PropagationPolicy = &propigationPolicy
 	}
 
-	if cfg.DeleteImmediately {
-		resp.GracePeriodSeconds = new(int64)
-	}
-
 	return &resp
 }
 
@@ -280,16 +218,16 @@ func (core *coreClient) List(namespace string, opts ...ListOption) ([]v1alpha1.S
 		return nil, fmt.Errorf("couldn't list Builds: %v", err)
 	}
 
-	return List(res.Items).Filter(AllPredicate(cfg.filters...)), nil
+	if cfg.filter == nil {
+		return res.Items, nil
+	}
+
+	return List(res.Items).Filter(cfg.filter), nil
 }
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
 		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
-	}
-
-	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return

--- a/pkg/kf/sources/zz_generated.clientoptions.go
+++ b/pkg/kf/sources/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 

--- a/pkg/kf/spaces/client.go
+++ b/pkg/kf/spaces/client.go
@@ -26,8 +26,7 @@ type ClientExtension interface {
 // NewClient creates a new space client.
 func NewClient(kclient cv1alpha1.SpacesGetter) Client {
 	return &coreClient{
-		kclient:      kclient,
-		upsertMutate: MutatorList{},
+		kclient: kclient,
 	}
 }
 

--- a/pkg/kf/spaces/zz_generated.client.go
+++ b/pkg/kf/spaces/zz_generated.client.go
@@ -51,19 +51,6 @@ const (
 // Predicate is a boolean function for a v1alpha1.Space.
 type Predicate func(*v1alpha1.Space) bool
 
-// AllPredicate is a predicate that passes if all children pass.
-func AllPredicate(children ...Predicate) Predicate {
-	return func(obj *v1alpha1.Space) bool {
-		for _, filter := range children {
-			if !filter(obj) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
 // Mutator is a function that changes v1alpha1.Space.
 type Mutator func(*v1alpha1.Space) error
 
@@ -117,51 +104,6 @@ func (list List) Filter(filter Predicate) (out List) {
 	return
 }
 
-// MutatorList is a list of mutators.
-type MutatorList []Mutator
-
-// Apply passes the given value to each of the mutators in the list failing if
-// one of them returns an error.
-func (list MutatorList) Apply(svc *v1alpha1.Space) error {
-	for _, mutator := range list {
-		if err := mutator(svc); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// LabelSetMutator creates a mutator that sets the given labels on the object.
-func LabelSetMutator(labels map[string]string) Mutator {
-	return func(obj *v1alpha1.Space) error {
-		if obj.Labels == nil {
-			obj.Labels = make(map[string]string)
-		}
-
-		for key, value := range labels {
-			obj.Labels[key] = value
-		}
-
-		return nil
-	}
-}
-
-// LabelEqualsPredicate validates that the given label exists exactly on the object.
-func LabelEqualsPredicate(key, value string) Predicate {
-	return func(obj *v1alpha1.Space) bool {
-		return obj.Labels[key] == value
-	}
-}
-
-// LabelsContainsPredicate validates that the given label exists on the object.
-func LabelsContainsPredicate(key string) Predicate {
-	return func(obj *v1alpha1.Space) bool {
-		_, ok := obj.Labels[key]
-		return ok
-	}
-}
-
 ////////////////////////////////////////////////////////////////////////////////
 // Client
 ////////////////////////////////////////////////////////////////////////////////
@@ -184,15 +126,15 @@ type Client interface {
 
 type coreClient struct {
 	kclient      cv1alpha1.SpacesGetter
-	upsertMutate MutatorList
+	upsertMutate Mutator
 }
 
 func (core *coreClient) preprocessUpsert(obj *v1alpha1.Space) error {
-	if err := core.upsertMutate.Apply(obj); err != nil {
-		return err
+	if core.upsertMutate == nil {
+		return nil
 	}
 
-	return nil
+	return core.upsertMutate(obj)
 }
 
 // Create inserts the given v1alpha1.Space into the cluster.
@@ -263,10 +205,6 @@ func (cfg deleteConfig) ToDeleteOptions() *metav1.DeleteOptions {
 		resp.PropagationPolicy = &propigationPolicy
 	}
 
-	if cfg.DeleteImmediately {
-		resp.GracePeriodSeconds = new(int64)
-	}
-
 	return &resp
 }
 
@@ -280,16 +218,16 @@ func (core *coreClient) List(opts ...ListOption) ([]v1alpha1.Space, error) {
 		return nil, fmt.Errorf("couldn't list Spaces: %v", err)
 	}
 
-	return List(res.Items).Filter(AllPredicate(cfg.filters...)), nil
+	if cfg.filter == nil {
+		return res.Items, nil
+	}
+
+	return List(res.Items).Filter(cfg.filter), nil
 }
 
 func (cfg listConfig) ToListOptions() (resp metav1.ListOptions) {
 	if cfg.fieldSelector != nil {
 		resp.FieldSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.fieldSelector))
-	}
-
-	if cfg.labelSelector != nil {
-		resp.LabelSelector = metav1.FormatLabelSelector(metav1.SetAsLabelSelector(cfg.labelSelector))
 	}
 
 	return

--- a/pkg/kf/spaces/zz_generated.clientoptions.go
+++ b/pkg/kf/spaces/zz_generated.clientoptions.go
@@ -119,8 +119,6 @@ func GetOptionDefaults() GetOptions {
 }
 
 type deleteConfig struct {
-	// DeleteImmediately is If the resource should be deleted immediately.
-	DeleteImmediately bool
 	// ForegroundDeletion is If the resource should be deleted in the foreground.
 	ForegroundDeletion bool
 }
@@ -151,23 +149,10 @@ func (opts DeleteOptions) Extend(other DeleteOptions) DeleteOptions {
 	return out
 }
 
-// DeleteImmediately returns the last set value for DeleteImmediately or the empty value
-// if not set.
-func (opts DeleteOptions) DeleteImmediately() bool {
-	return opts.toConfig().DeleteImmediately
-}
-
 // ForegroundDeletion returns the last set value for ForegroundDeletion or the empty value
 // if not set.
 func (opts DeleteOptions) ForegroundDeletion() bool {
 	return opts.toConfig().ForegroundDeletion
-}
-
-// WithDeleteDeleteImmediately creates an Option that sets If the resource should be deleted immediately.
-func WithDeleteDeleteImmediately(val bool) DeleteOption {
-	return func(cfg *deleteConfig) {
-		cfg.DeleteImmediately = val
-	}
 }
 
 // WithDeleteForegroundDeletion creates an Option that sets If the resource should be deleted in the foreground.
@@ -185,10 +170,8 @@ func DeleteOptionDefaults() DeleteOptions {
 type listConfig struct {
 	// fieldSelector is A selector on the resource's fields.
 	fieldSelector map[string]string
-	// filters is Additional filters to apply.
-	filters []Predicate
-	// labelSelector is A label selector.
-	labelSelector map[string]string
+	// filter is Filter to apply.
+	filter Predicate
 }
 
 // ListOption is a single option for configuring a listConfig
@@ -223,16 +206,10 @@ func (opts ListOptions) fieldSelector() map[string]string {
 	return opts.toConfig().fieldSelector
 }
 
-// filters returns the last set value for filters or the empty value
+// filter returns the last set value for filter or the empty value
 // if not set.
-func (opts ListOptions) filters() []Predicate {
-	return opts.toConfig().filters
-}
-
-// labelSelector returns the last set value for labelSelector or the empty value
-// if not set.
-func (opts ListOptions) labelSelector() map[string]string {
-	return opts.toConfig().labelSelector
+func (opts ListOptions) filter() Predicate {
+	return opts.toConfig().filter
 }
 
 // WithListFieldSelector creates an Option that sets A selector on the resource's fields.
@@ -242,17 +219,10 @@ func WithListFieldSelector(val map[string]string) ListOption {
 	}
 }
 
-// WithListFilters creates an Option that sets Additional filters to apply.
-func WithListFilters(val []Predicate) ListOption {
+// WithListFilter creates an Option that sets Filter to apply.
+func WithListFilter(val Predicate) ListOption {
 	return func(cfg *listConfig) {
-		cfg.filters = val
-	}
-}
-
-// WithListLabelSelector creates an Option that sets A label selector.
-func WithListLabelSelector(val map[string]string) ListOption {
-	return func(cfg *listConfig) {
-		cfg.labelSelector = val
+		cfg.filter = val
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Removed unused generation options that were created for when we were doing things client-side. This is preliminary cleanup before I add stuff for #599 

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
