### PR TITLE
changed apps commands to support async

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_map-route.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_map-route.md
@@ -26,6 +26,7 @@ kf map-route APP_NAME DOMAIN [--hostname HOSTNAME] [--path PATH] [flags]
 ### Options
 
 ```
+      --async             Don't wait for the action to complete on the server before returning
   -h, --help              help for map-route
       --hostname string   Hostname for the route
       --path string       URL Path for the route

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_restart.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_restart.md
@@ -24,7 +24,8 @@ kf restart APP_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for restart
+      --async   Don't wait for the action to complete on the server before returning
+  -h, --help    help for restart
 ```
 
 ### Options inherited from parent commands

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_scale.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_scale.md
@@ -33,6 +33,7 @@ kf scale APP_NAME [flags]
 ### Options
 
 ```
+      --async           Don't wait for the action to complete on the server before returning
   -h, --help            help for scale
   -i, --instances int   Number of instances. (default -1)
       --max int         Maximum number of instances to allow the autoscaler to scale to. 0 implies the app can be scaled to ∞. (default -1)

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_set-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_set-env.md
@@ -24,7 +24,8 @@ kf set-env APP_NAME ENV_VAR_NAME ENV_VAR_VALUE [flags]
 ### Options
 
 ```
-  -h, --help   help for set-env
+      --async   Don't wait for the action to complete on the server before returning
+  -h, --help    help for set-env
 ```
 
 ### Options inherited from parent commands

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_start.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_start.md
@@ -24,7 +24,8 @@ kf start APP_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for start
+      --async   Don't wait for the action to complete on the server before returning
+  -h, --help    help for start
 ```
 
 ### Options inherited from parent commands

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_stop.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_stop.md
@@ -24,7 +24,8 @@ kf stop APP_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for stop
+      --async   Don't wait for the action to complete on the server before returning
+  -h, --help    help for stop
 ```
 
 ### Options inherited from parent commands

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_unmap-route.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_unmap-route.md
@@ -26,6 +26,7 @@ kf unmap-route APP_NAME DOMAIN [--hostname HOSTNAME] [--path PATH] [flags]
 ### Options
 
 ```
+      --async             Don't wait for the action to complete on the server before returning
   -h, --help              help for unmap-route
       --hostname string   Hostname for the route
       --path string       URL Path for the route

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_unset-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_unset-env.md
@@ -24,7 +24,8 @@ kf unset-env APP_NAME ENV_VAR_NAME [flags]
 ### Options
 
 ```
-  -h, --help   help for unset-env
+      --async   Don't wait for the action to complete on the server before returning
+  -h, --help    help for unset-env
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kf/apps/client.yml
+++ b/pkg/kf/apps/client.yml
@@ -13,6 +13,10 @@ kubernetes:
     ref: v1alpha1.AppConditionReady
   - name: ServiceBindingsReady
     ref: v1alpha1.AppConditionServiceBindingsReady
+  - name: KnativeServiceReady
+    ref: v1alpha1.AppConditionKnativeServiceReady
+  - name: RoutesReady
+    ref: v1alpha1.AppConditionRouteReady
 type: "v1alpha1.App"
 clientType: "cv1alpha1.AppsGetter"
 cf:

--- a/pkg/kf/apps/fake/fake_client.go
+++ b/pkg/kf/apps/fake/fake_client.go
@@ -297,6 +297,21 @@ func (mr *FakeClientMockRecorder) WaitFor(arg0, arg1, arg2, arg3, arg4 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitFor", reflect.TypeOf((*FakeClient)(nil).WaitFor), arg0, arg1, arg2, arg3, arg4)
 }
 
+// WaitForConditionKnativeServiceReadyTrue mocks base method
+func (m *FakeClient) WaitForConditionKnativeServiceReadyTrue(arg0 context.Context, arg1, arg2 string, arg3 time.Duration) (*v1alpha1.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForConditionKnativeServiceReadyTrue", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForConditionKnativeServiceReadyTrue indicates an expected call of WaitForConditionKnativeServiceReadyTrue
+func (mr *FakeClientMockRecorder) WaitForConditionKnativeServiceReadyTrue(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForConditionKnativeServiceReadyTrue", reflect.TypeOf((*FakeClient)(nil).WaitForConditionKnativeServiceReadyTrue), arg0, arg1, arg2, arg3)
+}
+
 // WaitForConditionReadyTrue mocks base method
 func (m *FakeClient) WaitForConditionReadyTrue(arg0 context.Context, arg1, arg2 string, arg3 time.Duration) (*v1alpha1.App, error) {
 	m.ctrl.T.Helper()
@@ -310,6 +325,21 @@ func (m *FakeClient) WaitForConditionReadyTrue(arg0 context.Context, arg1, arg2 
 func (mr *FakeClientMockRecorder) WaitForConditionReadyTrue(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForConditionReadyTrue", reflect.TypeOf((*FakeClient)(nil).WaitForConditionReadyTrue), arg0, arg1, arg2, arg3)
+}
+
+// WaitForConditionRoutesReadyTrue mocks base method
+func (m *FakeClient) WaitForConditionRoutesReadyTrue(arg0 context.Context, arg1, arg2 string, arg3 time.Duration) (*v1alpha1.App, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForConditionRoutesReadyTrue", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*v1alpha1.App)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WaitForConditionRoutesReadyTrue indicates an expected call of WaitForConditionRoutesReadyTrue
+func (mr *FakeClientMockRecorder) WaitForConditionRoutesReadyTrue(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForConditionRoutesReadyTrue", reflect.TypeOf((*FakeClient)(nil).WaitForConditionRoutesReadyTrue), arg0, arg1, arg2, arg3)
 }
 
 // WaitForConditionServiceBindingsReadyTrue mocks base method

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -52,6 +52,8 @@ const (
 var (
 	ConditionReady                = apis.ConditionType(v1alpha1.AppConditionReady)
 	ConditionServiceBindingsReady = apis.ConditionType(v1alpha1.AppConditionServiceBindingsReady)
+	ConditionKnativeServiceReady  = apis.ConditionType(v1alpha1.AppConditionKnativeServiceReady)
+	ConditionRoutesReady          = apis.ConditionType(v1alpha1.AppConditionRouteReady)
 )
 
 // Predicate is a boolean function for a v1alpha1.App.
@@ -153,6 +155,8 @@ type Client interface {
 	WaitForDeletion(ctx context.Context, namespace string, name string, interval time.Duration) (*v1alpha1.App, error)
 	WaitForConditionReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (*v1alpha1.App, error)
 	WaitForConditionServiceBindingsReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (*v1alpha1.App, error)
+	WaitForConditionKnativeServiceReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (*v1alpha1.App, error)
+	WaitForConditionRoutesReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (*v1alpha1.App, error)
 
 	// ClientExtension can be used by the developer to extend the client.
 	ClientExtension
@@ -408,4 +412,26 @@ func ConditionServiceBindingsReadyTrue(obj *v1alpha1.App, err error) (bool, erro
 // WaitForConditionServiceBindingsReadyTrue is a utility function that combines WaitForE with ConditionServiceBindingsReadyTrue.
 func (core *coreClient) WaitForConditionServiceBindingsReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (instance *v1alpha1.App, err error) {
 	return core.WaitForE(ctx, namespace, name, interval, ConditionServiceBindingsReadyTrue)
+}
+
+// ConditionKnativeServiceReadyTrue is a ConditionFuncE that waits for Condition{KnativeServiceReady v1alpha1.AppConditionKnativeServiceReady } to
+// become true and fails with an error if the condition becomes false.
+func ConditionKnativeServiceReadyTrue(obj *v1alpha1.App, err error) (bool, error) {
+	return checkConditionTrue(obj, err, ConditionKnativeServiceReady)
+}
+
+// WaitForConditionKnativeServiceReadyTrue is a utility function that combines WaitForE with ConditionKnativeServiceReadyTrue.
+func (core *coreClient) WaitForConditionKnativeServiceReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (instance *v1alpha1.App, err error) {
+	return core.WaitForE(ctx, namespace, name, interval, ConditionKnativeServiceReadyTrue)
+}
+
+// ConditionRoutesReadyTrue is a ConditionFuncE that waits for Condition{RoutesReady v1alpha1.AppConditionRouteReady } to
+// become true and fails with an error if the condition becomes false.
+func ConditionRoutesReadyTrue(obj *v1alpha1.App, err error) (bool, error) {
+	return checkConditionTrue(obj, err, ConditionRoutesReady)
+}
+
+// WaitForConditionRoutesReadyTrue is a utility function that combines WaitForE with ConditionRoutesReadyTrue.
+func (core *coreClient) WaitForConditionRoutesReadyTrue(ctx context.Context, namespace string, name string, interval time.Duration) (instance *v1alpha1.App, err error) {
+	return core.WaitForE(ctx, namespace, name, interval, ConditionRoutesReadyTrue)
 }

--- a/pkg/kf/commands/apps/logs_test.go
+++ b/pkg/kf/commands/apps/logs_test.go
@@ -15,6 +15,7 @@
 package apps
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -107,11 +108,13 @@ func TestLogsCommand(t *testing.T) {
 			fake := fake.NewFakeTailer(ctrl)
 			tc.Setup(t, fake)
 
+			var buf bytes.Buffer
 			cmd := NewLogsCommand(
 				&config.KfParams{Namespace: tc.Namespace},
 				fake,
 			)
 			cmd.SetArgs(tc.Args)
+			cmd.SetOutput(&buf)
 
 			gotErr := cmd.Execute()
 

--- a/pkg/kf/commands/apps/restart.go
+++ b/pkg/kf/commands/apps/restart.go
@@ -15,7 +15,9 @@
 package apps
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/kf/pkg/kf/apps"
 	"github.com/google/kf/pkg/kf/commands/completion"
@@ -29,6 +31,8 @@ func NewRestartCommand(
 	p *config.KfParams,
 	client apps.Client,
 ) *cobra.Command {
+	var async utils.AsyncFlags
+
 	cmd := &cobra.Command{
 		Use:     "restart APP_NAME",
 		Short:   "Restarts all running instances of the app",
@@ -47,10 +51,15 @@ func NewRestartCommand(
 				return fmt.Errorf("failed to restart app: %s", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Restarting app %q %s", appName, utils.AsyncLogSuffix)
-			return nil
+			action := fmt.Sprintf("Restarting app %q in space %q", appName, p.Namespace)
+			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Namespace, appName, 1*time.Second)
+				return err
+			})
 		},
 	}
+
+	async.Add(cmd)
 
 	completion.MarkArgCompletionSupported(cmd, completion.AppCompletion)
 

--- a/pkg/kf/commands/apps/restart_test.go
+++ b/pkg/kf/commands/apps/restart_test.go
@@ -40,6 +40,14 @@ func TestRestart(t *testing.T) {
 			Args:      []string{"my-app"},
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Restart("default", "my-app")
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "default", "my-app", gomock.Any())
+			},
+		},
+		"async call does not wait": {
+			Namespace: "default",
+			Args:      []string{"my-app", "--async"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Restart(gomock.Any(), gomock.Any())
 			},
 		},
 		"no app name": {

--- a/pkg/kf/commands/apps/set_env.go
+++ b/pkg/kf/commands/apps/set_env.go
@@ -15,7 +15,9 @@
 package apps
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	v1alpha1 "github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/apps"
@@ -27,7 +29,9 @@ import (
 )
 
 // NewSetEnvCommand creates a SetEnv command.
-func NewSetEnvCommand(p *config.KfParams, appClient apps.Client) *cobra.Command {
+func NewSetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
+	var async utils.AsyncFlags
+
 	cmd := &cobra.Command{
 		Use:     "set-env APP_NAME ENV_VAR_NAME ENV_VAR_VALUE",
 		Short:   "Set an environment variable for an app",
@@ -48,7 +52,7 @@ func NewSetEnvCommand(p *config.KfParams, appClient apps.Client) *cobra.Command 
 				{Name: name, Value: value},
 			}
 
-			_, err := appClient.Transform(p.Namespace, appName, func(app *v1alpha1.App) error {
+			_, err := client.Transform(p.Namespace, appName, func(app *v1alpha1.App) error {
 				kfapp := (*apps.KfApp)(app)
 				kfapp.MergeEnvVars(toSet)
 				return nil
@@ -58,10 +62,15 @@ func NewSetEnvCommand(p *config.KfParams, appClient apps.Client) *cobra.Command 
 				return fmt.Errorf("failed to set env var on app: %s", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Setting environment variable on app %q %s", appName, utils.AsyncLogSuffix)
-			return nil
+			action := fmt.Sprintf("Setting environment variable on app %q in space %q", appName, p.Namespace)
+			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Namespace, appName, 1*time.Second)
+				return err
+			})
 		},
 	}
+
+	async.Add(cmd)
 
 	completion.MarkArgCompletionSupported(cmd, completion.AppCompletion)
 

--- a/pkg/kf/commands/apps/set_env_test.go
+++ b/pkg/kf/commands/apps/set_env_test.go
@@ -63,6 +63,7 @@ func TestSetEnvCommand(t *testing.T) {
 			Namespace: "some-namespace",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Transform("some-namespace", "app-name", gomock.Any())
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "some-namespace", "app-name", gomock.Any())
 			},
 		},
 		"sets values": {
@@ -78,6 +79,14 @@ func TestSetEnvCommand(t *testing.T) {
 					actualVars := envutil.EnvVarsToMap(app.GetEnvVars())
 					testutil.AssertEqual(t, "env vars", map[string]string{"NAME": "VALUE"}, actualVars)
 				})
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "some-namespace", "app-name", gomock.Any())
+			},
+		},
+		"async call does not wait": {
+			Args:      []string{"app-name", "NAME", "VALUE", "--async"},
+			Namespace: "some-namespace",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 	} {

--- a/pkg/kf/commands/apps/start.go
+++ b/pkg/kf/commands/apps/start.go
@@ -15,7 +15,9 @@
 package apps
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/apps"
@@ -30,6 +32,8 @@ func NewStartCommand(
 	p *config.KfParams,
 	client apps.Client,
 ) *cobra.Command {
+	var async utils.AsyncFlags
+
 	cmd := &cobra.Command{
 		Use:     "start APP_NAME",
 		Short:   "Start a staged application",
@@ -53,10 +57,15 @@ func NewStartCommand(
 				return fmt.Errorf("failed to start app: %s", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Starting app %q %s", appName, utils.AsyncLogSuffix)
-			return nil
+			action := fmt.Sprintf("Starting app %q in space %q", appName, p.Namespace)
+			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Namespace, appName, 1*time.Second)
+				return err
+			})
 		},
 	}
+
+	async.Add(cmd)
 
 	completion.MarkArgCompletionSupported(cmd, completion.AppCompletion)
 

--- a/pkg/kf/commands/apps/start_test.go
+++ b/pkg/kf/commands/apps/start_test.go
@@ -48,6 +48,14 @@ func TestStart(t *testing.T) {
 						mutator(&app)
 						testutil.AssertEqual(t, "app.spec.instances.stopped", false, app.Spec.Instances.Stopped)
 					})
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "default", "my-app", gomock.Any())
+			},
+		},
+		"async does not wait": {
+			Namespace: "default",
+			Args:      []string{"my-app", "--async"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 		"no app name": {

--- a/pkg/kf/commands/apps/stop_test.go
+++ b/pkg/kf/commands/apps/stop_test.go
@@ -48,6 +48,14 @@ func TestStop(t *testing.T) {
 						mutator(&app)
 						testutil.AssertEqual(t, "app.spec.instances.stopped", true, app.Spec.Instances.Stopped)
 					})
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "default", "my-app", gomock.Any())
+			},
+		},
+		"async does not wait": {
+			Namespace: "default",
+			Args:      []string{"my-app", "--async"},
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 		"no app name": {

--- a/pkg/kf/commands/apps/unset_env_test.go
+++ b/pkg/kf/commands/apps/unset_env_test.go
@@ -56,6 +56,7 @@ func TestUnsetEnvCommand(t *testing.T) {
 			Namespace: "some-namespace",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Transform("some-namespace", "app-name", gomock.Any())
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "some-namespace", "app-name", gomock.Any())
 			},
 		},
 		"namespace is not provided": {
@@ -81,6 +82,14 @@ func TestUnsetEnvCommand(t *testing.T) {
 					actualVars := envutil.EnvVarsToMap(result.GetEnvVars())
 					testutil.AssertEqual(t, "final values", map[string]string{"PORT": "8080"}, actualVars)
 				})
+				fake.EXPECT().WaitForConditionKnativeServiceReadyTrue(gomock.Any(), "some-namespace", "app-name", gomock.Any())
+			},
+		},
+		"async call does not wait": {
+			Args:      []string{"app-name", "NAME", "--async"},
+			Namespace: "some-namespace",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 	} {

--- a/pkg/kf/commands/routes/map_route.go
+++ b/pkg/kf/commands/routes/map_route.go
@@ -15,8 +15,10 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"path"
+	"time"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/apps"
@@ -30,7 +32,11 @@ func NewMapRouteCommand(
 	p *config.KfParams,
 	appsClient apps.Client,
 ) *cobra.Command {
-	var hostname, urlPath string
+	var (
+		async    utils.AsyncFlags
+		hostname string
+		urlPath  string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "map-route APP_NAME DOMAIN [--hostname HOSTNAME] [--path PATH]",
@@ -61,15 +67,19 @@ func NewMapRouteCommand(
 				return nil
 			}
 
-			_, err := appsClient.Transform(p.Namespace, appName, mutator)
-			if err != nil {
+			if _, err := appsClient.Transform(p.Namespace, appName, mutator); err != nil {
 				return fmt.Errorf("failed to map Route: %s", err)
 			}
 
-			fmt.Fprintf(cmd.OutOrStdout(), "Mapping route... %s", utils.AsyncLogSuffix)
-			return nil
+			action := fmt.Sprintf("Mapping route to app %q in space %q", appName, p.Namespace)
+			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+				_, err := appsClient.WaitForConditionRoutesReadyTrue(context.Background(), p.Namespace, appName, 1*time.Second)
+				return err
+			})
 		},
 	}
+
+	async.Add(cmd)
 
 	cmd.Flags().StringVar(
 		&hostname,

--- a/pkg/kf/commands/routes/unmap_route.go
+++ b/pkg/kf/commands/routes/unmap_route.go
@@ -15,9 +15,11 @@
 package routes
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"path"
+	"time"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/pkg/kf/algorithms"
@@ -30,8 +32,9 @@ import (
 // NewUnmapRouteCommand creates a MapRoute command.
 func NewUnmapRouteCommand(
 	p *config.KfParams,
-	c apps.Client,
+	appsClient apps.Client,
 ) *cobra.Command {
+	var async utils.AsyncFlags
 	var hostname, urlPath string
 
 	cmd := &cobra.Command{
@@ -57,9 +60,19 @@ func NewUnmapRouteCommand(
 				Path:     path.Join("/", urlPath),
 			}
 
-			return unmapApp(p.Namespace, appName, route, c, cmd.OutOrStdout())
+			if err := unmapApp(p.Namespace, appName, route, appsClient, cmd.OutOrStdout()); err != nil {
+				return err
+			}
+
+			action := fmt.Sprintf("Unmapping route to app %q in space %q", appName, p.Namespace)
+			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+				_, err := appsClient.WaitForConditionRoutesReadyTrue(context.Background(), p.Namespace, appName, 1*time.Second)
+				return err
+			})
 		},
 	}
+
+	async.Add(cmd)
 
 	cmd.Flags().StringVar(
 		&hostname,
@@ -81,7 +94,7 @@ func unmapApp(
 	namespace string,
 	appName string,
 	route v1alpha1.RouteSpecFields,
-	c apps.Client,
+	appsClient apps.Client,
 	w io.Writer,
 ) error {
 	mutator := apps.Mutator(func(app *v1alpha1.App) error {
@@ -102,10 +115,9 @@ func unmapApp(
 		return nil
 	})
 
-	if _, err := c.Transform(namespace, appName, mutator); err != nil {
+	if _, err := appsClient.Transform(namespace, appName, mutator); err != nil {
 		return fmt.Errorf("failed to unmap Route: %s", err)
 	}
 
-	fmt.Fprintf(w, "Unmapping route... %s", utils.AsyncLogSuffix)
 	return nil
 }

--- a/pkg/kf/commands/routes/unmap_route_test.go
+++ b/pkg/kf/commands/routes/unmap_route_test.go
@@ -33,16 +33,14 @@ func TestUnmapRoute(t *testing.T) {
 	t.Parallel()
 
 	for tn, tc := range map[string]struct {
-		Namespace string
-		Args      []string
-		Setup     func(t *testing.T, fake *fake.FakeClient)
-		Assert    func(t *testing.T, buffer *bytes.Buffer, err error)
+		Namespace   string
+		Args        []string
+		Setup       func(t *testing.T, fake *fake.FakeClient)
+		ExpectedErr error
 	}{
 		"wrong number of args": {
-			Args: []string{"some-app", "example.com", "extra"},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertErrorsEqual(t, errors.New("accepts 2 arg(s), received 3"), err)
-			},
+			Args:        []string{"some-app", "example.com", "extra"},
+			ExpectedErr: errors.New("accepts 2 arg(s), received 3"),
 		},
 		"transforming App fails": {
 			Args:      []string{"some-app", "example.com"},
@@ -52,40 +50,33 @@ func TestUnmapRoute(t *testing.T) {
 					Transform(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil, errors.New("some-error"))
 			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertErrorsEqual(t, errors.New("failed to unmap Route: some-error"), err)
-			},
+			ExpectedErr: errors.New("failed to unmap Route: some-error"),
 		},
 		"namespace": {
 			Args:      []string{"some-app", "example.com"},
 			Namespace: "some-space",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				fake.EXPECT().
-					Transform("some-space", gomock.Any(), gomock.Any())
-			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertNil(t, "err", err)
+				fake.EXPECT().Transform("some-space", gomock.Any(), gomock.Any())
+				fake.EXPECT().WaitForConditionRoutesReadyTrue(gomock.Any(), "some-space", gomock.Any(), gomock.Any())
 			},
 		},
 		"without namespace": {
-			Args: []string{"some-app", "example.com"},
-			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				fake.EXPECT().
-					Transform("some-space", gomock.Any(), gomock.Any())
-			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertErrorsEqual(t, errors.New(utils.EmptyNamespaceError), err)
-			},
+			Args:        []string{"some-app", "example.com"},
+			ExpectedErr: errors.New(utils.EmptyNamespaceError),
 		},
 		"App name": {
 			Args:      []string{"some-app", "example.com", "--hostname=some-host", "--path=some-path"},
 			Namespace: "some-space",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
-				fake.EXPECT().
-					Transform(gomock.Any(), "some-app", gomock.Any())
+				fake.EXPECT().Transform(gomock.Any(), "some-app", gomock.Any())
+				fake.EXPECT().WaitForConditionRoutesReadyTrue(gomock.Any(), gomock.Any(), "some-app", gomock.Any())
 			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertNil(t, "err", err)
+		},
+		"async does not wait": {
+			Args:      []string{"some-app", "example.com", "--hostname=some-host", "--path=some-path", "--async"},
+			Namespace: "some-space",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), "some-app", gomock.Any())
 			},
 		},
 		"remove non-existent app": {
@@ -93,19 +84,12 @@ func TestUnmapRoute(t *testing.T) {
 			Namespace: "some-space",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any()).
-					Do(func(_, _ string, m apps.Mutator) {
+					DoAndReturn(func(_, _ string, m apps.Mutator) (*v1alpha1.App, error) {
 						app := buildApp("some-app", "some-host", "example.com", "")
-						testutil.AssertEqual(
-							t,
-							"err",
-							errors.New("App some-app not found"),
-							m(&app),
-						)
+						return nil, m(&app)
 					})
 			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertNil(t, "err", err)
-			},
+			ExpectedErr: errors.New("failed to unmap Route: App some-app not found"),
 		},
 		"remove 1 of 1 routes": {
 			Args:      []string{"some-app", "example.com", "--hostname=some-host", "--path=some-path"},
@@ -117,9 +101,7 @@ func TestUnmapRoute(t *testing.T) {
 						testutil.AssertNil(t, "err", m(&app))
 						testutil.AssertEqual(t, "len", 0, len(app.Spec.Routes))
 					})
-			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertNil(t, "err", err)
+				fake.EXPECT().WaitForConditionRoutesReadyTrue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 		"remove 1 of 2 routes": {
@@ -137,14 +119,13 @@ func TestUnmapRoute(t *testing.T) {
 						testutil.AssertNil(t, "err", m(&app))
 						testutil.AssertEqual(t, "routes", "some-other-host", app.Spec.Routes[0].Hostname)
 					})
-			},
-			Assert: func(t *testing.T, buffer *bytes.Buffer, err error) {
-				testutil.AssertNil(t, "err", err)
+				fake.EXPECT().WaitForConditionRoutesReadyTrue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			fake := fake.NewFakeClient(ctrl)
 
 			if tc.Setup != nil {
@@ -162,15 +143,9 @@ func TestUnmapRoute(t *testing.T) {
 			cmd.SetOutput(&buffer)
 
 			gotErr := cmd.Execute()
-
-			if tc.Assert != nil {
-				tc.Assert(t, &buffer, gotErr)
+			if gotErr != nil || tc.ExpectedErr != nil {
+				testutil.AssertErrorsEqual(t, tc.ExpectedErr, gotErr)
 			}
-
-			if gotErr != nil {
-				return
-			}
-			ctrl.Finish()
 		})
 	}
 }


### PR DESCRIPTION
<!-- Include the issue number below -->
Part of #599 

## Proposed Changes

* Add the ability to wait for Knative Service sync and Routes sync to apps.
* Using those, change all app transformation functions to wait until the thing they changed is completed.
* Replace the output for the logs tests to be a buffer so it stops writing into our test output.
* Change a few of the tests to normalize them with the other tests in their package

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changed the `restart` command to now be synchronous by default
Changed the `scale` command to now be synchronous by default
Changed the `stop` command to now be synchronous by default
Changed the `start` command to now be synchronous by default
Changed the `set-env` command to now be synchronous by default
Changed the `unset-env` command to now be synchronous by default
Changed the `map-route` command to now be synchronous by default
Changed the `unmap-route` command to now be synchronous by default
```
