### PR TITLE
docs: Publish develop branch as default

### DIFF
--- a/docs/kf.dev/ci/concourse/pipelines/website-pipeline.yml
+++ b/docs/kf.dev/ci/concourse/pipelines/website-pipeline.yml
@@ -89,6 +89,7 @@ jobs:
         GAE_SA: *gae_sa
         GOOGLE_PROJECT: *gae_project
         VERSION: develop
+        DEFAULT: true
       run:
         path: bash
         args:


### PR DESCRIPTION
This change publishes docs from the develop branch to the IAP-protected
App Engine site at https://kf-dev-site.appspot.com
