### PR TITLE
Update gateway names and namespaces

### DIFF
--- a/pkg/kf/istio/istio_client_options.go
+++ b/pkg/kf/istio/istio_client_options.go
@@ -78,7 +78,7 @@ func WithListIngressesService(val string) ListIngressesOption {
 // ListIngressesOptionDefaults gets the default values for ListIngresses.
 func ListIngressesOptionDefaults() ListIngressesOptions {
 	return ListIngressesOptions{
-		WithListIngressesNamespace("istio-system"),
-		WithListIngressesService("istio-ingressgateway"),
+		WithListIngressesNamespace("gke-system"),
+		WithListIngressesService("istio-ingress"),
 	}
 }

--- a/pkg/kf/istio/istio_client_options.yml
+++ b/pkg/kf/istio/istio_client_options.yml
@@ -23,8 +23,8 @@ configs:
   - name: Service
     type: string
     description: the name of the ingress service
-    default: '"istio-ingressgateway"'
+    default: '"istio-ingress"'
   - name: Namespace
     type: string
     description: the Kubernetes namespace to search for Ingresses
-    default: '"istio-system"'
+    default: '"gke-system"'

--- a/pkg/kf/istio/istio_client_test.go
+++ b/pkg/kf/istio/istio_client_test.go
@@ -47,8 +47,8 @@ func TestIstioClient_ListIngresses(t *testing.T) {
 		"default values": {
 			setup: func(mockK8s kubernetes.Interface) {
 				svc := &corev1.Service{}
-				svc.Name = "istio-ingressgateway"
-				mockK8s.CoreV1().Services("istio-system").Create(svc)
+				svc.Name = "istio-ingress"
+				mockK8s.CoreV1().Services("gke-system").Create(svc)
 			},
 		},
 		"custom values": {

--- a/pkg/reconciler/route/resources/virtual_service.go
+++ b/pkg/reconciler/route/resources/virtual_service.go
@@ -31,8 +31,8 @@ import (
 
 const (
 	ManagedByLabel        = "app.kubernetes.io/managed-by"
-	KnativeIngressGateway = "knative-ingress-gateway.knative-serving.svc.cluster.local"
-	GatewayHost           = "istio-ingressgateway.istio-system.svc.cluster.local"
+	KnativeIngressGateway = "knative-serving/gke-system-gateway"
+	GatewayHost           = "cluster-local-gateway.gke-system.svc.cluster.local"
 )
 
 // MakeVirtualServiceLabels creates Labels that can be used to tie a

--- a/pkg/reconciler/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/route/resources/virtual_service_test.go
@@ -185,7 +185,7 @@ func TestMakeVirtualService(t *testing.T) {
 						},
 						Route: []networking.HTTPRouteDestination{
 							{
-								Destination: networking.Destination{Host: "istio-ingressgateway.istio-system.svc.cluster.local"},
+								Destination: networking.Destination{Host: "cluster-local-gateway.gke-system.svc.cluster.local"},
 								Weight:      100,
 								Headers: &networking.Headers{
 									Request: &networking.HeaderOperations{
@@ -228,7 +228,7 @@ func TestMakeVirtualService(t *testing.T) {
 						},
 						Route: []networking.HTTPRouteDestination{
 							{
-								Destination: networking.Destination{Host: "istio-ingressgateway.istio-system.svc.cluster.local"},
+								Destination: networking.Destination{Host: "cluster-local-gateway.gke-system.svc.cluster.local"},
 								Weight:      34,
 								Headers: &networking.Headers{
 									Request: &networking.HeaderOperations{
@@ -239,7 +239,7 @@ func TestMakeVirtualService(t *testing.T) {
 								},
 							},
 							{
-								Destination: networking.Destination{Host: "istio-ingressgateway.istio-system.svc.cluster.local"},
+								Destination: networking.Destination{Host: "cluster-local-gateway.gke-system.svc.cluster.local"},
 								Weight:      33,
 								Headers: &networking.Headers{
 									Request: &networking.HeaderOperations{
@@ -250,7 +250,7 @@ func TestMakeVirtualService(t *testing.T) {
 								},
 							},
 							{
-								Destination: networking.Destination{Host: "istio-ingressgateway.istio-system.svc.cluster.local"},
+								Destination: networking.Destination{Host: "cluster-local-gateway.gke-system.svc.cluster.local"},
 								Weight:      33,
 								Headers: &networking.Headers{
 									Request: &networking.HeaderOperations{


### PR DESCRIPTION
## Proposed Changes

* Update fields in virtualservices to support naming discrepancies in upgraded GKE/knative serving versions (see #805)
* Change default Istio Ingress namespace and Ingress svc name
* Change Knative ingress gateway and change route destination to cluster-local-gateway

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added routing support for GKE versions 1.13.10 and greater
Changed BREAKING default ingress gateways
```
