### PR TITLE
pkg/reconciler/source: move Build to use Secrets

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle.go
@@ -15,8 +15,6 @@
 package v1alpha1
 
 import (
-	"fmt"
-
 	build "github.com/google/kf/third_party/knative-build/pkg/apis/build/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -67,12 +65,6 @@ func (status *SourceStatus) InitializeConditions() {
 	status.manage().InitializeConditions()
 }
 
-// MarkBuildNotOwned marks the Build as not being owned by the Source.
-func (status *SourceStatus) MarkBuildNotOwned(name string) {
-	status.manage().MarkFalse(SourceConditionBuildSucceeded, "NotOwned",
-		fmt.Sprintf("There is an existing Build %q that we do not own.", name))
-}
-
 // PropagateBuildStatus copies fields from the Build status to Source and
 // updates the readiness based on the current phase.
 func (status *SourceStatus) PropagateBuildStatus(build *build.Build) {
@@ -94,6 +86,15 @@ func (status *SourceStatus) PropagateBuildStatus(build *build.Build) {
 // and updates the readiness based on the current phase.
 func (status *SourceStatus) PropagateBuildSecretStatus(secret *corev1.Secret) {
 	status.manage().MarkTrue(SourceConditionBuildSecretReady)
+}
+
+// BuildCondition gets a manager for the state of the build.
+func (status *SourceStatus) BuildCondition() SingleConditionManager {
+	return NewSingleConditionManager(
+		status.manage(),
+		SourceConditionBuildSucceeded,
+		"Build",
+	)
 }
 
 // BuildSecretCondition gets a manager for the state of the env var secret.

--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
-	secretinformer "knative.dev/pkg/injection/informers/kubeinformers/corev1/secret"
 )
 
 // NewController creates a new controller capable of reconciling Kf Routes.
@@ -49,7 +48,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	routeClaimInformer := routeclaiminformer.Get(ctx)
 	serviceBindingInformer := servicebindinginformer.Get(ctx)
 	serviceInstanceInformer := serviceinstanceinformer.Get(ctx)
-	secretInformer := secretinformer.Get(ctx)
 
 	serviceCatalogClient := servicecatalogclient.Get(ctx)
 
@@ -61,7 +59,6 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		knativeRevisionLister: knativeRevisionInformer.Lister(),
 		sourceLister:          sourceInformer.Lister(),
 		appLister:             appInformer.Lister(),
-		secretLister:          secretInformer.Lister(),
 		spaceLister:           spaceInformer.Lister(),
 		routeLister:           routeInformer.Lister(),
 		routeClaimLister:      routeClaimInformer.Lister(),

--- a/pkg/reconciler/base.go
+++ b/pkg/reconciler/base.go
@@ -26,6 +26,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	informerscorev1 "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	v1listers "k8s.io/client-go/listers/core/v1"
@@ -63,6 +64,9 @@ type Base struct {
 
 	// SecretLister allows us to list Secrets.
 	SecretLister v1listers.SecretLister
+
+	// SecretInformer allows us to AddEventHandlers for Secrets.
+	SecretInformer informerscorev1.SecretInformer
 }
 
 // NewBase instantiates a new instance of Base implementing
@@ -79,6 +83,7 @@ func NewBase(ctx context.Context, cmw configmap.Watcher) *Base {
 		ServingClientSet: knativeclient.Get(ctx),
 		ConfigMapWatcher: cmw,
 		SecretLister:     secretInformer.Lister(),
+		SecretInformer:   secretInformer,
 
 		NamespaceLister: nsInformer.Lister(),
 	}

--- a/pkg/reconciler/source/controller.go
+++ b/pkg/reconciler/source/controller.go
@@ -56,5 +56,10 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 
+	c.SecretInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.Filter(kfv1alpha1.SchemeGroupVersion.WithKind("Source")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
 	return impl
 }

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -150,6 +150,11 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) 
 			return secretCondition.MarkReconciliationError("updating existing", err)
 		}
 		source.Status.PropagateBuildSecretStatus(actual)
+
+		if secretCondition.IsPending() {
+			logger.Info("Waiting for Secret; exiting early")
+			return nil
+		}
 	}
 
 	// Sync Build

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -16,7 +16,6 @@ package source
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"github.com/google/kf/pkg/apis/kf/v1alpha1"
@@ -121,6 +120,7 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) 
 	}
 
 	secretCondition := source.Status.BuildSecretCondition()
+	buildCondtion := source.Status.BuildCondition()
 
 	desiredBuild, desiredSecret, err := resources.MakeBuild(source)
 	if err != nil {
@@ -172,8 +172,7 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) 
 				return err
 			}
 		} else if !metav1.IsControlledBy(actual, source) {
-			source.Status.MarkBuildNotOwned(desiredBuild.Name)
-			return fmt.Errorf("source: %q does not own build: %q", source.Name, desiredBuild.Name)
+			return buildCondtion.MarkChildNotOwned(desiredBuild.Name)
 		}
 
 		source.Status.PropagateBuildStatus(actual)

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
@@ -119,24 +120,55 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) 
 		return nil
 	}
 
-	// Sync build
+	secretCondition := source.Status.BuildSecretCondition()
+
+	desiredBuild, desiredSecret, err := resources.MakeBuild(source)
+	if err != nil {
+		return secretCondition.MarkTemplateError(err)
+	}
+
+	// Sync Build Secret
+	if desiredSecret != nil {
+		logger.Debug("reconciling build secret")
+
+		actual, err := r.SecretLister.
+			Secrets(desiredSecret.Namespace).
+			Get(desiredSecret.Name)
+		if apierrs.IsNotFound(err) {
+			actual, err = r.KubeClientSet.
+				CoreV1().
+				Secrets(desiredSecret.Namespace).
+				Create(desiredSecret)
+			if err != nil {
+				return secretCondition.MarkReconciliationError("creating", err)
+			}
+		} else if err != nil {
+			return secretCondition.MarkReconciliationError("getting latest", err)
+		} else if !metav1.IsControlledBy(actual, source) {
+			return secretCondition.MarkChildNotOwned(desiredSecret.Name)
+		} else if actual, err = r.ReconcileSecret(ctx, desiredSecret, actual); err != nil {
+			return secretCondition.MarkReconciliationError("updating existing", err)
+		}
+		source.Status.PropagateBuildSecretStatus(actual)
+	}
+
+	// Sync Build
 	{
 		logger.Debug("reconciling Build")
 
-		desired, err := resources.MakeBuild(source)
-		if err != nil {
-			return err
-		}
-
-		actual, err := r.buildLister.Builds(source.Namespace).Get(desired.Name)
+		actual, err := r.buildLister.
+			Builds(source.Namespace).
+			Get(desiredBuild.Name)
 		if errors.IsNotFound(err) {
-			actual, err = r.buildClient.Builds(desired.Namespace).Create(desired)
+			actual, err = r.buildClient.
+				Builds(desiredBuild.Namespace).
+				Create(desiredBuild)
 			if err != nil {
 				return err
 			}
 		} else if !metav1.IsControlledBy(actual, source) {
-			source.Status.MarkBuildNotOwned(desired.Name)
-			return fmt.Errorf("source: %q does not own build: %q", source.Name, desired.Name)
+			source.Status.MarkBuildNotOwned(desiredBuild.Name)
+			return fmt.Errorf("source: %q does not own build: %q", source.Name, desiredBuild.Name)
 		}
 
 		source.Status.PropagateBuildStatus(actual)

--- a/pkg/reconciler/source/resources/build.go
+++ b/pkg/reconciler/source/resources/build.go
@@ -137,7 +137,7 @@ func makeBuildpackBuild(source *v1alpha1.Source) (*build.Build, *corev1.Secret, 
 func makeSecret(source *v1alpha1.Source) *corev1.Secret {
 	m := map[string][]byte{}
 
-	// TODO: Support source.Env.ValueFrom
+	// TODO(#821): Support source.Env.ValueFrom
 	for _, e := range source.Spec.BuildpackBuild.Env {
 		m[e.Name] = []byte(e.Value)
 	}

--- a/pkg/reconciler/source/resources/build.go
+++ b/pkg/reconciler/source/resources/build.go
@@ -34,7 +34,12 @@ func BuildName(source *v1alpha1.Source) string {
 	return source.Name
 }
 
-func makeContainerImageBuild(source *v1alpha1.Source) (*build.Build, error) {
+// BuildSecretName gets the name of a Secret for a Source.
+func BuildSecretName(source *v1alpha1.Source) string {
+	return BuildName(source)
+}
+
+func makeContainerImageBuild(source *v1alpha1.Source) (*build.Build, *corev1.Secret, error) {
 	return &build.Build{
 		ObjectMeta: makeObjectMeta(source),
 		Spec: build.BuildSpec{
@@ -50,10 +55,10 @@ func makeContainerImageBuild(source *v1alpha1.Source) (*build.Build, error) {
 				},
 			},
 		},
-	}, nil
+	}, nil, nil
 }
 
-func makeDockerImageBuild(source *v1alpha1.Source) (*build.Build, error) {
+func makeDockerImageBuild(source *v1alpha1.Source) (*build.Build, *corev1.Secret, error) {
 	return &build.Build{
 		ObjectMeta: makeObjectMeta(source),
 		Spec: build.BuildSpec{
@@ -72,10 +77,27 @@ func makeDockerImageBuild(source *v1alpha1.Source) (*build.Build, error) {
 				},
 			},
 		},
-	}, nil
+	}, nil, nil
 }
 
-func makeBuildpackBuild(source *v1alpha1.Source) (*build.Build, error) {
+func makeBuildpackBuild(source *v1alpha1.Source) (*build.Build, *corev1.Secret, error) {
+	// We want to use a secret to store these, so we'll have to point at the
+	// secret.
+	env := []corev1.EnvVar{}
+	for _, e := range source.Spec.BuildpackBuild.Env {
+		env = append(env, corev1.EnvVar{
+			Name: e.Name,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: BuildSecretName(source),
+					},
+					Key: e.Name,
+				},
+			},
+		})
+	}
+
 	return &build.Build{
 		ObjectMeta: makeObjectMeta(source),
 		Spec: build.BuildSpec{
@@ -106,10 +128,24 @@ func makeBuildpackBuild(source *v1alpha1.Source) (*build.Build, error) {
 						Value: source.Spec.BuildpackBuild.Stack,
 					},
 				},
-				Env: source.Spec.BuildpackBuild.Env,
+				Env: env,
 			},
 		},
-	}, nil
+	}, makeSecret(source), nil
+}
+
+func makeSecret(source *v1alpha1.Source) *corev1.Secret {
+	m := map[string][]byte{}
+
+	// TODO: Support source.Env.ValueFrom
+	for _, e := range source.Spec.BuildpackBuild.Env {
+		m[e.Name] = []byte(e.Value)
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: makeObjectMeta(source),
+		Data:       m,
+	}
 }
 
 func makeObjectMeta(source *v1alpha1.Source) metav1.ObjectMeta {
@@ -127,8 +163,9 @@ func makeObjectMeta(source *v1alpha1.Source) metav1.ObjectMeta {
 	}
 }
 
-// MakeBuild creates a Build for a Source.
-func MakeBuild(source *v1alpha1.Source) (*build.Build, error) {
+// MakeBuild creates a Build and Secret for a Source. The Secret CAN be nil if
+// the Source does not require it.
+func MakeBuild(source *v1alpha1.Source) (*build.Build, *corev1.Secret, error) {
 	switch {
 	case source.Spec.IsContainerBuild():
 		return makeContainerImageBuild(source)


### PR DESCRIPTION

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* Moves Builds to reference Secrets for environment variables.
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changed the way Build stores environment variables to use Secrets
```
