### PR TITLE
fix terraform in ci

### DIFF
--- a/ci/concourse/pipelines/nightly-release-pipeline.yml
+++ b/ci/concourse/pipelines/nightly-release-pipeline.yml
@@ -34,7 +34,6 @@ vars:
 
 # k8s config
 - &gcp_project_id ((gcp_project_id))
-- &k8s_network_selflink ((k8s_network_selflink))
 
 # go config
 - &go_proxy https://proxy.golang.org
@@ -82,7 +81,6 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      k8s_network_selflink: *k8s_network_selflink
       gke_version: 1.13.11-gke.11
     env:
       GOOGLE_CREDENTIALS: *service_account_json

--- a/ci/concourse/pipelines/pr-unipipeline.yml
+++ b/ci/concourse/pipelines/pr-unipipeline.yml
@@ -20,7 +20,6 @@ vars:
 
 # k8s config
 - &gcp_project_id ((gcp_project_id))
-- &k8s_network_selflink ((k8s_network_selflink))
 
 # go config
 - &go_proxy https://proxy.golang.org
@@ -159,7 +158,6 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      k8s_network_selflink: *k8s_network_selflink
       gke_version: 1.13.11-gke.11
     env:
       GOOGLE_CREDENTIALS: *service_account_json

--- a/ci/concourse/pipelines/release-pipeline.yml
+++ b/ci/concourse/pipelines/release-pipeline.yml
@@ -34,7 +34,6 @@ vars:
 
 # k8s config
 - &gcp_project_id ((gcp_project_id))
-- &k8s_network_selflink ((k8s_network_selflink))
 
 # go config
 - &go_proxy https://proxy.golang.org
@@ -94,7 +93,6 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      k8s_network_selflink: *k8s_network_selflink
       gke_version: 1.13.11-gke.11
     env:
       GOOGLE_CREDENTIALS: *service_account_json

--- a/ci/concourse/terraform/main.tf
+++ b/ci/concourse/terraform/main.tf
@@ -52,10 +52,6 @@ resource "google_container_cluster" "kf_test" {
     }
   }
 
-  ip_allocation_policy {
-    use_ip_aliases = true
-  }
-
   addons_config {
     istio_config {
       disabled = false


### PR DESCRIPTION
# Proposed Changes

* remove network selflink because it's no longer used
* remove ip_allocation_policy because Terraform gives the following instructions: `This field is being removed in 3.0.0. If set to true, remove it from your config.`

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
