### PR TITLE
update doctor with deployment and istio ingress checks

### DIFF
--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/kf/pkg/kf/commands/group"
 	"github.com/google/kf/pkg/kf/commands/install"
 	pkgdoctor "github.com/google/kf/pkg/kf/doctor"
+	"github.com/google/kf/pkg/kf/istio"
 	templates "github.com/google/kf/third_party/kubectl-templates"
 	"github.com/imdario/mergo"
 	"github.com/spf13/cobra"
@@ -181,6 +182,7 @@ func NewKfCommand() *cobra.Command {
 				doctor.NewDoctorCommand(p, []doctor.DoctorTest{
 					{Name: "cluster", Test: pkgdoctor.NewClusterDiagnostic(config.GetKubernetes(p))},
 					{Name: "buildpacks", Test: InjectBuildpacksClient(p)},
+					{Name: "istio", Test: istio.NewIstioClient(config.GetKubernetes(p))},
 				}),
 
 				completionCommand(rootCmd),

--- a/pkg/kf/doctor/cluster.go
+++ b/pkg/kf/doctor/cluster.go
@@ -16,6 +16,7 @@ package doctor
 
 import (
 	"github.com/google/kf/pkg/kf/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 )
@@ -33,6 +34,10 @@ var _ Diagnosable = (*ClusterDiagnostic)(nil)
 func (c *ClusterDiagnostic) Diagnose(d *Diagnostic) {
 	d.Run("Version", func(d *Diagnostic) {
 		diagnoseKubernetesVersion(d, c.kubeClient.Discovery())
+	})
+
+	d.Run("Controllers", func(d *Diagnostic) {
+		diagnoseControllers(d, c.kubeClient)
 	})
 
 	d.Run("Components", func(d *Diagnostic) {
@@ -96,6 +101,45 @@ func diagnoseComponents(d *Diagnostic, vc discovery.ServerResourcesInterface) {
 				d.Run(resource, func(d *Diagnostic) {
 					if !foundResources[resource] {
 						d.Errorf("Expected to find resource %s", resource)
+					}
+				})
+			}
+		})
+	}
+}
+
+func diagnoseControllers(d *Diagnostic, kubernetes kubernetes.Interface) {
+	expectedDeployments := []struct {
+		Namespace   string
+		Deployments []string
+	}{
+		{
+			Namespace:   "kf",
+			Deployments: []string{"webhook", "controller"},
+		},
+		{
+			Namespace:   "knative-serving",
+			Deployments: []string{"webhook", "controller", "activator", "autoscaler"},
+		},
+	}
+
+	for _, tc := range expectedDeployments {
+		d.Run(tc.Namespace, func(d *Diagnostic) {
+
+			for _, deploymentName := range tc.Deployments {
+				d.Run(deploymentName, func(d *Diagnostic) {
+
+					actual, err := kubernetes.AppsV1().Deployments(tc.Namespace).Get(deploymentName, metav1.GetOptions{})
+					if err != nil {
+						d.Errorf("couldn't fetch deployment %s: %v", actual, err)
+						return
+					}
+
+					ready := actual.Status.ReadyReplicas
+					desired := actual.Status.Replicas
+
+					if ready != desired {
+						d.Errorf("ready: %d/%d", ready, desired)
 					}
 				})
 			}


### PR DESCRIPTION
Adds checks to doctor for Istio ingress availability and deployments. These are tested as part of e2e tests and pass locally.