### PR TITLE
pkg/reconciler/space: add build Service Account

### DIFF
--- a/pkg/apis/kf/v1alpha1/space_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/space_lifecycle.go
@@ -48,6 +48,9 @@ const (
 	// SpaceConditionLimitRangeReady is set when the limit range is
 	// ready.
 	SpaceConditionLimitRangeReady apis.ConditionType = "LimitRangeReady"
+	// SpaceConditionBuildServiceAccountReady is set when the
+	// BuildServiceAccount is ready.
+	SpaceConditionBuildServiceAccountReady apis.ConditionType = "BuildServiceAccountReady"
 )
 
 func (status *SpaceStatus) manage() apis.ConditionManager {
@@ -57,6 +60,7 @@ func (status *SpaceStatus) manage() apis.ConditionManager {
 		SpaceConditionAuditorRoleReady,
 		SpaceConditionResourceQuotaReady,
 		SpaceConditionLimitRangeReady,
+		SpaceConditionBuildServiceAccountReady,
 	).Manage(status)
 }
 
@@ -105,6 +109,13 @@ func (status *SpaceStatus) MarkLimitRangeNotOwned(name string) {
 		fmt.Sprintf("There is an existing limitrange %q that we do not own.", name))
 }
 
+// MarkBuildServiceAccountNotOwned marks the build ServiceAccount as not being
+// owned by the Space.
+func (status *SpaceStatus) MarkBuildServiceAccountNotOwned(name string) {
+	status.manage().MarkFalse(SpaceConditionBuildServiceAccountReady, "NotOwned",
+		fmt.Sprintf("There is an existing build serviceaccount %q that we do not own.", name))
+}
+
 // PropagateNamespaceStatus copies fields from the Namespace status to Space
 // and updates the readiness based on the current phase.
 func (status *SpaceStatus) PropagateNamespaceStatus(ns *v1.Namespace) {
@@ -145,6 +156,12 @@ func (status *SpaceStatus) PropagateResourceQuotaStatus(quota *v1.ResourceQuota)
 // based on if a LimitRange exists.
 func (status *SpaceStatus) PropagateLimitRangeStatus(limitRange *v1.LimitRange) {
 	status.manage().MarkTrue(SpaceConditionLimitRangeReady)
+}
+
+// PropagateBuildServiceAccountStatus updates the readiness of the space based
+// on if a BuildServiceAccount exists.
+func (status *SpaceStatus) PropagateBuildServiceAccountStatus(sa *v1.ServiceAccount) {
+	status.manage().MarkTrue(SpaceConditionBuildServiceAccountReady)
 }
 
 func (status *SpaceStatus) duck() *duckv1beta1.Status {

--- a/pkg/apis/kf/v1alpha1/space_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/space_lifecycle_test.go
@@ -170,6 +170,7 @@ func initTestStatus(t *testing.T) *SpaceStatus {
 	apitesting.CheckConditionOngoing(status.duck(), SpaceConditionDeveloperRoleReady, t)
 	apitesting.CheckConditionOngoing(status.duck(), SpaceConditionResourceQuotaReady, t)
 	apitesting.CheckConditionOngoing(status.duck(), SpaceConditionLimitRangeReady, t)
+	apitesting.CheckConditionOngoing(status.duck(), SpaceConditionBuildServiceAccountReady, t)
 
 	return status
 }
@@ -184,6 +185,7 @@ func TestSpaceHappyPath(t *testing.T) {
 		Status: corev1.ResourceQuotaStatus{},
 	})
 	status.PropagateLimitRangeStatus(nil)
+	status.PropagateBuildServiceAccountStatus(nil)
 
 	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionReady, t)
 	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionNamespaceReady, t)
@@ -191,6 +193,7 @@ func TestSpaceHappyPath(t *testing.T) {
 	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionDeveloperRoleReady, t)
 	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionResourceQuotaReady, t)
 	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionLimitRangeReady, t)
+	apitesting.CheckConditionSucceeded(status.duck(), SpaceConditionBuildServiceAccountReady, t)
 }
 
 func TestPropagateNamespaceStatus_terminating(t *testing.T) {
@@ -248,6 +251,7 @@ func TestSpaceStatus_lifecycle(t *testing.T) {
 					Status: corev1.ResourceQuotaStatus{},
 				})
 				status.PropagateLimitRangeStatus(nil)
+				status.PropagateBuildServiceAccountStatus(nil)
 			},
 			ExpectSucceeded: []apis.ConditionType{
 				SpaceConditionReady,
@@ -256,6 +260,7 @@ func TestSpaceStatus_lifecycle(t *testing.T) {
 				SpaceConditionDeveloperRoleReady,
 				SpaceConditionResourceQuotaReady,
 				SpaceConditionLimitRangeReady,
+				SpaceConditionBuildServiceAccountReady,
 			},
 		},
 		"terminating namespace": {
@@ -343,6 +348,18 @@ func TestSpaceStatus_lifecycle(t *testing.T) {
 			ExpectFailed: []apis.ConditionType{
 				SpaceConditionReady,
 				SpaceConditionLimitRangeReady,
+			},
+		},
+		"Build ServiceAccount not owned": {
+			Init: func(status *SpaceStatus) {
+				status.MarkBuildServiceAccountNotOwned("build-service-account")
+			},
+			ExpectOngoing: []apis.ConditionType{
+				SpaceConditionNamespaceReady,
+			},
+			ExpectFailed: []apis.ConditionType{
+				SpaceConditionReady,
+				SpaceConditionBuildServiceAccountReady,
 			},
 		},
 	}

--- a/pkg/reconciler/space/controller.go
+++ b/pkg/reconciler/space/controller.go
@@ -21,6 +21,7 @@ import (
 	spaceinformer "github.com/google/kf/pkg/client/injection/informers/kf/v1alpha1/space"
 	"github.com/google/kf/pkg/reconciler"
 	namespaceinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/namespace"
+	serviceaccountinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/serviceaccount"
 	roleinformer "knative.dev/pkg/injection/informers/kubeinformers/rbacv1/role"
 
 	// TODO (juliaguo): replace with knative informer pkgs once they are merged in
@@ -43,15 +44,17 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	roleInformer := roleinformer.Get(ctx)
 	quotaInformer := quotainformer.Get(ctx)
 	limitRangeInformer := limitrangeinformer.Get(ctx)
+	serviceAccountInformer := serviceaccountinformer.Get(ctx)
 
 	// Create reconciler
 	c := &Reconciler{
-		Base:                reconciler.NewBase(ctx, cmw),
-		spaceLister:         spaceInformer.Lister(),
-		namespaceLister:     nsInformer.Lister(),
-		roleLister:          roleInformer.Lister(),
-		resourceQuotaLister: quotaInformer.Lister(),
-		limitRangeLister:    limitRangeInformer.Lister(),
+		Base:                 reconciler.NewBase(ctx, cmw),
+		spaceLister:          spaceInformer.Lister(),
+		namespaceLister:      nsInformer.Lister(),
+		roleLister:           roleInformer.Lister(),
+		resourceQuotaLister:  quotaInformer.Lister(),
+		limitRangeLister:     limitRangeInformer.Lister(),
+		serviceAccountLister: serviceAccountInformer.Lister(),
 	}
 
 	impl := controller.NewImpl(c, logger, "Spaces")
@@ -76,6 +79,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	})
 
 	limitRangeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Space")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
+	serviceAccountInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.Filter(v1alpha1.SchemeGroupVersion.WithKind("Space")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})

--- a/pkg/reconciler/space/resources/build_service_account.go
+++ b/pkg/reconciler/space/resources/build_service_account.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/kmeta"
+)
+
+// BuildServiceAccountName gets the name of the service account for given the
+// space.
+func BuildServiceAccountName(space *v1alpha1.Space) string {
+	return "kf-build-service-account"
+}
+
+// MakeBuildServiceAccount creates a ServiceAccount for build pipelines to
+// use.
+func MakeBuildServiceAccount(space *v1alpha1.Space) (*corev1.ServiceAccount, error) {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      BuildServiceAccountName(space),
+			Namespace: NamespaceName(space),
+			OwnerReferences: []metav1.OwnerReference{
+				*kmeta.NewControllerRef(space),
+			},
+			Labels: v1alpha1.UnionMaps(space.GetLabels(), map[string]string{
+				v1alpha1.ManagedByLabel: "kf",
+			}),
+		},
+	}, nil
+}

--- a/pkg/reconciler/space/resources/build_service_account_test.go
+++ b/pkg/reconciler/space/resources/build_service_account_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resources
+
+import (
+	"fmt"
+
+	"github.com/google/kf/pkg/apis/kf/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func ExampleBuildServiceAccountName() {
+	fmt.Println(BuildServiceAccountName(&v1alpha1.Space{}))
+
+	// Output: kf-build-service-account
+}
+
+func ExampleMakeBuildServiceAccount() {
+	sa, err := MakeBuildServiceAccount(&v1alpha1.Space{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "some-space",
+		},
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Name:", sa.Name)
+	fmt.Println("Namespace:", sa.Namespace)
+	fmt.Println("Managed Label:", sa.Labels[v1alpha1.ManagedByLabel])
+
+	// Output: Name: kf-build-service-account
+	// Namespace: some-space
+	// Managed Label: kf
+}


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Space reconciler creates a service account per space. The SA does not have any secrets (yet). It will eventually be used by build pipelines for uploading containers.
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added feature for space reconciler to add service account
```
