### PR TITLE
default period and failure threshold

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_defaults.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults.go
@@ -38,6 +38,14 @@ const (
 	// healthchecks in seconds. This matches Cloud Foundry's default timeout.
 	DefaultHealthCheckProbeTimeout = 60
 
+	// DefaultHealthCheckPeriodSeconds holds the default period to use for health
+	// checks.
+	DefaultHealthCheckPeriodSeconds = 10
+
+	// DefaultHealthCheckFailureThreshold holds the failure threshold for health
+	// checks.
+	DefaultHealthCheckFailureThreshold = 3
+
 	// DefaultHealthCheckProbeEndpoint is the default endpoint to use for HTTP
 	// Get health checks.
 	DefaultHealthCheckProbeEndpoint = "/"
@@ -120,9 +128,17 @@ func SetKfAppContainerDefaults(_ context.Context, container *corev1.Container) {
 
 	readinessProbe := container.ReadinessProbe
 
-	// Default the probe timeout
+	// Default the probe settings
 	if readinessProbe.TimeoutSeconds == 0 {
 		readinessProbe.TimeoutSeconds = DefaultHealthCheckProbeTimeout
+	}
+
+	if readinessProbe.PeriodSeconds == 0 {
+		readinessProbe.PeriodSeconds = DefaultHealthCheckPeriodSeconds
+	}
+
+	if readinessProbe.FailureThreshold == 0 {
+		readinessProbe.FailureThreshold = DefaultHealthCheckFailureThreshold
 	}
 
 	// If the probe is HTTP, default the path

--- a/pkg/apis/kf/v1alpha1/app_defaults_test.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults_test.go
@@ -80,7 +80,9 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 			template: &corev1.Container{},
 			expected: &corev1.Container{
 				ReadinessProbe: &corev1.Probe{
-					TimeoutSeconds: DefaultHealthCheckProbeTimeout,
+					TimeoutSeconds:   DefaultHealthCheckProbeTimeout,
+					FailureThreshold: DefaultHealthCheckFailureThreshold,
+					PeriodSeconds:    DefaultHealthCheckPeriodSeconds,
 					Handler: corev1.Handler{
 						TCPSocket: &corev1.TCPSocketAction{},
 					},
@@ -97,7 +99,9 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 		"http path gets defaulted": {
 			template: &corev1.Container{
 				ReadinessProbe: &corev1.Probe{
-					TimeoutSeconds: DefaultHealthCheckProbeTimeout,
+					TimeoutSeconds:   DefaultHealthCheckProbeTimeout,
+					FailureThreshold: DefaultHealthCheckFailureThreshold,
+					PeriodSeconds:    DefaultHealthCheckPeriodSeconds,
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{},
 					},
@@ -105,7 +109,9 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 			},
 			expected: &corev1.Container{
 				ReadinessProbe: &corev1.Probe{
-					TimeoutSeconds: DefaultHealthCheckProbeTimeout,
+					TimeoutSeconds:   DefaultHealthCheckProbeTimeout,
+					FailureThreshold: DefaultHealthCheckFailureThreshold,
+					PeriodSeconds:    DefaultHealthCheckPeriodSeconds,
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{Path: DefaultHealthCheckProbeEndpoint},
 					},
@@ -116,7 +122,9 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 		"full http doesn't get overwritten": {
 			template: &corev1.Container{
 				ReadinessProbe: &corev1.Probe{
-					TimeoutSeconds: 180,
+					TimeoutSeconds:   180,
+					FailureThreshold: 33,
+					PeriodSeconds:    12,
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{Path: "/healthz"},
 					},
@@ -124,7 +132,9 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 			},
 			expected: &corev1.Container{
 				ReadinessProbe: &corev1.Probe{
-					TimeoutSeconds: 180,
+					TimeoutSeconds:   180,
+					FailureThreshold: 33,
+					PeriodSeconds:    12,
 					Handler: corev1.Handler{
 						HTTPGet: &corev1.HTTPGetAction{Path: "/healthz"},
 					},


### PR DESCRIPTION
<!-- Include the issue number below -->

## Proposed Changes

* Add defaults for health check period and failure threshold per @juliaguo's recommendations as this is now affecting builds: https://sunrisecafe.ci.cloud-graphite.com/teams/kf/pipelines/721/jobs/test/builds/4#L5d94f3e7:763

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
