### PR TITLE
pkg/kf/commands/spaces: configure BuildServiceAccount

### DIFF
--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space.md
@@ -39,6 +39,7 @@ kf configure-space [subcommand] [flags]
 * [kf](/docs/general-info/kf-cli/commands/kf/)	 - A MicroPaaS for Kubernetes with a Cloud Foundry style developer expeience
 * [kf configure-space append-domain](/docs/general-info/kf-cli/commands/kf-configure-space-append-domain/)	 - Append a domain for a space
 * [kf configure-space delete-quota](/docs/general-info/kf-cli/commands/kf-configure-space-delete-quota/)	 - Remove all quotas for the space
+* [kf configure-space get-build-service-account](/docs/general-info/kf-cli/commands/kf-configure-space-get-build-service-account/)	 - Get the service account that is used when building containers in the space.
 * [kf configure-space get-buildpack-builder](/docs/general-info/kf-cli/commands/kf-configure-space-get-buildpack-builder/)	 - Get the buildpack builder used for builds.
 * [kf configure-space get-buildpack-env](/docs/general-info/kf-cli/commands/kf-configure-space-get-buildpack-env/)	 - Get the environment variables for buildpack builds in a space.
 * [kf configure-space get-container-registry](/docs/general-info/kf-cli/commands/kf-configure-space-get-container-registry/)	 - Get the container registry used for builds.
@@ -46,6 +47,7 @@ kf configure-space [subcommand] [flags]
 * [kf configure-space get-execution-env](/docs/general-info/kf-cli/commands/kf-configure-space-get-execution-env/)	 - Get the space-wide environment variables.
 * [kf configure-space quota](/docs/general-info/kf-cli/commands/kf-configure-space-quota/)	 - Show quota info for a space
 * [kf configure-space remove-domain](/docs/general-info/kf-cli/commands/kf-configure-space-remove-domain/)	 - Remove a domain from a space
+* [kf configure-space set-build-service-account](/docs/general-info/kf-cli/commands/kf-configure-space-set-build-service-account/)	 - Set the service account to use when building containers
 * [kf configure-space set-buildpack-builder](/docs/general-info/kf-cli/commands/kf-configure-space-set-buildpack-builder/)	 - Set the buildpack builder image.
 * [kf configure-space set-buildpack-env](/docs/general-info/kf-cli/commands/kf-configure-space-set-buildpack-env/)	 - Set an environment variable for buildpack builds in a space.
 * [kf configure-space set-container-registry](/docs/general-info/kf-cli/commands/kf-configure-space-set-container-registry/)	 - Set the container registry used for builds.

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-build-service-account.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_get-build-service-account.md
@@ -1,0 +1,42 @@
+---
+title: "kf configure-space get-build-service-account"
+slug: kf-configure-space-get-build-service-account
+url: /docs/general-info/kf-cli/commands/kf-configure-space-get-build-service-account/
+---
+## kf configure-space get-build-service-account
+
+Get the service account that is used when building containers in the space.
+
+### Synopsis
+
+Get the service account that is used when building containers in the space.
+
+```
+kf configure-space get-build-service-account SPACE_NAME [flags]
+```
+
+### Examples
+
+```
+  kf configure-space get-build-service-account my-space
+```
+
+### Options
+
+```
+  -h, --help   help for get-build-service-account
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       Config file (default is $HOME/.kf)
+      --kubeconfig string   Kubectl config file (default is $HOME/.kube/config)
+      --log-http            Log HTTP requests to stderr
+      --namespace string    Kubernetes namespace to target
+```
+
+### SEE ALSO
+
+* [kf configure-space](/docs/general-info/kf-cli/commands/kf-configure-space/)	 - Set configuration for a space
+

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-build-service-account.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_configure-space_set-build-service-account.md
@@ -1,0 +1,42 @@
+---
+title: "kf configure-space set-build-service-account"
+slug: kf-configure-space-set-build-service-account
+url: /docs/general-info/kf-cli/commands/kf-configure-space-set-build-service-account/
+---
+## kf configure-space set-build-service-account
+
+Set the service account to use when building containers
+
+### Synopsis
+
+Set the service account to use when building containers
+
+```
+kf configure-space set-build-service-account SPACE_NAME SERVICE_ACCOUNT [flags]
+```
+
+### Examples
+
+```
+  kf configure-space set-build-service-account my-space myserviceaccount
+```
+
+### Options
+
+```
+  -h, --help   help for set-build-service-account
+```
+
+### Options inherited from parent commands
+
+```
+      --config string       Config file (default is $HOME/.kf)
+      --kubeconfig string   Kubectl config file (default is $HOME/.kube/config)
+      --log-http            Log HTTP requests to stderr
+      --namespace string    Kubernetes namespace to target
+```
+
+### SEE ALSO
+
+* [kf configure-space](/docs/general-info/kf-cli/commands/kf-configure-space/)	 - Set configuration for a space
+

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_create-space.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_create-space.md
@@ -18,15 +18,16 @@ kf create-space SPACE [flags]
 ### Examples
 
 ```
-  kf create-space my-space --container-registry gcr.io/my-project --domain myspace.example.com
+  kf create-space my-space --container-registry gcr.io/my-project --domain myspace.example.com --build-service-account myserviceaccount
 ```
 
 ### Options
 
 ```
-      --container-registry string   Container registry built apps and sources will be stored in.
-      --domain stringArray          Sets the valid domains for the space. The first provided domain will be the default.
-  -h, --help                        help for create-space
+      --build-service-account string   Service account that the build pipeline will use to build containers.
+      --container-registry string      Container registry built apps and sources will be stored in.
+      --domain stringArray             Sets the valid domains for the space. The first provided domain will be the default.
+  -h, --help                           help for create-space
 ```
 
 ### Options inherited from parent commands

--- a/pkg/kf/commands/spaces/config_space.go
+++ b/pkg/kf/commands/spaces/config_space.go
@@ -61,6 +61,7 @@ func NewConfigSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 		newAppendDomainMutator(),
 		newSetDefaultDomainMutator(),
 		newRemoveDomainMutator(),
+		newBuildServiceAccountMutator(),
 	}
 
 	for _, sm := range subcommands {
@@ -73,6 +74,7 @@ func NewConfigSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 		newGetExecutionEnvAccessor(),
 		newGetBuildpackEnvAccessor(),
 		newGetDomainsAccessor(),
+		newGetBuildServiceAccountAccessor(),
 	}
 
 	for _, sa := range accessors {
@@ -307,6 +309,23 @@ func newRemoveDomainMutator() spaceMutator {
 	}
 }
 
+func newBuildServiceAccountMutator() spaceMutator {
+	return spaceMutator{
+		Name:        "set-build-service-account",
+		Short:       "Set the service account to use when building containers",
+		Args:        []string{"SERVICE_ACCOUNT"},
+		ExampleArgs: []string{"myserviceaccount"},
+		Init: func(args []string) (spaces.Mutator, error) {
+			serviceAccount := args[0]
+
+			return func(space *v1alpha1.Space) error {
+				space.Spec.Security.BuildServiceAccount = serviceAccount
+				return nil
+			}, nil
+		},
+	}
+}
+
 type spaceAccessor struct {
 	Name     string
 	Short    string
@@ -397,6 +416,16 @@ func newGetDomainsAccessor() spaceAccessor {
 		Short: "Get domains associated with the space.",
 		Accessor: func(space *v1alpha1.Space) interface{} {
 			return space.Spec.Execution.Domains
+		},
+	}
+}
+
+func newGetBuildServiceAccountAccessor() spaceAccessor {
+	return spaceAccessor{
+		Name:  "get-build-service-account",
+		Short: "Get the service account that is used when building containers in the space.",
+		Accessor: func(space *v1alpha1.Space) interface{} {
+			return space.Spec.Security.BuildServiceAccount
 		},
 	}
 }

--- a/pkg/kf/commands/spaces/config_space_test.go
+++ b/pkg/kf/commands/spaces/config_space_test.go
@@ -194,6 +194,20 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 				testutil.AssertEqual(t, "domains", "example.com", space.Spec.Execution.Domains[0].Domain)
 			},
 		},
+
+		"set-build-service-account valid": {
+			space: v1alpha1.Space{
+				Spec: v1alpha1.SpaceSpec{
+					Security: v1alpha1.SpaceSpecSecurity{
+						BuildServiceAccount: "some-service-account",
+					},
+				},
+			},
+			args: []string{"set-build-service-account", space, "some-other-service-account"},
+			validate: func(t *testing.T, space *v1alpha1.Space) {
+				testutil.AssertEqual(t, "build-service-account", "some-other-service-account", space.Spec.Security.BuildServiceAccount)
+			},
+		},
 	}
 
 	for tn, tc := range cases {
@@ -233,6 +247,9 @@ func TestNewConfigSpaceCommand(t *testing.T) {
 func TestNewConfigSpaceCommand_accessors(t *testing.T) {
 	space := v1alpha1.Space{
 		Spec: v1alpha1.SpaceSpec{
+			Security: v1alpha1.SpaceSpecSecurity{
+				BuildServiceAccount: "some-service-account",
+			},
 			BuildpackBuild: v1alpha1.SpaceSpecBuildpackBuild{
 				ContainerRegistry: "gcr.io/foo",
 				BuilderImage:      "gcr.io/buildpack-builder:latest",
@@ -295,6 +312,11 @@ func TestNewConfigSpaceCommand_accessors(t *testing.T) {
   domain: example.com
 - domain: other-example.com
 `,
+		},
+		"get-build-service-account valid": {
+			args:       []string{"get-build-service-account", "space-name"},
+			space:      space,
+			wantOutput: "some-service-account\n",
 		},
 	}
 

--- a/pkg/kf/commands/spaces/create.go
+++ b/pkg/kf/commands/spaces/create.go
@@ -30,14 +30,15 @@ import (
 // NewCreateSpaceCommand allows users to create spaces.
 func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
 	var (
-		containerRegistry string
-		domains           []string
+		containerRegistry   string
+		buildServiceAccount string
+		domains             []string
 	)
 
 	cmd := &cobra.Command{
 		Use:     "create-space SPACE",
 		Short:   "Create a space",
-		Example: `kf create-space my-space --container-registry gcr.io/my-project --domain myspace.example.com`,
+		Example: `kf create-space my-space --container-registry gcr.io/my-project --domain myspace.example.com --build-service-account myserviceaccount`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -47,6 +48,7 @@ func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 			toCreate := spaces.NewKfSpace()
 			toCreate.SetName(name)
 			toCreate.SetContainerRegistry(containerRegistry)
+			toCreate.SetBuildServiceAccount(buildServiceAccount)
 
 			for i, domain := range domains {
 				toCreate.AppendDomains(v1alpha1.SpaceDomain{Domain: domain, Default: i == 0})
@@ -77,6 +79,13 @@ func NewCreateSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Comm
 		"container-registry",
 		"",
 		"Container registry built apps and sources will be stored in.",
+	)
+
+	cmd.Flags().StringVar(
+		&buildServiceAccount,
+		"build-service-account",
+		"",
+		"Service account that the build pipeline will use to build containers.",
 	)
 
 	cmd.Flags().StringArrayVar(

--- a/pkg/kf/commands/spaces/create_test.go
+++ b/pkg/kf/commands/spaces/create_test.go
@@ -40,7 +40,7 @@ func TestNewCreateSpaceCommand(t *testing.T) {
 			wantErr: errors.New("accepts 1 arg(s), received 0"),
 		},
 		"object passed through": {
-			args: []string{"my-ns", "--container-registry=some-registry", "--domain=domain-1", "--domain=domain-2"},
+			args: []string{"my-ns", "--container-registry=some-registry", "--domain=domain-1", "--domain=domain-2", "--build-service-account=some-service-account"},
 			setup: func(t *testing.T, fakeSpaces *fake.FakeClient) {
 				fakeSpaces.
 					EXPECT().
@@ -49,6 +49,7 @@ func TestNewCreateSpaceCommand(t *testing.T) {
 						testutil.AssertEqual(t, "sets name", "my-ns", space.Name)
 						testutil.AssertEqual(t, "sets container registry", "some-registry", space.Spec.BuildpackBuild.ContainerRegistry)
 						testutil.AssertEqual(t, "sets domains", []v1alpha1.SpaceDomain{{Domain: "domain-1", Default: true}, {Domain: "domain-2"}}, space.Spec.Execution.Domains)
+						testutil.AssertEqual(t, "sets build service account", "some-service-account", space.Spec.Security.BuildServiceAccount)
 					})
 
 				fakeSpaces.EXPECT().WaitFor(gomock.Any(), "my-ns", 1*time.Second, gomock.Any()).Return(&v1alpha1.Space{}, nil)

--- a/pkg/kf/commands/spaces/get.go
+++ b/pkg/kf/commands/spaces/get.go
@@ -61,6 +61,7 @@ func NewGetSpaceCommand(p *config.KfParams, client spaces.Client) *cobra.Command
 			describe.SectionWriter(w, "Security", func(w io.Writer) {
 				security := space.Spec.Security
 				fmt.Fprintf(w, "Developers can read logs?\t%v\n", security.EnableDeveloperLogsAccess)
+				fmt.Fprintf(w, "Build Service Account:\t%s\n", security.BuildServiceAccount)
 			})
 			fmt.Fprintln(w)
 

--- a/pkg/kf/commands/spaces/get_test.go
+++ b/pkg/kf/commands/spaces/get_test.go
@@ -35,6 +35,7 @@ func TestNewGetSpaceCommand(t *testing.T) {
 	goodSpace.Name = "my-space"
 	goodSpace.Spec = v1alpha1.SpaceSpec{}
 	goodSpace.Spec.Security.EnableDeveloperLogsAccess = true
+	goodSpace.Spec.Security.BuildServiceAccount = "some-service-account"
 	goodSpace.Status.Conditions = []apis.Condition{{
 		Type:   "Ready",
 		Status: "TESTING",
@@ -67,7 +68,7 @@ func TestNewGetSpaceCommand(t *testing.T) {
 		"security": {
 			args:       []string{"my-space"},
 			space:      goodSpace,
-			wantOutput: []string{"Security", "read logs?", "true"},
+			wantOutput: []string{"Security", "read logs?", "true", "Build Service Account", "some-service-account"},
 		},
 		"build": {
 			args:       []string{"my-space"},

--- a/pkg/kf/spaces/kfspace.go
+++ b/pkg/kf/spaces/kfspace.go
@@ -44,6 +44,16 @@ func (k *KfSpace) SetContainerRegistry(registry string) {
 	k.Spec.BuildpackBuild.ContainerRegistry = registry
 }
 
+// GetBuildServiceAccount gets the build service account for the space.
+func (k *KfSpace) GetBuildServiceAccount() string {
+	return k.Spec.Security.BuildServiceAccount
+}
+
+// SetBuildServiceAccount sets the build service account for the space.
+func (k *KfSpace) SetBuildServiceAccount(serviceAccount string) {
+	k.Spec.Security.BuildServiceAccount = serviceAccount
+}
+
 // GetQuota retrieves the space quota.
 func (k *KfSpace) GetQuota() v1.ResourceList {
 	return k.Spec.ResourceLimits.SpaceQuota

--- a/pkg/kf/spaces/kfspace_test.go
+++ b/pkg/kf/spaces/kfspace_test.go
@@ -28,13 +28,16 @@ func ExampleKfSpace() {
 	// Setup
 	space.SetName("nsname")
 	space.SetContainerRegistry("gcr.io/my-registry")
+	space.SetBuildServiceAccount("some-service-account")
 
 	// Values
 	fmt.Println("Name:", space.GetName())
 	fmt.Println("Registry:", space.GetContainerRegistry())
+	fmt.Println("Build Service Account:", space.GetBuildServiceAccount())
 
 	// Output: Name: nsname
 	// Registry: gcr.io/my-registry
+	// Build Service Account: some-service-account
 }
 
 func TestKfSpace_ToSpace(t *testing.T) {


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #785 

## Proposed Changes

* Adds way to configure BuildServiceAccount for spaces
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Adds way to configure space's BuildServiceAccount property
```
