### PR TITLE
pkg/reconciler/source: fix Secret Status

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/source_lifecycle_test.go
@@ -274,6 +274,17 @@ func TestSourceStatus_lifecycle(t *testing.T) {
 				SourceConditionBuildSecretReady,
 			},
 		},
+		"happy path with nil secret": {
+			Init: func(status *SourceStatus) {
+				status.PropagateBuildStatus(happyBuild())
+				status.PropagateBuildSecretStatus(nil)
+			},
+			ExpectSucceeded: []apis.ConditionType{
+				SourceConditionSucceeded,
+				SourceConditionBuildSucceeded,
+				SourceConditionBuildSecretReady,
+			},
+		},
 		"build not owned": {
 			Init: func(status *SourceStatus) {
 				condition := status.BuildCondition()

--- a/pkg/reconciler/source/reconciler.go
+++ b/pkg/reconciler/source/reconciler.go
@@ -155,6 +155,10 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, source *v1alpha1.Source) 
 			logger.Info("Waiting for Secret; exiting early")
 			return nil
 		}
+	} else {
+		// We still need to update the status even when we don't have a
+		// secret. Otherwise the Source's status will always be not ready.
+		source.Status.PropagateBuildSecretStatus(nil)
 	}
 
 	// Sync Build


### PR DESCRIPTION


<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* This CL fixes a bug where the Secret status is only propagated if there
is an envs secret. Docker builds for example don't require a secret but
the Status still needs to be set to true.
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
