### PR TITLE
changed manifest to produce sub-types

### DIFF
--- a/pkg/kf/apps/kfapp.go
+++ b/pkg/kf/apps/kfapp.go
@@ -153,58 +153,19 @@ func (k *KfApp) DeleteEnvVars(names []string) {
 	k.SetEnvVars(envutil.RemoveEnvVars(names, k.GetEnvVars()))
 }
 
-// GetMemory gets memory request for the app.
-func (k *KfApp) GetMemory() *resource.Quantity {
+// SetResourceRequests sets the resource request list for the container
+func (k *KfApp) SetResourceRequests(requests v1.ResourceList) {
+	container := k.getOrCreateContainer()
+	container.Resources.Requests = requests
+}
+
+// GetResourceRequests gets the resource request list for the container
+func (k *KfApp) GetResourceRequests() v1.ResourceList {
 	if container := k.getContainerOrNil(); container != nil {
-		if resourceRequests := container.Resources.Requests; resourceRequests != nil {
-			memory, exists := resourceRequests[corev1.ResourceMemory]
-			if exists {
-				return &memory
-			}
-		}
+		return container.Resources.Requests
 	}
+
 	return nil
-}
-
-// SetMemory sets memory request for the app.
-func (k *KfApp) SetMemory(memory *resource.Quantity) {
-	k.setResourceRequest(corev1.ResourceMemory, memory)
-}
-
-// GetStorage gets disk storage request for the app.
-func (k *KfApp) GetStorage() *resource.Quantity {
-	if container := k.getContainerOrNil(); container != nil {
-		if resourceRequests := container.Resources.Requests; resourceRequests != nil {
-			storage, exists := resourceRequests[corev1.ResourceEphemeralStorage]
-			if exists {
-				return &storage
-			}
-		}
-	}
-	return nil
-}
-
-// SetStorage sets disk storage request for the app.
-func (k *KfApp) SetStorage(storage *resource.Quantity) {
-	k.setResourceRequest(corev1.ResourceEphemeralStorage, storage)
-}
-
-// GetCPU gets CPU request for the app.
-func (k *KfApp) GetCPU() *resource.Quantity {
-	if container := k.getContainerOrNil(); container != nil {
-		if resourceRequests := container.Resources.Requests; resourceRequests != nil {
-			cpu, exists := resourceRequests[corev1.ResourceCPU]
-			if exists {
-				return &cpu
-			}
-		}
-	}
-	return nil
-}
-
-// SetCPU sets CPU request for the app.
-func (k *KfApp) SetCPU(cpu *resource.Quantity) {
-	k.setResourceRequest(corev1.ResourceCPU, cpu)
 }
 
 // Set a resource request for an app. Request amount can be cleared by passing in nil

--- a/pkg/kf/apps/kfapp_test.go
+++ b/pkg/kf/apps/kfapp_test.go
@@ -198,37 +198,23 @@ func ExampleKfApp_GetHealthCheck() {
 	//   Endpoint:  /healthz
 }
 
-func ExampleKfApp_GetMemory() {
+func ExampleKfApp_GetResourceRequests() {
+	requests := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("1Gi"),
+	}
+
 	myApp := NewKfApp()
-	mem := resource.MustParse("1Gi")
-	myApp.SetMemory(&mem)
+	myApp.SetResourceRequests(requests)
 
-	getMem := myApp.GetMemory()
-	fmt.Println((*getMem).String())
+	out := myApp.GetResourceRequests()
+	for _, key := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		qty := out[key]
+		fmt.Println(key, "=", qty.String())
+	}
 
-	// Output: 1Gi
-}
-
-func ExampleKfApp_GetStorage() {
-	myApp := NewKfApp()
-	storage := resource.MustParse("2Gi")
-	myApp.SetStorage(&storage)
-
-	getStorage := myApp.GetStorage()
-	fmt.Println((*getStorage).String())
-
-	// Output: 2Gi
-}
-
-func ExampleKfApp_GetCPU() {
-	myApp := NewKfApp()
-	cpu := resource.MustParse("100m")
-	myApp.SetCPU(&cpu)
-
-	getCPU := myApp.GetCPU()
-	fmt.Println((*getCPU).String())
-
-	// Output: 100m
+	// Output: cpu = 100m
+	// memory = 1Gi
 }
 
 func ExampleKfApp_GetClusterURL() {

--- a/pkg/kf/apps/push-options.yml
+++ b/pkg/kf/apps/push-options.yml
@@ -1,7 +1,7 @@
 # This file contains options for option-builder.go
 ---
 package: apps
-imports: {"io":"", "os":"", "k8s.io/api/core/v1":"corev1","github.com/google/kf/pkg/apis/kf/v1alpha1":"", "k8s.io/apimachinery/pkg/api/resource":""}
+imports: {"io":"", "os":"", "k8s.io/api/core/v1":"corev1","github.com/google/kf/pkg/apis/kf/v1alpha1":""}
 common:
 - name: Namespace
   type: string
@@ -32,18 +32,12 @@ configs:
   - name: Grpc
     type: bool
     description: setup the ports for the container to allow gRPC to work
-  - name: MinScale
-    type: "*int"
-    description: the lower scale bound
-  - name: MaxScale
-    type: "*int"
-    description: the upper scale bound
-  - name: ExactScale
-    type: "*int"
-    description: scale exactly to this number of instances
-  - name: NoStart
-    type: bool
-    description: setup the app without starting it
+  - name: ResourceRequests
+    type: corev1.ResourceList
+    description: Resource requests for the container
+  - name: AppSpecInstances
+    type: v1alpha1.AppSpecInstances
+    description: Scaling information for the service
   - name: HealthCheck
     type: "*corev1.Probe"
     description: the health check to use on the app
@@ -56,15 +50,6 @@ configs:
   - name: RandomRouteDomain
     type: string
     description: Domain for a random route. Only used if a route doesn't already exist
-  - name: DiskQuota
-    type: "*resource.Quantity"
-    description: app disk storage quota
-  - name: Memory
-    type: "*resource.Quantity"
-    description: app memory request
-  - name: CPU
-    type: "*resource.Quantity"
-    description: app CPU request
   - name: ServiceBindings
     type: "[]v1alpha1.AppSpecServiceBinding"
     description: a list of Services to bind to the app

--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -67,10 +67,8 @@ func newApp(appName string, opts ...PushOption) (*v1alpha1.App, error) {
 	app.SetName(appName)
 	app.SetNamespace(cfg.Namespace)
 	app.SetSource(src)
-	app.SetMemory(cfg.Memory)
-	app.SetStorage(cfg.DiskQuota)
-	app.SetCPU(cfg.CPU)
-	app.Spec.Instances.Stopped = cfg.NoStart
+	app.SetResourceRequests(cfg.ResourceRequests)
+	app.Spec.Instances = cfg.AppSpecInstances
 	app.SetHealthCheck(cfg.HealthCheck)
 	app.Spec.Routes = cfg.Routes
 	app.Spec.ServiceBindings = cfg.ServiceBindings
@@ -102,14 +100,7 @@ func (p *pusher) Push(appName string, opts ...PushOption) error {
 	app.Spec.Routes, hasDefaultRoutes = setupRoutes(cfg, app.Name, app.Spec.Routes)
 
 	// Scaling
-	if cfg.ExactScale != nil {
-		// Exactly
-		app.Spec.Instances.Exactly = cfg.ExactScale
-	} else if !noCfgScaling(cfg) {
-		// Autoscaling or unset
-		app.Spec.Instances.Min = cfg.MinScale
-		app.Spec.Instances.Max = cfg.MaxScale
-	} else {
+	if noScaling(app.Spec.Instances) {
 		// Default to 1
 		singleInstance := 1
 		app.Spec.Instances.Exactly = &singleInstance
@@ -129,15 +120,12 @@ func (p *pusher) Push(appName string, opts ...PushOption) error {
 	}
 
 	status := "deployed"
-	if cfg.NoStart {
+	if resultingApp.Spec.Instances.Stopped {
 		status = "deployed without starting"
 	}
 
 	_, err = fmt.Fprintf(cfg.Output, "%q successfully %s\n", appName, status)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func setupRoutes(cfg pushConfig, appName string, r []v1alpha1.RouteSpecFields) (routes []v1alpha1.RouteSpecFields, hasDefaultRoutes bool) {
@@ -168,14 +156,10 @@ func setupRoutes(cfg pushConfig, appName string, r []v1alpha1.RouteSpecFields) (
 	}
 }
 
-func noCfgScaling(cfg pushConfig) bool {
-	return cfg.MinScale == nil && cfg.MaxScale == nil && cfg.ExactScale == nil
-}
-
-func noScaling(app *v1alpha1.App) bool {
-	return app.Spec.Instances.Exactly == nil &&
-		app.Spec.Instances.Min == nil &&
-		app.Spec.Instances.Max == nil
+func noScaling(instances v1alpha1.AppSpecInstances) bool {
+	return instances.Exactly == nil &&
+		instances.Min == nil &&
+		instances.Max == nil
 }
 
 func mergeApps(cfg pushConfig, hasDefaultRoutes bool) func(newapp, oldapp *v1alpha1.App) *v1alpha1.App {
@@ -186,7 +170,7 @@ func mergeApps(cfg pushConfig, hasDefaultRoutes bool) func(newapp, oldapp *v1alp
 		}
 
 		// Scaling overrides
-		if noCfgScaling(cfg) {
+		if noScaling(cfg.AppSpecInstances) {
 			// Looks like the user did not set a new value, use the old one
 			newapp.Spec.Instances.Exactly = oldapp.Spec.Instances.Exactly
 			newapp.Spec.Instances.Min = oldapp.Spec.Instances.Min
@@ -194,7 +178,7 @@ func mergeApps(cfg pushConfig, hasDefaultRoutes bool) func(newapp, oldapp *v1alp
 		}
 
 		// Default scaling
-		if noCfgScaling(cfg) && noScaling(oldapp) {
+		if noScaling(cfg.AppSpecInstances) && noScaling(oldapp.Spec.Instances) {
 			// No scaling in old or new, go with a default of 1. This is to
 			// match expectaions for CF users. See
 			// https://github.com/google/kf/issues/8 for more context.

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -17,11 +17,10 @@
 package apps
 
 import (
-	"io"
-	"os"
-
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"io"
 	corev1 "k8s.io/api/core/v1"
+	"os"
 )
 
 type pushConfig struct {

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -17,50 +17,40 @@
 package apps
 
 import (
-	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"io"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type pushConfig struct {
+	// AppSpecInstances is Scaling information for the service
+	AppSpecInstances v1alpha1.AppSpecInstances
 	// Args is the app container arguments
 	Args []string
 	// Buildpack is skip the detect buildpack step and use the given name
 	Buildpack string
-	// CPU is app CPU request
-	CPU *resource.Quantity
 	// Command is the app container entrypoint
 	Command []string
 	// ContainerImage is the container to deploy
 	ContainerImage string
 	// DefaultRouteDomain is Domain for a defaultroute. Only used if a route doesn't already exist
 	DefaultRouteDomain string
-	// DiskQuota is app disk storage quota
-	DiskQuota *resource.Quantity
 	// EnvironmentVariables is set environment variables
 	EnvironmentVariables map[string]string
-	// ExactScale is scale exactly to this number of instances
-	ExactScale *int
 	// Grpc is setup the ports for the container to allow gRPC to work
 	Grpc bool
 	// HealthCheck is the health check to use on the app
 	HealthCheck *corev1.Probe
-	// MaxScale is the upper scale bound
-	MaxScale *int
-	// Memory is app memory request
-	Memory *resource.Quantity
-	// MinScale is the lower scale bound
-	MinScale *int
 	// Namespace is the Kubernetes namespace to use
 	Namespace string
-	// NoStart is setup the app without starting it
-	NoStart bool
 	// Output is the io.Writer to write output such as build logs
 	Output io.Writer
 	// RandomRouteDomain is Domain for a random route. Only used if a route doesn't already exist
 	RandomRouteDomain string
+	// ResourceRequests is Resource requests for the container
+	ResourceRequests corev1.ResourceList
 	// Routes is routes for the app
 	Routes []v1alpha1.RouteSpecFields
 	// ServiceBindings is a list of Services to bind to the app
@@ -97,6 +87,12 @@ func (opts PushOptions) Extend(other PushOptions) PushOptions {
 	return out
 }
 
+// AppSpecInstances returns the last set value for AppSpecInstances or the empty value
+// if not set.
+func (opts PushOptions) AppSpecInstances() v1alpha1.AppSpecInstances {
+	return opts.toConfig().AppSpecInstances
+}
+
 // Args returns the last set value for Args or the empty value
 // if not set.
 func (opts PushOptions) Args() []string {
@@ -107,12 +103,6 @@ func (opts PushOptions) Args() []string {
 // if not set.
 func (opts PushOptions) Buildpack() string {
 	return opts.toConfig().Buildpack
-}
-
-// CPU returns the last set value for CPU or the empty value
-// if not set.
-func (opts PushOptions) CPU() *resource.Quantity {
-	return opts.toConfig().CPU
 }
 
 // Command returns the last set value for Command or the empty value
@@ -133,22 +123,10 @@ func (opts PushOptions) DefaultRouteDomain() string {
 	return opts.toConfig().DefaultRouteDomain
 }
 
-// DiskQuota returns the last set value for DiskQuota or the empty value
-// if not set.
-func (opts PushOptions) DiskQuota() *resource.Quantity {
-	return opts.toConfig().DiskQuota
-}
-
 // EnvironmentVariables returns the last set value for EnvironmentVariables or the empty value
 // if not set.
 func (opts PushOptions) EnvironmentVariables() map[string]string {
 	return opts.toConfig().EnvironmentVariables
-}
-
-// ExactScale returns the last set value for ExactScale or the empty value
-// if not set.
-func (opts PushOptions) ExactScale() *int {
-	return opts.toConfig().ExactScale
 }
 
 // Grpc returns the last set value for Grpc or the empty value
@@ -163,34 +141,10 @@ func (opts PushOptions) HealthCheck() *corev1.Probe {
 	return opts.toConfig().HealthCheck
 }
 
-// MaxScale returns the last set value for MaxScale or the empty value
-// if not set.
-func (opts PushOptions) MaxScale() *int {
-	return opts.toConfig().MaxScale
-}
-
-// Memory returns the last set value for Memory or the empty value
-// if not set.
-func (opts PushOptions) Memory() *resource.Quantity {
-	return opts.toConfig().Memory
-}
-
-// MinScale returns the last set value for MinScale or the empty value
-// if not set.
-func (opts PushOptions) MinScale() *int {
-	return opts.toConfig().MinScale
-}
-
 // Namespace returns the last set value for Namespace or the empty value
 // if not set.
 func (opts PushOptions) Namespace() string {
 	return opts.toConfig().Namespace
-}
-
-// NoStart returns the last set value for NoStart or the empty value
-// if not set.
-func (opts PushOptions) NoStart() bool {
-	return opts.toConfig().NoStart
 }
 
 // Output returns the last set value for Output or the empty value
@@ -203,6 +157,12 @@ func (opts PushOptions) Output() io.Writer {
 // if not set.
 func (opts PushOptions) RandomRouteDomain() string {
 	return opts.toConfig().RandomRouteDomain
+}
+
+// ResourceRequests returns the last set value for ResourceRequests or the empty value
+// if not set.
+func (opts PushOptions) ResourceRequests() corev1.ResourceList {
+	return opts.toConfig().ResourceRequests
 }
 
 // Routes returns the last set value for Routes or the empty value
@@ -229,6 +189,13 @@ func (opts PushOptions) Stack() string {
 	return opts.toConfig().Stack
 }
 
+// WithPushAppSpecInstances creates an Option that sets Scaling information for the service
+func WithPushAppSpecInstances(val v1alpha1.AppSpecInstances) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.AppSpecInstances = val
+	}
+}
+
 // WithPushArgs creates an Option that sets the app container arguments
 func WithPushArgs(val []string) PushOption {
 	return func(cfg *pushConfig) {
@@ -240,13 +207,6 @@ func WithPushArgs(val []string) PushOption {
 func WithPushBuildpack(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.Buildpack = val
-	}
-}
-
-// WithPushCPU creates an Option that sets app CPU request
-func WithPushCPU(val *resource.Quantity) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.CPU = val
 	}
 }
 
@@ -271,24 +231,10 @@ func WithPushDefaultRouteDomain(val string) PushOption {
 	}
 }
 
-// WithPushDiskQuota creates an Option that sets app disk storage quota
-func WithPushDiskQuota(val *resource.Quantity) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.DiskQuota = val
-	}
-}
-
 // WithPushEnvironmentVariables creates an Option that sets set environment variables
 func WithPushEnvironmentVariables(val map[string]string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.EnvironmentVariables = val
-	}
-}
-
-// WithPushExactScale creates an Option that sets scale exactly to this number of instances
-func WithPushExactScale(val *int) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.ExactScale = val
 	}
 }
 
@@ -306,38 +252,10 @@ func WithPushHealthCheck(val *corev1.Probe) PushOption {
 	}
 }
 
-// WithPushMaxScale creates an Option that sets the upper scale bound
-func WithPushMaxScale(val *int) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.MaxScale = val
-	}
-}
-
-// WithPushMemory creates an Option that sets app memory request
-func WithPushMemory(val *resource.Quantity) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.Memory = val
-	}
-}
-
-// WithPushMinScale creates an Option that sets the lower scale bound
-func WithPushMinScale(val *int) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.MinScale = val
-	}
-}
-
 // WithPushNamespace creates an Option that sets the Kubernetes namespace to use
 func WithPushNamespace(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.Namespace = val
-	}
-}
-
-// WithPushNoStart creates an Option that sets setup the app without starting it
-func WithPushNoStart(val bool) PushOption {
-	return func(cfg *pushConfig) {
-		cfg.NoStart = val
 	}
 }
 
@@ -352,6 +270,13 @@ func WithPushOutput(val io.Writer) PushOption {
 func WithPushRandomRouteDomain(val string) PushOption {
 	return func(cfg *pushConfig) {
 		cfg.RandomRouteDomain = val
+	}
+}
+
+// WithPushResourceRequests creates an Option that sets Resource requests for the container
+func WithPushResourceRequests(val corev1.ResourceList) PushOption {
+	return func(cfg *pushConfig) {
+		cfg.ResourceRequests = val
 	}
 }
 

--- a/pkg/kf/commands/apps/push_test.go
+++ b/pkg/kf/commands/apps/push_test.go
@@ -109,8 +109,10 @@ func TestPushCommand(t *testing.T) {
 				apps.WithPushBuildpack("some-buildpack"),
 				apps.WithPushStack("cflinuxfs3"),
 				apps.WithPushEnvironmentVariables(map[string]string{"env1": "val1", "env2": "val2"}),
-				apps.WithPushNoStart(true),
-				apps.WithPushExactScale(intPtr(1)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{
+					Stopped: true,
+					Exactly: intPtr(1),
+				}),
 				apps.WithPushArgs([]string{"a", "b"}),
 				apps.WithPushCommand([]string{"start-web.sh"}),
 				apps.WithPushHealthCheck(&corev1.Probe{
@@ -157,7 +159,7 @@ func TestPushCommand(t *testing.T) {
 			},
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
-				apps.WithPushExactScale(intPtr(11)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{Exactly: intPtr(11)}),
 			),
 		},
 		"instances from manifest": {
@@ -168,7 +170,7 @@ func TestPushCommand(t *testing.T) {
 			},
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
-				apps.WithPushExactScale(intPtr(9)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{Exactly: intPtr(9)}),
 			),
 		},
 		"override manifest min instances": {
@@ -180,8 +182,7 @@ func TestPushCommand(t *testing.T) {
 			},
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
-				apps.WithPushMinScale(intPtr(11)),
-				apps.WithPushMaxScale(intPtr(11)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{Min: intPtr(11), Max: intPtr(11)}),
 			),
 		},
 		"override manifest max instances": {
@@ -194,8 +195,7 @@ func TestPushCommand(t *testing.T) {
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
 				// Manifest has 9 for min
-				apps.WithPushMinScale(intPtr(9)),
-				apps.WithPushMaxScale(intPtr(13)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{Min: intPtr(9), Max: intPtr(13)}),
 			),
 		},
 		"min and max instances from manifest": {
@@ -206,8 +206,7 @@ func TestPushCommand(t *testing.T) {
 			},
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
-				apps.WithPushMinScale(intPtr(9)),
-				apps.WithPushMaxScale(intPtr(11)),
+				apps.WithPushAppSpecInstances(v1alpha1.AppSpecInstances{Min: intPtr(9), Max: intPtr(11)}),
 			),
 		},
 		"bind-service-instance": {
@@ -513,9 +512,11 @@ func TestPushCommand(t *testing.T) {
 			},
 			wantOpts: append(defaultOptions,
 				apps.WithPushNamespace("some-namespace"),
-				apps.WithPushMemory(&wantMemory),
-				apps.WithPushDiskQuota(&wantDiskQuota),
-				apps.WithPushCPU(&wantCPU),
+				apps.WithPushResourceRequests(corev1.ResourceList{
+					corev1.ResourceMemory:           wantMemory,
+					corev1.ResourceEphemeralStorage: wantDiskQuota,
+					corev1.ResourceCPU:              wantCPU,
+				}),
 			),
 		},
 	} {
@@ -541,14 +542,9 @@ func TestPushCommand(t *testing.T) {
 					testutil.AssertEqual(t, "buildpack", expectOpts.Buildpack(), actualOpts.Buildpack())
 					testutil.AssertEqual(t, "grpc", expectOpts.Grpc(), actualOpts.Grpc())
 					testutil.AssertEqual(t, "env vars", expectOpts.EnvironmentVariables(), actualOpts.EnvironmentVariables())
-					testutil.AssertEqual(t, "exact scale bound", expectOpts.ExactScale(), actualOpts.ExactScale())
-					testutil.AssertEqual(t, "min scale bound", expectOpts.MinScale(), actualOpts.MinScale())
-					testutil.AssertEqual(t, "max scale bound", expectOpts.MaxScale(), actualOpts.MaxScale())
-					testutil.AssertEqual(t, "no start", expectOpts.NoStart(), actualOpts.NoStart())
+					testutil.AssertEqual(t, "instances", expectOpts.AppSpecInstances(), actualOpts.AppSpecInstances())
 					testutil.AssertEqual(t, "routes", expectOpts.Routes(), actualOpts.Routes())
-					testutil.AssertEqual(t, "memory requests", expectOpts.Memory(), actualOpts.Memory())
-					testutil.AssertEqual(t, "storage requests", expectOpts.DiskQuota(), actualOpts.DiskQuota())
-					testutil.AssertEqual(t, "cpu requests", expectOpts.CPU(), actualOpts.CPU())
+					testutil.AssertEqual(t, "resource requests", expectOpts.ResourceRequests(), actualOpts.ResourceRequests())
 					testutil.AssertEqual(t, "health check", expectOpts.HealthCheck(), actualOpts.HealthCheck())
 					testutil.AssertEqual(t, "default route", expectOpts.DefaultRouteDomain(), actualOpts.DefaultRouteDomain())
 					testutil.AssertEqual(t, "random route", expectOpts.RandomRouteDomain(), actualOpts.RandomRouteDomain())

--- a/pkg/kf/manifest/manifest_conversion.go
+++ b/pkg/kf/manifest/manifest_conversion.go
@@ -1,0 +1,89 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// ToAppSpecInstances extracts scaling info from the manifest.
+func (source *Application) ToAppSpecInstances() v1alpha1.AppSpecInstances {
+	instances := v1alpha1.AppSpecInstances{}
+	if source.NoStart != nil {
+		instances.Stopped = *source.NoStart
+	}
+
+	instances.Min = source.MinScale
+	instances.Max = source.MaxScale
+	instances.Exactly = source.Instances
+
+	return instances
+}
+
+// intPtr creates a pointer to an int.
+func intPtr(i int) *int {
+	return &i
+}
+
+// ToResourceRequests returns a ResourceList with memory, CPU, and storage set.
+// If none are set by the user, the returned ResourceList will be nil.
+func (source *Application) ToResourceRequests() (corev1.ResourceList, error) {
+	resourceMapping := map[corev1.ResourceName]string{
+		corev1.ResourceMemory:           cfToSIUnits(source.Memory),
+		corev1.ResourceEphemeralStorage: cfToSIUnits(source.DiskQuota),
+		// CPU is not converted to SI because it's not a normal CF field
+		// and is therefore expected to be in SI to begin with.
+		corev1.ResourceCPU: source.CPU,
+	}
+
+	requests := corev1.ResourceList{}
+	for kind, rawQuantity := range resourceMapping {
+		if rawQuantity != "" {
+			quantity, err := resource.ParseQuantity(rawQuantity)
+			if err != nil {
+				return nil, fmt.Errorf("couldn't parse resource quantity %s: %v", rawQuantity, err)
+			}
+
+			requests[kind] = quantity
+		}
+	}
+
+	if len(requests) == 0 {
+		return nil, nil
+	}
+
+	return requests, nil
+}
+
+// cfToSiUnits converts CF resource quantities into the equivalent k8s quantity
+// strings. CF interprets K, M, G, T as binary SI units while k8s interprets
+// them as decimal, so we convert them here into binary SI units (Ki, Mi, Gi, Ti)
+func cfToSIUnits(orig string) string {
+	trimmed := strings.TrimSuffix(strings.TrimSpace(orig), "B")
+
+	for _, suffix := range []string{"T", "G", "M", "K"} {
+		if strings.HasSuffix(trimmed, suffix) {
+			return trimmed + "i"
+		}
+	}
+
+	// if it's not a CF unit, return the value unmodified
+	return orig
+}

--- a/pkg/kf/manifest/manifest_conversion_test.go
+++ b/pkg/kf/manifest/manifest_conversion_test.go
@@ -1,0 +1,123 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the License);
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an AS IS BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	"github.com/google/kf/pkg/kf/testutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"knative.dev/pkg/ptr"
+)
+
+func TestApplication_ToResourceRequests(t *testing.T) {
+	cases := map[string]struct {
+		source       Application
+		expectedList corev1.ResourceList
+		expectedErr  error
+	}{
+		"full": {
+			source: Application{
+				Memory:    "30MB", // CF uses X and XB as SI units, these get changed to SI
+				DiskQuota: "1G",
+				KfApplicationExtension: KfApplicationExtension{
+					CPU: "200m",
+				},
+			},
+			expectedList: corev1.ResourceList{
+				corev1.ResourceMemory:           resource.MustParse("30Mi"),
+				corev1.ResourceCPU:              resource.MustParse("200m"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			},
+		},
+		"normal cf subset": {
+			source: Application{
+				Memory:    "30M",
+				DiskQuota: "1Gi",
+			},
+			expectedList: corev1.ResourceList{
+				corev1.ResourceMemory:           resource.MustParse("30Mi"),
+				corev1.ResourceEphemeralStorage: resource.MustParse("1Gi"),
+			},
+		},
+		"bad quantity": {
+			source: Application{
+				Memory: "30Y",
+			},
+			expectedErr: errors.New("couldn't parse resource quantity 30Y: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"),
+		},
+		"no quotas": {
+			source:       Application{},
+			expectedList: nil, // explicitly want nil rather than the empty map
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actualList, actualErr := tc.source.ToResourceRequests()
+
+			testutil.AssertErrorsEqual(t, tc.expectedErr, actualErr)
+			testutil.AssertEqual(t, "resource lists", tc.expectedList, actualList)
+		})
+	}
+}
+
+func TestApplication_ToAppSpecInstances(t *testing.T) {
+	cases := map[string]struct {
+		source   Application
+		expected v1alpha1.AppSpecInstances
+	}{
+		"blank app": {
+			source:   Application{},
+			expected: v1alpha1.AppSpecInstances{},
+		},
+		"stopped autoscaled app": {
+			source: Application{
+				KfApplicationExtension: KfApplicationExtension{
+					NoStart:  ptr.Bool(true),
+					MinScale: intPtr(2),
+					MaxScale: intPtr(300),
+				},
+			},
+			expected: v1alpha1.AppSpecInstances{
+				Stopped: true,
+				Min:     intPtr(2),
+				Max:     intPtr(300),
+			},
+		},
+		"started app with instances": {
+			source: Application{
+				Instances: intPtr(3),
+				KfApplicationExtension: KfApplicationExtension{
+					NoStart: ptr.Bool(false),
+				},
+			},
+			expected: v1alpha1.AppSpecInstances{
+				Exactly: intPtr(3),
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			actual := tc.source.ToAppSpecInstances()
+
+			testutil.AssertEqual(t, "instances", tc.expected, actual)
+		})
+	}
+}

--- a/pkg/kf/manifest/manifest_validation.go
+++ b/pkg/kf/manifest/manifest_validation.go
@@ -40,5 +40,14 @@ func (app *Application) Validate(ctx context.Context) (errs *apis.FieldError) {
 		}
 	}
 
+	if app.Instances != nil {
+		if app.KfApplicationExtension.MinScale != nil {
+			errs = errs.Also(apis.ErrMultipleOneOf("min-scale", "instances"))
+		}
+		if app.KfApplicationExtension.MaxScale != nil {
+			errs = errs.Also(apis.ErrMultipleOneOf("max-scale", "instances"))
+		}
+	}
+
 	return
 }

--- a/pkg/kf/manifest/manifest_validation_test.go
+++ b/pkg/kf/manifest/manifest_validation_test.go
@@ -63,6 +63,24 @@ func TestApplication_Validation(t *testing.T) {
 			},
 			want: apis.ErrMultipleOneOf("buildpack", "buildpacks"),
 		},
+		"min and instances": {
+			spec: Application{
+				Instances: intPtr(3),
+				KfApplicationExtension: KfApplicationExtension{
+					MinScale: intPtr(3),
+				},
+			},
+			want: apis.ErrMultipleOneOf("instances", "min-scale"),
+		},
+		"max and instances": {
+			spec: Application{
+				Instances: intPtr(3),
+				KfApplicationExtension: KfApplicationExtension{
+					MaxScale: intPtr(3),
+				},
+			},
+			want: apis.ErrMultipleOneOf("instances", "max-scale"),
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
<!-- Include the issue number below -->
Cleanup before continuing #656 

The step after this is creating a full container definition from the manifest, then a full `v1alpha1.App` once source can be created. This will allow us to print diffs before push or just dump a yaml instead while reducing the dizzying array of options to Push.

## Proposed Changes

* Pass complete scaling and quota objects to pusher.
* Use validator to notify of bad config.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
