### PR TITLE
Fix configure-space set-default-domain

### DIFF
--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -275,7 +275,6 @@ func newSetDefaultDomainMutator() spaceMutator {
 					}
 					found = true
 					space.Spec.Execution.Domains[i].Default = true
-					return nil
 				}
 
 				if !found {

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -148,8 +148,8 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 				Spec: v1alpha1.SpaceSpec{
 					Execution: v1alpha1.SpaceSpecExecution{
 						Domains: []v1alpha1.SpaceDomain{
-							{Domain: "other-example.com", Default: true},
 							{Domain: "example.com"},
+							{Domain: "other-example.com", Default: true},
 						},
 					},
 				},
@@ -157,9 +157,9 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 			args: []string{"set-default-domain", space, "example.com"},
 			validate: func(t *testing.T, space *v1alpha1.Space) {
 				testutil.AssertEqual(t, "len(domains)", 2, len(space.Spec.Execution.Domains))
-				testutil.AssertEqual(t, "domains", "example.com", space.Spec.Execution.Domains[1].Domain)
-				testutil.AssertEqual(t, "default", true, space.Spec.Execution.Domains[1].Default)
-				testutil.AssertEqual(t, "unsets previous default", false, space.Spec.Execution.Domains[0].Default)
+				testutil.AssertEqual(t, "domains", "example.com", space.Spec.Execution.Domains[0].Domain)
+				testutil.AssertEqual(t, "default", true, space.Spec.Execution.Domains[0].Default)
+				testutil.AssertEqual(t, "unsets previous default", false, space.Spec.Execution.Domains[1].Default)
 			},
 		},
 


### PR DESCRIPTION
All other domains must no longer be labeled as default.

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

*
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
