### PR TITLE
moved unofficial fields out of manifest proper

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_push.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_push.md
@@ -32,9 +32,9 @@ kf push APP_NAME [flags]
   -c, --command string              Startup command for the app, this overrides the default command specified by the web process.
       --container-registry string   Container registry to push sources to. Required for buildpack builds not targeting a Kf space.
       --docker-image string         Docker image to deploy.
+      --enable-http2                Setup the container to allow application to use HTTP2 and gRPC.
       --entrypoint string           Overwrite the default entrypoint of the image. Can't be used with the command flag.
   -e, --env stringArray             Set environment variables. Multiple can be set by using the flag multiple times (e.g., NAME=VALUE).
-      --grpc                        Setup the container to allow application to use gRPC.
   -u, --health-check-type string    Application health check type (http or port, default: port)
   -h, --help                        help for push
   -i, --instances int               Number of instances of the app to run (default: 1) (default -1)

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -83,7 +83,7 @@ func TestPushCommand(t *testing.T) {
 			args: []string{
 				"example-app",
 				"--buildpack", "some-buildpack",
-				"--grpc",
+				"--enable-http2",
 				"--env", "env1=val1",
 				"-e", "env2=val2",
 				"--container-registry", "some-reg.io",

--- a/pkg/kf/commands/root_test.go
+++ b/pkg/kf/commands/root_test.go
@@ -77,7 +77,7 @@ func checkCommandStyle(t *testing.T, cmd *cobra.Command) {
 
 			cmd.LocalFlags().VisitAll(func(f *flag.Flag) {
 				t.Run("flag:"+f.Name, func(t *testing.T) {
-					testutil.AssertRegexp(t, "name", "^[a-z][a-z-]+$", f.Name)
+					testutil.AssertRegexp(t, "name", "^[a-z][a-z0-9-]+$", f.Name)
 
 					if !startsWithUpper(f.Usage) {
 						t.Errorf("usage must start with an upper-case character, got: %s", f.Usage)

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -22,10 +22,12 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/google/kf/pkg/internal/envutil"
 	"github.com/imdario/mergo"
+	"knative.dev/pkg/kmp"
 	"sigs.k8s.io/yaml"
 )
 
@@ -41,18 +43,10 @@ type Application struct {
 	Services        []string          `json:"services,omitempty"`
 	DiskQuota       string            `json:"disk_quota,omitempty"`
 	Memory          string            `json:"memory,omitempty"`
-	CPU             string            `json:"cpu,omitempty"`
 	Instances       *int              `json:"instances,omitempty"`
 
 	// Container command configuration
-	Entrypoint string   `json:"entrypoint,omitempty"`
-	Args       []string `json:"args,omitempty"`
-	Command    string   `json:"command,omitempty"`
-
-	// TODO(#95): These aren't CF proper. How do we expose these in the
-	// manifest?
-	MinScale *int `json:"min-scale,omitempty"`
-	MaxScale *int `json:"max-scale,omitempty"`
+	Command string `json:"command,omitempty"`
 
 	Routes      []Route `json:"routes,omitempty"`
 	NoRoute     *bool   `json:"no-route,omitempty"`
@@ -69,6 +63,25 @@ type Application struct {
 	// HealthCheckHTTPEndpoint holds the HTTP endpoint that will receive the
 	// get requests to determine liveness if HealthCheckType is http.
 	HealthCheckHTTPEndpoint string `json:"health-check-http-endpoint,omitempty"`
+
+	// KfApplicationExtension holds fields that aren't officially in cf
+	KfApplicationExtension `json:",inline"`
+}
+
+// KfApplicationExtension holds fields that aren't officially in cf
+type KfApplicationExtension struct {
+	// TODO(#95): These aren't CF proper. How do we expose these in the manifest?
+
+	CPU string `json:"cpu,omitempty"`
+
+	MinScale *int  `json:"min-scale,omitempty"`
+	MaxScale *int  `json:"max-scale,omitempty"`
+	NoStart  *bool `json:"no-start,omitempty"`
+
+	EnableHTTP2 *bool `json:"enable-http2,omitempty"`
+
+	Entrypoint string   `json:"entrypoint,omitempty"`
+	Args       []string `json:"args,omitempty"`
 }
 
 // AppDockerImage is the struct for docker configuration.
@@ -164,19 +177,6 @@ func (m Manifest) App(name string) (*Application, error) {
 // Override overrides values using corresponding non-empty values from overrides.
 // Environment variables are extended with override taking priority.
 func (app *Application) Override(overrides *Application) error {
-
-	// TODO(#95) MinScale and MaxScale aren't CF proper and therefore may not
-	// stick around. We should warn the user, however there is no reason to
-	// not support it for now.
-	if app.MinScale != nil || app.MaxScale != nil {
-		fmt.Fprintf(os.Stderr, `
-WARNING! min-scale and max-scale are not normal CF fields in a manifest.
-Therefore they are subject to change.
-Please follow the thread in https://github.com/google/kf/issues/95
-for more info.
-`)
-	}
-
 	appEnv := envutil.MapToEnvVars(app.Env)
 	overrideEnv := envutil.MapToEnvVars(overrides.Env)
 	combined := append(appEnv, overrideEnv...)
@@ -206,6 +206,28 @@ for more info.
 
 	if err := app.Validate(context.Background()); err.Error() != "" {
 		return err
+	}
+
+	return nil
+}
+
+// WarnUnofficialFields prints a message to the given writer if the user is
+// using any kf specific fields in their configuration.
+func (app *Application) WarnUnofficialFields(w io.Writer) error {
+	// TODO(#95) Warn the user about using unofficial fields that are subject to
+	// change.
+	unofficialFields, err := kmp.CompareSetFields(app.KfApplicationExtension, KfApplicationExtension{})
+	if err != nil {
+		return err
+	}
+
+	if len(unofficialFields) != 0 {
+		sort.Strings(unofficialFields)
+
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, `WARNING! The field(s) %v are Kf extensions to the manifest and are subject to change.
+See https://github.com/google/kf/issues/95 for more info.`, unofficialFields)
+		fmt.Fprintln(w)
 	}
 
 	return nil

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -225,8 +225,8 @@ func (app *Application) WarnUnofficialFields(w io.Writer) error {
 		sort.Strings(unofficialFields)
 
 		fmt.Fprintln(w)
-		fmt.Fprintf(w, `WARNING! The field(s) %v are Kf extensions to the manifest and are subject to change.
-See https://github.com/google/kf/issues/95 for more info.`, unofficialFields)
+		fmt.Fprintf(w, "WARNING! The field(s) %v are Kf-specific manifest extensions and may change.\n", unofficialFields)
+		fmt.Fprintln(w, "See https://github.com/google/kf/issues/95 for more info.")
 		fmt.Fprintln(w)
 	}
 

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -311,6 +311,6 @@ func ExampleApplication_WarnUnofficialFields() {
 	app.WarnUnofficialFields(os.Stdout)
 
 	// Output:
-	// WARNING! The field(s) [enable-http2 no-start] are Kf extensions to the manifest and are subject to change.
+	// WARNING! The field(s) [enable-http2 no-start] are Kf-specific manifest extensions and may change.
 	// See https://github.com/google/kf/issues/95 for more info.
 }

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/kf/pkg/kf/manifest"
 	"github.com/google/kf/pkg/kf/testutil"
+	"knative.dev/pkg/ptr"
 )
 
 func TestNewFromReader(t *testing.T) {
@@ -123,9 +124,11 @@ applications:
 			expected: &manifest.Manifest{
 				Applications: []manifest.Application{
 					{
-						Name:       "CUSTOM_START",
-						Entrypoint: "python",
-						Args:       []string{"-m", "SimpleHTTPServer"},
+						Name: "CUSTOM_START",
+						KfApplicationExtension: manifest.KfApplicationExtension{
+							Entrypoint: "python",
+							Args:       []string{"-m", "SimpleHTTPServer"},
+						},
 					},
 				},
 			},
@@ -223,6 +226,16 @@ func TestOverride(t *testing.T) {
 			override: manifest.Application{Buildpacks: []string{"node", "npm"}},
 			expected: manifest.Application{Buildpacks: []string{"node", "npm"}},
 		},
+		"no start, no override": {
+			base:     manifest.Application{KfApplicationExtension: manifest.KfApplicationExtension{NoStart: ptr.Bool(true)}},
+			override: manifest.Application{},
+			expected: manifest.Application{KfApplicationExtension: manifest.KfApplicationExtension{NoStart: ptr.Bool(true)}},
+		},
+		"no start, override": {
+			base:     manifest.Application{KfApplicationExtension: manifest.KfApplicationExtension{NoStart: ptr.Bool(false)}},
+			override: manifest.Application{KfApplicationExtension: manifest.KfApplicationExtension{NoStart: ptr.Bool(true)}},
+			expected: manifest.Application{KfApplicationExtension: manifest.KfApplicationExtension{NoStart: ptr.Bool(true)}},
+		},
 	}
 
 	for tn, tc := range cases {
@@ -261,7 +274,9 @@ func ExampleApplication_CommandArgs() {
 	fmt.Printf("Command: %v\n", app.CommandArgs())
 
 	app = manifest.Application{
-		Args: []string{"-m", "SimpleHTTPServer"},
+		KfApplicationExtension: manifest.KfApplicationExtension{
+			Args: []string{"-m", "SimpleHTTPServer"},
+		},
 	}
 	fmt.Printf("Args: %v\n", app.CommandArgs())
 
@@ -275,10 +290,27 @@ func ExampleApplication_CommandEntrypoint() {
 	fmt.Printf("Blank: %v\n", app.CommandEntrypoint())
 
 	app = manifest.Application{
-		Entrypoint: "python",
+		KfApplicationExtension: manifest.KfApplicationExtension{
+			Entrypoint: "python",
+		},
 	}
 	fmt.Printf("Entrypoint: %v\n", app.CommandEntrypoint())
 
 	// Output: Blank: []
 	// Entrypoint: [python]
+}
+
+func ExampleApplication_WarnUnofficialFields() {
+	app := manifest.Application{
+		KfApplicationExtension: manifest.KfApplicationExtension{
+			EnableHTTP2: ptr.Bool(true),
+			NoStart:     ptr.Bool(false),
+		},
+	}
+
+	app.WarnUnofficialFields(os.Stdout)
+
+	// Output:
+	// WARNING! The field(s) [enable-http2 no-start] are Kf extensions to the manifest and are subject to change.
+	// See https://github.com/google/kf/issues/95 for more info.
 }

--- a/pkg/kf/manifest/manifest_validation_test.go
+++ b/pkg/kf/manifest/manifest_validation_test.go
@@ -32,21 +32,27 @@ func TestApplication_Validation(t *testing.T) {
 		},
 		"entrypoint and args": {
 			spec: Application{
-				Entrypoint: "python",
-				Args:       []string{"-m", "SimpleHTTPServer"},
+				KfApplicationExtension: KfApplicationExtension{
+					Args:       []string{"-m", "SimpleHTTPServer"},
+					Entrypoint: "python",
+				},
 			},
 		},
 		"command and args": {
 			spec: Application{
 				Command: "python",
-				Args:    []string{"-m", "SimpleHTTPServer"},
+				KfApplicationExtension: KfApplicationExtension{
+					Args: []string{"-m", "SimpleHTTPServer"},
+				},
 			},
 			want: apis.ErrMultipleOneOf("args", "command"),
 		},
 		"entrypoint and command": {
 			spec: Application{
-				Entrypoint: "/lifecycle/launcher",
-				Command:    "python",
+				KfApplicationExtension: KfApplicationExtension{
+					Entrypoint: "/lifecycle/launcher",
+				},
+				Command: "python",
 			},
 			want: apis.ErrMultipleOneOf("entrypoint", "command"),
 		},

--- a/pkg/kf/services/fake/fake_client.go
+++ b/pkg/kf/services/fake/fake_client.go
@@ -195,6 +195,21 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3, arg4)
 }
 
+// WaitForDeletion mocks base method
+func (m *FakeClient) WaitForDeletion(arg0 context.Context, arg1, arg2 string, arg3 time.Duration) (*v1beta1.ServiceInstance, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForDeletion", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1beta1.ServiceInstance)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForDeletion indicates an expected call of WaitForDeletion
+func (mr *FakeClientMockRecorder) WaitForDeletion(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForDeletion", reflect.TypeOf((*FakeClient)(nil).WaitForDeletion), arg0, arg1, arg2, arg3)
+}
+
 // WaitForE mocks base method
 func (m *FakeClient) WaitForE(arg0 context.Context, arg1, arg2 string, arg3 time.Duration, arg4 services.ConditionFuncE) (*v1beta1.ServiceInstance, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kf/services/zz_generated.client.go
+++ b/pkg/kf/services/zz_generated.client.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"time"
 
+	"knative.dev/pkg/kmp"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/kmp"
 )
 
 // User defined imports
@@ -119,6 +120,9 @@ type Client interface {
 	Upsert(namespace string, newObj *v1beta1.ServiceInstance, merge Merger) (*v1beta1.ServiceInstance, error)
 	WaitFor(ctx context.Context, namespace string, name string, interval time.Duration, condition Predicate) (*v1beta1.ServiceInstance, error)
 	WaitForE(ctx context.Context, namespace string, name string, interval time.Duration, condition ConditionFuncE) (*v1beta1.ServiceInstance, error)
+
+	// Utility functions
+	WaitForDeletion(ctx context.Context, namespace string, name string, interval time.Duration) (*v1beta1.ServiceInstance, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -317,4 +321,9 @@ func wrapPredicate(condition Predicate) ConditionFuncE {
 
 		return condition(obj), nil
 	}
+}
+
+// WaitForDeletion is a utility function that combines WaitForE with ConditionDeleted.
+func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, name string, interval time.Duration) (instance *v1beta1.ServiceInstance, err error) {
+	return core.WaitForE(ctx, namespace, name, interval, ConditionDeleted)
 }


### PR DESCRIPTION
<!-- Include the issue number below -->
Related to #95

## Proposed Changes

* Fixed the warning about unofficial fields to show all Kf added fields.
* Added manifest fields for HTTP2 and no-start to match CLI flags so an app can be (almost) entirely declarative.
* Changed the `--grpc` flag to `--enable-http2` to reflect what's actually happening in Knative Serving.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed the warning about unofficial fields to show all Kf added fields.
Added manifest fields for HTTP2 and no-start to match CLI flags so an app can be (almost) entirely declarative.
Changed the `--grpc` flag to `--enable-http2` to reflect what's actually happening in Knative Serving.
```
