### PR TITLE
change check-code-generator to bash

### DIFF
--- a/hack/check-code-generator.sh
+++ b/hack/check-code-generator.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Copyright 2019 Google LLC
 #


### PR DESCRIPTION
## Proposed Changes

* move check-code-generator.sh to use bash because `[[` isn't supported in `sh` which we're using to check the GOPATH due to https://github.com/kubernetes-sigs/kubebuilder/issues/359
