### PR TITLE
third_party/knative-build: move Status to v1beta1

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	build "github.com/google/kf/third_party/knative-build/pkg/apis/build/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
@@ -78,19 +77,9 @@ func (status *SourceStatus) PropagateBuildStatus(build *build.Build) {
 	status.BuildName = build.Name
 	status.manage().MarkUnknown(SourceConditionBuildSucceeded, "initializing", "Build in progress")
 
-	for _, condition := range build.Status.GetConditions() {
-		if condition.Type == "Succeeded" {
-			switch condition.Status {
-			case corev1.ConditionTrue:
-				status.Image = GetBuildArg(build, BuildArgImage)
-
-				status.manage().MarkTrue(SourceConditionBuildSucceeded)
-			case corev1.ConditionFalse:
-				status.manage().MarkFalse(SourceConditionBuildSucceeded, condition.Reason, "Build failed: %s", condition.Message)
-			case corev1.ConditionUnknown:
-				status.manage().MarkUnknown(SourceConditionBuildSucceeded, condition.Reason, "Build in progress")
-			}
-		}
+	cond := build.Status.GetCondition(apis.ConditionSucceeded)
+	if PropagateCondition(status.manage(), SourceConditionBuildSucceeded, cond) {
+		status.Image = GetBuildArg(build, BuildArgImage)
 	}
 }
 

--- a/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck"
-	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	apitesting "knative.dev/pkg/apis/testing"
 )
@@ -184,10 +183,10 @@ func happyBuild() *build.Build {
 			},
 		},
 		Status: build.BuildStatus{
-			Status: duckv1alpha1.Status{
-				Conditions: duckv1alpha1.Conditions{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
 					{
-						Type:   duckv1alpha1.ConditionType("Succeeded"),
+						Type:   apis.ConditionType("Succeeded"),
 						Status: corev1.ConditionTrue,
 					},
 				},
@@ -212,10 +211,10 @@ func pendingBuild() *build.Build {
 			},
 		},
 		Status: build.BuildStatus{
-			Status: duckv1alpha1.Status{
-				Conditions: duckv1alpha1.Conditions{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{
 					{
-						Type:   duckv1alpha1.ConditionType("Succeeded"),
+						Type:   apis.ConditionType("Succeeded"),
 						Status: corev1.ConditionUnknown,
 					},
 				},

--- a/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
@@ -186,7 +186,7 @@ func happyBuild() *build.Build {
 			Status: duckv1beta1.Status{
 				Conditions: duckv1beta1.Conditions{
 					{
-						Type:   apis.ConditionType("Succeeded"),
+						Type:   apis.ConditionSucceeded,
 						Status: corev1.ConditionTrue,
 					},
 				},
@@ -214,7 +214,7 @@ func pendingBuild() *build.Build {
 			Status: duckv1beta1.Status{
 				Conditions: duckv1beta1.Conditions{
 					{
-						Type:   apis.ConditionType("Succeeded"),
+						Type:   apis.ConditionSucceeded,
 						Status: corev1.ConditionUnknown,
 					},
 				},

--- a/third_party/knative-build/pkg/apis/build/v1alpha1/build_types.go
+++ b/third_party/knative-build/pkg/apis/build/v1alpha1/build_types.go
@@ -21,7 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
+	"knative.dev/pkg/apis"
+	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/kmeta"
 )
 
@@ -233,7 +234,7 @@ const (
 
 // BuildStatus is the status for a Build resource
 type BuildStatus struct {
-	duckv1alpha1.Status `json:",inline"`
+	duckv1beta1.Status `json:",inline"`
 
 	// +optional
 	Builder BuildProvider `json:"builder,omitempty"`
@@ -264,7 +265,7 @@ type BuildStatus struct {
 }
 
 // Check that BuildStatus may have its conditions managed.
-var _ duckv1alpha1.ConditionsAccessor = (*BuildStatus)(nil)
+var _ apis.ConditionsAccessor = (*BuildStatus)(nil)
 
 // ClusterSpec provides information about the on-cluster build, if applicable.
 type ClusterSpec struct {
@@ -285,11 +286,11 @@ type GoogleSpec struct {
 //
 // If the build is ongoing, its status will be Unknown. If it fails, its status
 // will be False.
-const BuildSucceeded = duckv1alpha1.ConditionSucceeded
+const BuildSucceeded = apis.ConditionSucceeded
 
-const BuildCancelled duckv1alpha1.ConditionType = "Cancelled"
+const BuildCancelled apis.ConditionType = "Cancelled"
 
-var buildCondSet = duckv1alpha1.NewBatchConditionSet()
+var buildCondSet = apis.NewBatchConditionSet()
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -303,28 +304,8 @@ type BuildList struct {
 }
 
 // GetCondition returns the Condition matching the given type.
-func (bs *BuildStatus) GetCondition(t duckv1alpha1.ConditionType) *duckv1alpha1.Condition {
+func (bs *BuildStatus) GetCondition(t apis.ConditionType) *apis.Condition {
 	return buildCondSet.Manage(bs).GetCondition(t)
-}
-
-// SetCondition sets the condition, unsetting previous conditions with the same
-// type as necessary.
-func (bs *BuildStatus) SetCondition(newCond *duckv1alpha1.Condition) {
-	if newCond != nil {
-		buildCondSet.Manage(bs).SetCondition(*newCond)
-	}
-}
-
-// GetConditions returns the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (bs *BuildStatus) GetConditions() duckv1alpha1.Conditions {
-	return bs.Conditions
-}
-
-// SetConditions sets the Conditions array. This enables generic handling of
-// conditions by implementing the duckv1alpha1.Conditions interface.
-func (bs *BuildStatus) SetConditions(conditions duckv1alpha1.Conditions) {
-	bs.Conditions = conditions
 }
 
 func (b *Build) GetGroupVersionKind() schema.GroupVersionKind {

--- a/third_party/knative-build/pkg/logs/logs.go
+++ b/third_party/knative-build/pkg/logs/logs.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
+	"knative.dev/pkg/apis"
 )
 
 const buildExecuteFailed = "BuildExecuteFailed"
@@ -227,7 +227,7 @@ func podName(cfg *rest.Config, out io.Writer, buildName, namespace string) (stri
 			return cluster.PodName, nil
 		}
 
-		condition := b.Status.GetCondition(duckv1alpha1.ConditionSucceeded)
+		condition := b.Status.GetCondition(apis.ConditionSucceeded)
 		if condition.IsFalse() {
 			return "", fmt.Errorf("build failed for reason: %s and msg: %s", condition.Reason, condition.Message)
 		}


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Moves ./third_party/knative-build's `Status` type to use v1beta1 (from v1alpha1). This is possible as both types are semantically the same. (This is a small step towards using Tekton as it moves the build status handling into the same pattern other CRDs use.)
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changes knative-build's Status type to v1beta1 (from v1alpha1).
```
