### PR TITLE
pkg/kf/apps: ensure ServiceBindings are preserved

### DIFF
--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -174,6 +174,7 @@ func noScaling(instances v1alpha1.AppSpecInstances) bool {
 func mergeApps(cfg pushConfig, hasDefaultRoutes bool) func(newapp, oldapp *v1alpha1.App) *v1alpha1.App {
 	return func(newapp, oldapp *v1alpha1.App) *v1alpha1.App {
 
+		// Routes
 		if len(oldapp.Spec.Routes) > 0 && hasDefaultRoutes {
 			newapp.Spec.Routes = oldapp.Spec.Routes
 		}
@@ -196,9 +197,19 @@ func mergeApps(cfg pushConfig, hasDefaultRoutes bool) func(newapp, oldapp *v1alp
 		}
 
 		newapp.ResourceVersion = oldapp.ResourceVersion
+
+		// Envs
 		newEnvs := envutil.GetAppEnvVars(newapp)
 		oldEnvs := envutil.GetAppEnvVars(oldapp)
-		envutil.SetAppEnvVars(newapp, envutil.DeduplicateEnvVars(append(oldEnvs, newEnvs...)))
+		envutil.SetAppEnvVars(
+			newapp,
+			envutil.DeduplicateEnvVars(append(oldEnvs, newEnvs...)),
+		)
+
+		// Service Bindings
+		if len(newapp.Spec.ServiceBindings) == 0 {
+			newapp.Spec.ServiceBindings = oldapp.Spec.ServiceBindings
+		}
 
 		return newapp
 	}

--- a/pkg/kf/apps/push_test.go
+++ b/pkg/kf/apps/push_test.go
@@ -541,6 +541,53 @@ func TestPush(t *testing.T) {
 					}).Return(&v1alpha1.App{}, nil)
 			},
 		},
+		"does not overwrite existing ServiceBindings": {
+			appName: "some-app",
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
+						app := &v1alpha1.App{}
+						app.Spec.ServiceBindings = []v1alpha1.AppSpecServiceBinding{
+							{Instance: "existing-binding"},
+						}
+						app = merge(newObj, app)
+
+						testutil.AssertEqual(t, "len(ServiceBindings)", 1, len(app.Spec.ServiceBindings))
+						testutil.AssertEqual(t, "ServiceBindings.Instance", "existing-binding", app.Spec.ServiceBindings[0].Instance)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+			assert: func(t *testing.T, err error) {
+				testutil.AssertNil(t, "err", err)
+			},
+		},
+		"uses new ServiceBindings": {
+			appName: "some-app",
+			opts: apps.PushOptions{
+				apps.WithPushServiceBindings([]v1alpha1.AppSpecServiceBinding{
+					{Instance: "new-binding"},
+				}),
+			},
+			setup: func(t *testing.T, appsClient *appsfake.FakeClient) {
+				appsClient.EXPECT().
+					Upsert(gomock.Not(gomock.Nil()), gomock.Any(), gomock.Any()).
+					Do(func(namespace string, newObj *v1alpha1.App, merge apps.Merger) {
+						app := &v1alpha1.App{}
+						app.Spec.ServiceBindings = []v1alpha1.AppSpecServiceBinding{
+							{Instance: "existing-binding"},
+						}
+						app = merge(newObj, app)
+
+						testutil.AssertEqual(t, "len(ServiceBindings)", 1, len(app.Spec.ServiceBindings))
+						testutil.AssertEqual(t, "ServiceBindings.Instance", "new-binding", app.Spec.ServiceBindings[0].Instance)
+					}).
+					Return(&v1alpha1.App{}, nil)
+			},
+			assert: func(t *testing.T, err error) {
+				testutil.AssertNil(t, "err", err)
+			},
+		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			if tc.assert == nil {


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #738

## Proposed Changes

* Fixed push to ensure services bindings are preserved
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed push to ensure services bindings are preserved
```
