### PR TITLE
pkg/kf/apps: handle metav1.Status failures in logs

### DIFF
--- a/pkg/kf/apps/log_tailer_test.go
+++ b/pkg/kf/apps/log_tailer_test.go
@@ -96,6 +96,9 @@ func TestLogTailer_DeployLogs_ServiceLogs(t *testing.T) {
 			events: append([]watch.Event{
 				{
 					Object: &metav1.Status{
+						ListMeta: metav1.ListMeta{
+							ResourceVersion: "some-version",
+						},
 						Status: metav1.StatusFailure,
 					},
 				},


### PR DESCRIPTION
Previous to this CL, our log stream would sometimes spit out:


<!-- Include the issue number below -->
Fixes #793

## Proposed Changes

* Logging stop watching Pod once resource is old
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed logging bug where old pods are still being watched
```
