### PR TITLE
Fix hack/update-codegen.sh so it takes 1 min

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -164,7 +164,26 @@ svccat-knative-gen() {
     "servicecatalog:v1beta1"
 }
 
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+cd "${REPO_ROOT}"
+
+# enable modules and the proxy cache
+export GO111MODULE="on"
+GOPROXY="${GOPROXY:-https://proxy.golang.org}"
+export GOPROXY
+
 go mod vendor
+export GO111MODULE="off"
+
+# fake being in a gopath
+FAKE_GOPATH="$(mktemp -d)"
+trap 'rm -rf ${FAKE_GOPATH}' EXIT
+
+FAKE_REPOPATH="${FAKE_GOPATH}/src/github.com/google/kf"
+mkdir -p "$(dirname "${FAKE_REPOPATH}")" && ln -s "${REPO_ROOT}" "${FAKE_REPOPATH}"
+export GOPATH="${FAKE_GOPATH}"
+cd "${FAKE_REPOPATH}"
+
 download-scripts
 
 case $GENS in


### PR DESCRIPTION
Thanks to
https://github.com/kubernetes-sigs/kind/blob/10642f530782963ed23b3d4a14587950bbacaa63/hack/update-generated.sh

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Create fake GOPATH when running the code generator

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
