### PR TITLE
Add scripts to scrape Cloud Run documentation

### DIFF
--- a/hack/flatten-supported-gke-versions.py
+++ b/hack/flatten-supported-gke-versions.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Consumes the output of ./hack/scrape-supported-gke-versions.py
+# and inverts the relationship between Cloud Run and GKE.
+
+import json
+import sys
+
+versions = json.loads(sys.stdin.read())
+flattened = []
+for version in versions:
+    for gke_version in version["gke_versions"]:
+        flattened.append({
+            "gke_version": gke_version,
+            "cloud_run_version": version["cloud_run_version"],
+        })
+flattened.sort(key=lambda x: x["gke_version"])
+print(json.dumps(flattened))

--- a/hack/scrape-supported-gke-versions.py
+++ b/hack/scrape-supported-gke-versions.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the License);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script uses the chrome web driver and selenium to scapre the GCP docs for
+# supported Cloud Run versions on GKE
+#
+# Prerequisites for this script are:
+# - pip install selenium
+# - download chromedriver from https://chromedriver.chromium.org/downloads
+
+from selenium import webdriver
+import json
+
+options = webdriver.ChromeOptions()
+options.add_argument('headless')
+browser = webdriver.Chrome(options=options)
+browser.get("https://cloud.google.com/run/docs/gke/cluster-versions")
+
+# assume there's only one div with this class.
+elem = browser.find_element_by_class_name("devsite-table-wrapper")
+table = elem.find_element_by_tag_name("table")
+rows = table.find_elements_by_tag_name("tr")
+
+title = True
+supported_versions = []
+for row in rows:
+    if title:
+        title = False
+        continue
+    cols = row.find_elements_by_tag_name("td")
+    cloud_run_cell = cols[0]
+    gke_cell = cols[1]
+    cloud_run_version = cloud_run_cell.text
+    gke_verions = gke_cell.find_elements_by_tag_name("p")
+    gke_verions = [p.text for p in gke_verions]
+    supported_versions.append({
+        "cloud_run_version": cloud_run_version,
+        "gke_versions": gke_verions,
+    })
+
+print(json.dumps(supported_versions))


### PR DESCRIPTION
## Proposed Changes

* Add scripts to scrape Cloud Run documentation for knowing which versions of Cloud Run are available on which versions
of GKE

./hack/scrape-supported-gke-versions.py
```
[{"cloud_run_version": "0.8.1-gke.0", "gke_versions": ["1.14.6-gke.13", "1.13.10-gke.7", "1.12.10-gke.11"]}, {"cloud_run_version": "0.8.0-gke.0", "gke_versions": ["1.13.10-gke.0", "1.12.10-gke.5"]}, {"cloud_run_version": "0.6.1-gke.1", "gke_versions": ["1.13.9-gke.3", "1.13.7-gke.24", "1.12.9-gke.16", "1.12.9-gke.15"]}]
```

./hack/scrape-supported-gke-versions.py | ./hack/flatten-supported-gke-versions.py
```
[{"gke_version": "1.12.10-gke.11", "cloud_run_version": "0.8.1-gke.0"}, {"gke_version": "1.12.10-gke.5", "cloud_run_version": "0.8.0-gke.0"}, {"gke_version": "1.12.9-gke.15", "cloud_run_version": "0.6.1-gke.1"}, {"gke_version": "1.12.9-gke.16", "cloud_run_version": "0.6.1-gke.1"}, {"gke_version": "1.13.10-gke.0", "cloud_run_version": "0.8.0-gke.0"}, {"gke_version": "1.13.10-gke.7", "cloud_run_version": "0.8.1-gke.0"}, {"gke_version": "1.13.7-gke.24", "cloud_run_version": "0.6.1-gke.1"}, {"gke_version": "1.13.9-gke.3", "cloud_run_version": "0.6.1-gke.1"}, {"gke_version": "1.14.6-gke.13", "cloud_run_version": "0.8.1-gke.0"}]
```

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
