### PR TITLE
Make space an optional arg to configure-space

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_append-domain.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_append-domain.md
@@ -12,13 +12,16 @@ Append a domain for a space
 Append a domain for a space
 
 ```
-kf configure-space append-domain SPACE_NAME DOMAIN [flags]
+kf configure-space append-domain [SPACE_NAME] DOMAIN [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space append-domain my-space myspace.mycompany.com
+  # Configure the targeted space
+  kf configure-space append-domain myspace.mycompany.com
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-buildpack-builder.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-buildpack-builder.md
@@ -12,13 +12,16 @@ Get the buildpack builder used for builds.
 Get the buildpack builder used for builds.
 
 ```
-kf configure-space get-buildpack-builder SPACE_NAME [flags]
+kf configure-space get-buildpack-builder [SPACE_NAME] [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space get-buildpack-builder my-space
+  # Configure the targeted space
+  kf configure-space get-buildpack-builder
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-buildpack-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-buildpack-env.md
@@ -12,13 +12,16 @@ Get the environment variables for buildpack builds in a space.
 Get the environment variables for buildpack builds in a space.
 
 ```
-kf configure-space get-buildpack-env SPACE_NAME [flags]
+kf configure-space get-buildpack-env [SPACE_NAME] [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space get-buildpack-env my-space
+  # Configure the targeted space
+  kf configure-space get-buildpack-env
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-container-registry.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-container-registry.md
@@ -12,13 +12,16 @@ Get the container registry used for builds.
 Get the container registry used for builds.
 
 ```
-kf configure-space get-container-registry SPACE_NAME [flags]
+kf configure-space get-container-registry [SPACE_NAME] [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space get-container-registry my-space
+  # Configure the targeted space
+  kf configure-space get-container-registry
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-domains.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-domains.md
@@ -12,13 +12,16 @@ Get domains associated with the space.
 Get domains associated with the space.
 
 ```
-kf configure-space get-domains SPACE_NAME [flags]
+kf configure-space get-domains [SPACE_NAME] [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space get-domains my-space
+  # Configure the targeted space
+  kf configure-space get-domains
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-execution-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-execution-env.md
@@ -12,13 +12,16 @@ Get the space-wide environment variables.
 Get the space-wide environment variables.
 
 ```
-kf configure-space get-execution-env SPACE_NAME [flags]
+kf configure-space get-execution-env [SPACE_NAME] [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space get-execution-env my-space
+  # Configure the targeted space
+  kf configure-space get-execution-env
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_remove-domain.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_remove-domain.md
@@ -12,13 +12,16 @@ Remove a domain from a space
 Remove a domain from a space
 
 ```
-kf configure-space remove-domain SPACE_NAME DOMAIN [flags]
+kf configure-space remove-domain [SPACE_NAME] DOMAIN [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space remove-domain my-space myspace.mycompany.com
+  # Configure the targeted space
+  kf configure-space remove-domain myspace.mycompany.com
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-buildpack-builder.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-buildpack-builder.md
@@ -12,13 +12,16 @@ Set the buildpack builder image.
 Set the buildpack builder image.
 
 ```
-kf configure-space set-buildpack-builder SPACE_NAME BUILDER_IMAGE [flags]
+kf configure-space set-buildpack-builder [SPACE_NAME] BUILDER_IMAGE [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space set-buildpack-builder my-space gcr.io/my-project/builder:latest
+  # Configure the targeted space
+  kf configure-space set-buildpack-builder gcr.io/my-project/builder:latest
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-buildpack-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-buildpack-env.md
@@ -12,13 +12,16 @@ Set an environment variable for buildpack builds in a space.
 Set an environment variable for buildpack builds in a space.
 
 ```
-kf configure-space set-buildpack-env SPACE_NAME ENV_VAR_NAME ENV_VAR_VALUE [flags]
+kf configure-space set-buildpack-env [SPACE_NAME] ENV_VAR_NAME ENV_VAR_VALUE [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space set-buildpack-env my-space JDK_VERSION 11
+  # Configure the targeted space
+  kf configure-space set-buildpack-env JDK_VERSION 11
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-container-registry.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-container-registry.md
@@ -12,13 +12,16 @@ Set the container registry used for builds.
 Set the container registry used for builds.
 
 ```
-kf configure-space set-container-registry SPACE_NAME REGISTRY [flags]
+kf configure-space set-container-registry [SPACE_NAME] REGISTRY [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space set-container-registry my-space gcr.io/my-project
+  # Configure the targeted space
+  kf configure-space set-container-registry gcr.io/my-project
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-default-domain.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-default-domain.md
@@ -12,13 +12,16 @@ Set a default domain for a space
 Set a default domain for a space
 
 ```
-kf configure-space set-default-domain SPACE_NAME DOMAIN [flags]
+kf configure-space set-default-domain [SPACE_NAME] DOMAIN [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space set-default-domain my-space myspace.mycompany.com
+  # Configure the targeted space
+  kf configure-space set-default-domain myspace.mycompany.com
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-env.md
@@ -12,13 +12,16 @@ Set a space-wide environment variable.
 Set a space-wide environment variable.
 
 ```
-kf configure-space set-env SPACE_NAME ENV_VAR_NAME ENV_VAR_VALUE [flags]
+kf configure-space set-env [SPACE_NAME] ENV_VAR_NAME ENV_VAR_VALUE [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space set-env my-space ENVIRONMENT production
+  # Configure the targeted space
+  kf configure-space set-env ENVIRONMENT production
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_unset-buildpack-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_unset-buildpack-env.md
@@ -12,13 +12,16 @@ Unset an environment variable for buildpack builds in a space.
 Unset an environment variable for buildpack builds in a space.
 
 ```
-kf configure-space unset-buildpack-env SPACE_NAME ENV_VAR_NAME [flags]
+kf configure-space unset-buildpack-env [SPACE_NAME] ENV_VAR_NAME [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space unset-buildpack-env my-space JDK_VERSION
+  # Configure the targeted space
+  kf configure-space unset-buildpack-env JDK_VERSION
 ```
 
 ### Options

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_unset-env.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_unset-env.md
@@ -12,13 +12,16 @@ Unset a space-wide environment variable.
 Unset a space-wide environment variable.
 
 ```
-kf configure-space unset-env SPACE_NAME ENV_VAR_NAME [flags]
+kf configure-space unset-env [SPACE_NAME] ENV_VAR_NAME [flags]
 ```
 
 ### Examples
 
 ```
+  # Configure the space "my-space"
   kf configure-space unset-env my-space ENVIRONMENT
+  # Configure the targeted space
+  kf configure-space unset-env ENVIRONMENT
 ```
 
 ### Options

--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -15,6 +15,7 @@
 package spaces
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -97,13 +98,24 @@ type spaceMutator struct {
 	Init        func(args []string) (spaces.Mutator, error)
 }
 
+func (sm spaceMutator) exampleCommands() string {
+	joinedArgs := strings.Join(sm.ExampleArgs, " ")
+	buffer := &bytes.Buffer{}
+	fmt.Fprintln(buffer)
+	fmt.Fprintf(buffer, "  # Configure the space \"my-space\"\n")
+	fmt.Fprintf(buffer, "  kf configure-space %s my-space %s\n", sm.Name, joinedArgs)
+	fmt.Fprintf(buffer, "  # Configure the targeted space\n")
+	fmt.Fprintf(buffer, "  kf configure-space %s %s\n", sm.Name, joinedArgs)
+	return buffer.String()
+}
+
 func (sm spaceMutator) ToCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s SPACE_NAME %s", sm.Name, strings.Join(sm.Args, " ")),
+		Use:     fmt.Sprintf("%s [SPACE_NAME] %s", sm.Name, strings.Join(sm.Args, " ")),
 		Short:   sm.Short,
 		Long:    sm.Short,
 		Args:    cobra.RangeArgs(len(sm.Args), 1+len(sm.Args)),
-		Example: fmt.Sprintf("kf configure-space %s my-space %s", sm.Name, strings.Join(sm.ExampleArgs, " ")),
+		Example: sm.exampleCommands(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var spaceName string
 			if len(args) <= len(sm.Args) {
@@ -323,12 +335,22 @@ type spaceAccessor struct {
 	Accessor func(space *v1alpha1.Space) interface{}
 }
 
+func (sm spaceAccessor) exampleCommands() string {
+	buffer := &bytes.Buffer{}
+	fmt.Fprintln(buffer)
+	fmt.Fprintf(buffer, "  # Configure the space \"my-space\"\n")
+	fmt.Fprintf(buffer, "  kf configure-space %s my-space\n", sm.Name)
+	fmt.Fprintf(buffer, "  # Configure the targeted space\n")
+	fmt.Fprintf(buffer, "  kf configure-space %s\n", sm.Name)
+	return buffer.String()
+}
+
 func (sm spaceAccessor) ToCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     fmt.Sprintf("%s SPACE_NAME", sm.Name),
+		Use:     fmt.Sprintf("%s [SPACE_NAME]", sm.Name),
 		Short:   sm.Short,
 		Long:    sm.Short,
-		Example: fmt.Sprintf("kf configure-space %s my-space", sm.Name),
+		Example: sm.exampleCommands(),
 		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var spaceName string

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/kf/pkg/kf/spaces"
 	"github.com/google/kf/pkg/kf/spaces/fake"
 	"github.com/google/kf/pkg/kf/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNewConfigSpaceCommand(t *testing.T) {
@@ -40,13 +41,25 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 		"invalid number of args": {
 			// Should have 2 more args
 			args:    []string{"set-container-registry"},
-			wantErr: errors.New("accepts 2 arg(s), received 0"),
+			wantErr: errors.New("accepts between 1 and 2 arg(s), received 0"),
 		},
 
 		"set-container-registry valid": {
 			args: []string{"set-container-registry", space, "gcr.io/foo"},
 			validate: func(t *testing.T, space *v1alpha1.Space) {
 				testutil.AssertEqual(t, "container registry", "gcr.io/foo", space.Spec.BuildpackBuild.ContainerRegistry)
+			},
+		},
+
+		"set with targeted space": {
+			args: []string{"set-container-registry", "gcr.io/foo"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "container registry", "gcr.io/foo", space.Spec.BuildpackBuild.ContainerRegistry)
+			},
+			space: v1alpha1.Space{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: space,
+				},
 			},
 		},
 
@@ -211,7 +224,9 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 
 			buffer := &bytes.Buffer{}
 
-			c := NewConfigSpaceCommand(&config.KfParams{}, fakeSpaces)
+			c := NewConfigSpaceCommand(&config.KfParams{
+				Namespace: tc.space.GetName(),
+			}, fakeSpaces)
 			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 
@@ -232,6 +247,9 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 
 func TestNewConfigSpaceCommand_accessors(t *testing.T) {
 	space := v1alpha1.Space{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "space-name",
+		},
 		Spec: v1alpha1.SpaceSpec{
 			BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
 				ContainerRegistry: "gcr.io/foo",
@@ -262,6 +280,15 @@ func TestNewConfigSpaceCommand_accessors(t *testing.T) {
 	}{
 		"get-execution-env valid": {
 			args:  []string{"get-execution-env", "space-name"},
+			space: space,
+			wantOutput: `- name: BAR
+  value: BAZZ
+- name: PROFILE
+  value: development
+`,
+		},
+		"get-execution-env targeted space": {
+			args:  []string{"get-execution-env"},
 			space: space,
 			wantOutput: `- name: BAR
   value: BAZZ
@@ -307,7 +334,9 @@ func TestNewConfigSpaceCommand_accessors(t *testing.T) {
 
 			buffer := &bytes.Buffer{}
 
-			c := NewConfigSpaceCommand(&config.KfParams{}, fakeSpaces)
+			c := NewConfigSpaceCommand(&config.KfParams{
+				Namespace: tc.space.GetName(),
+			}, fakeSpaces)
 			c.SetOutput(buffer)
 			c.SetArgs(tc.args)
 


### PR DESCRIPTION

<!-- Include the issue number below -->

## Proposed Changes

* configure-space uses the targeted namespace by default

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
