### PR TITLE
ci: Improve code generation script

### DIFF
--- a/ci/concourse/pipelines/pr-pipeline.yml
+++ b/ci/concourse/pipelines/pr-pipeline.yml
@@ -112,11 +112,6 @@ jobs:
         - |
           hack/check-linters.sh
           hack/check-go-generate.sh
-          mkdir -p $(go env GOPATH)/src/github.com/google
-          olddir=$(pwd)
-          cd $(go env GOPATH)/src/github.com/google
-          ln -s $olddir kf
-          cd $olddir
           hack/check-code-generator.sh
     on_failure: *on_failure
 - name: build


### PR DESCRIPTION
This change moves env setup code required to run check-code-generator.sh
from Concourse pipeline task into check-code-generator.sh itself. This
allows the script to be run from other pipelines without replicating the
env setup code.