### PR TITLE
fix routes ready status on app

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle.go
@@ -136,6 +136,11 @@ func (status *AppStatus) PropagateEnvVarSecretStatus(secret *v1.Secret) {
 	status.manage().MarkTrue(AppConditionEnvVarSecretReady)
 }
 
+// PropagateRouteStatus updates the route readiness status.
+func (status *AppStatus) PropagateRouteStatus() {
+	status.manage().MarkTrue(AppConditionRouteReady)
+}
+
 // serviceBindingConditionType creates a Conditiontype for a ServiceBinding.
 func serviceBindingConditionType(binding *servicecatalogv1beta1.ServiceBinding) (apis.ConditionType, error) {
 	serviceInstance, ok := binding.Labels[ComponentLabel]

--- a/pkg/kf/testutil/integration.go
+++ b/pkg/kf/testutil/integration.go
@@ -996,6 +996,46 @@ func (k *Kf) CreateRoute(ctx context.Context, domain string, extraArgs ...string
 	StreamOutput(ctx, k.t, output)
 }
 
+// MapRoute runs the map-route command.
+func (k *Kf) MapRoute(ctx context.Context, appName, domain string, extraArgs ...string) {
+	k.t.Helper()
+	Logf(k.t, "running map-route...")
+	defer Logf(k.t, "done running map-route.")
+
+	args := []string{
+		"map-route",
+		"--namespace", SpaceFromContext(ctx),
+		appName,
+		domain,
+	}
+
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: append(args, extraArgs...),
+	})
+	PanicOnError(ctx, k.t, "map-route", errs)
+	StreamOutput(ctx, k.t, output)
+}
+
+// UnmapRoute runs the unmap-route command.
+func (k *Kf) UnmapRoute(ctx context.Context, appName, domain string, extraArgs ...string) {
+	k.t.Helper()
+	Logf(k.t, "running unmap-route...")
+	defer Logf(k.t, "done running unmap-route.")
+
+	args := []string{
+		"unmap-route",
+		"--namespace", SpaceFromContext(ctx),
+		appName,
+		domain,
+	}
+
+	output, errs := k.kf(ctx, k.t, KfTestConfig{
+		Args: append(args, extraArgs...),
+	})
+	PanicOnError(ctx, k.t, "unmap-route", errs)
+	StreamOutput(ctx, k.t, output)
+}
+
 // DeleteRoute runs the delete-route command.
 func (k *Kf) DeleteRoute(ctx context.Context, domain string, extraArgs ...string) {
 	k.t.Helper()

--- a/pkg/reconciler/app/reconciler.go
+++ b/pkg/reconciler/app/reconciler.go
@@ -409,6 +409,9 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, app *v1alpha1.App) error 
 		}
 	}
 
+	// If there are no errors reconciling Routes and RouteClaims, mark RouteReady as true
+	app.Status.PropagateRouteStatus()
+
 	return r.gcRevisions(ctx, app)
 }
 


### PR DESCRIPTION
## Proposed Changes

* Fixes bug where `map-route` command was hanging. Mark `RouteReady` condition as True when routes and routeclaims are reconciled successfully
* Add integration test for map-route

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed hanging route commands bug
```
