### PR TITLE
Ask user for public/internal GKE server IP

### DIFF
--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -526,15 +526,25 @@ func targetCluster(
 ) error {
 	ctx = SetLogPrefix(ctx, "Target Cluster")
 	Logf(ctx, "targeting cluster")
-	_, err := gcloud(
-		ctx,
+
+	_, selection, err := SelectPrompt(ctx, "Public or internal GKE server ip", "public", "internal")
+	if err != nil {
+		return err
+	}
+
+	args := []string{
 		"container",
 		"clusters",
 		"get-credentials",
 		clusterName,
 		"--zone", zone,
 		"--project", projID,
-	)
+	}
+
+	if selection == "internal" {
+		args = append(args, "--internal-ip")
+	}
+	_, err = gcloud(ctx, args...)
 
 	return err
 }

--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -527,7 +527,7 @@ func targetCluster(
 	ctx = SetLogPrefix(ctx, "Target Cluster")
 	Logf(ctx, "targeting cluster")
 
-	_, selection, err := SelectPrompt(ctx, "Public or internal GKE server ip", "public", "internal")
+	_, selection, err := SelectPrompt(ctx, "GKE Master Server IP", "public", "internal")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #823

## Proposed Changes

* Add a question to the `kf install gke` command to ask which IP addr to hit when targeting the cluster

Note that more setup differences might be required for creating private GKE clusters, but this is an easy question to answer.

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
