### PR TITLE
config: explicitly state input types as strings

### DIFF
--- a/config/300-buildpack-clustertask.yaml
+++ b/config/300-buildpack-clustertask.yaml
@@ -21,19 +21,25 @@ spec:
     params:
     - name: SOURCE_IMAGE
       description: The image built via Kontext that contains the app's source code.
+      type: string
     - name: ENV_SECRET
       description: The Secret that stores the environment variables used for each step
+      type: string
     - name: BUILDPACK
       description: When set, skip the detect step and use the given buildpack.
+      type: string
       default: ''
     - name: RUN_IMAGE
       description: The run image buildpacks will use as the base for IMAGE (output).
+      type: string
       default: packs/run:v3alpha2
     - name: BUILDER_IMAGE
       description: The image on which builds will run (must include v3 lifecycle and compatible buildpacks).
+      type: string
       default: gcr.io/kf-releases/buildpack-builder:latest
     - name: CACHE_VOLUME
       description: The name of the persistent app cache volume
+      type: string
       default: empty-dir
 
   outputs:

--- a/config/300-kaniko-clustertask.yaml
+++ b/config/300-kaniko-clustertask.yaml
@@ -21,8 +21,10 @@ spec:
     params:
     - name: SOURCE_IMAGE
       description: The image built via Kontext that contains the app's source code.
+      type: string
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
+      type: string
       default: ./Dockerfile
   outputs:
     resources:


### PR DESCRIPTION
There is an issue with Tekton where it will sometimes assume an array
type if the type is not specified. This is easily fixed by explicitly
stating it as a string.

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* explicitly state input types as strings
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed bug where Tekton sometimes assumes inputs should be an array.
```
