### PR TITLE
Use Terraform for Service Accounts and Subnetworks

### DIFF
--- a/ci/concourse/pipelines/pr-unipipeline.yml
+++ b/ci/concourse/pipelines/pr-unipipeline.yml
@@ -397,6 +397,7 @@ jobs:
           project=`cat terraform/metadata | jq -r '.cluster_project'`
           cluster=`cat terraform/metadata | jq -r '.cluster_name'`
           region=`cat terraform/metadata | jq -r '.cluster_region'`
+          gcr_key=`cat terraform/metadata | jq -r '.gcr_key'`
           # Login to Kubernetes
           set +x
           echo "$SERVICE_ACCOUNT_JSON" > key.json
@@ -423,7 +424,7 @@ jobs:
             ./hack/ko-apply.sh
 
             # Setup Kf Secret and ConifgMap
-            ./hack/create-gke-secret.sh
+            ./hack/create-gke-secret.sh -k "$gcr_key"
 
             # Run integration tests
             ./hack/integration-test.sh

--- a/ci/concourse/pipelines/pr-unipipeline.yml
+++ b/ci/concourse/pipelines/pr-unipipeline.yml
@@ -112,6 +112,11 @@ templates:
     params:
       path: pr
       status: FAILURE
+  - *release-lock
+
+- &on-success
+  do:
+  - *release-lock
 
 resource_types:
 - name: pull-request
@@ -165,13 +170,13 @@ jobs:
     resource: kf-dev
   - *terraform-destroy
   on_failure: *on-failure
-  ensure:
-  - *release-lock
+  on_success:
+    do:
+    - *release-lock
 
 - name: test
   on_failure: *on-failure
-  ensure:
-  - *release-lock
+  on_success: *on-success
   plan:
   - get: pr
     trigger: true
@@ -370,7 +375,7 @@ jobs:
               ./hack/tidy.sh
               ./hack/check-clean-git-state.sh
             popd
-  - *terraform-destroy
+    - *terraform-destroy
   - *terraform-pre-destroy
   - *terraform-destroy
   - *terraform-create

--- a/ci/concourse/pipelines/pr-unipipeline.yml
+++ b/ci/concourse/pipelines/pr-unipipeline.yml
@@ -112,11 +112,6 @@ templates:
     params:
       path: pr
       status: FAILURE
-  - *release-lock
-
-- &on-success
-  do:
-  - *release-lock
 
 resource_types:
 - name: pull-request
@@ -170,13 +165,13 @@ jobs:
     resource: kf-dev
   - *terraform-destroy
   on_failure: *on-failure
-  on_success:
-    do:
-    - *release-lock
+  ensure:
+  - *release-lock
 
 - name: test
   on_failure: *on-failure
-  on_success: *on-success
+  ensure:
+  - *release-lock
   plan:
   - get: pr
     trigger: true
@@ -375,7 +370,8 @@ jobs:
               ./hack/tidy.sh
               ./hack/check-clean-git-state.sh
             popd
-    - *terraform-pre-destroy
+  - *terraform-destroy
+  - *terraform-pre-destroy
   - *terraform-destroy
   - *terraform-create
   - task: integration

--- a/hack/create-gke-secret.sh
+++ b/hack/create-gke-secret.sh
@@ -14,39 +14,78 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -eux
+set -eu
 
 cd "${0%/*}"/..
 
-project=$(gcloud config get-value project)
-sa_name_prefix=create-gke-secret-${RANDOM}
-sa_name="${sa_name_prefix}@${project}.iam.gserviceaccount.com"
+project=''
+sa_name=''
+key_json=''
 
-echo "creating a GCP ServiceAccount (${sa_name}) for Project ${project}"
-gcloud iam service-accounts create ${sa_name_prefix} --project ${project}
 
-echo "adding role roles/storage.admin binding to ServiceAccount"
-gcloud projects add-iam-policy-binding ${project} \
-    --member "serviceAccount:${sa_name}" \
-    --role "roles/storage.admin"
-
-echo "downloading key... (this will be deleted after)"
-temp_dir=$(mktemp -d)
-delete_temp() {
-    rm -rf ${temp_dir}
+print_usage() {
+  echo "Usage: [-p GCP_PROJECT] [-a SERVICE ACCOUNT EMAIL] [-k JSON KEY]"
+  echo
+  echo "Examples:"
+  echo "  # create a new service account and key"
+  echo "  ${0}"
+  echo "  # use an existing key (don't create SA)"
+  echo "  ${0} -k '{json here}'"
+  echo "  # use an existing SA, creating a new key"
+  echo "  ${0} -p my-project -a my-sa@my-project.google.com"
 }
-trap delete_temp EXIT
 
-key_path=${temp_dir}/key.json
-gcloud iam service-accounts keys create \
-  --iam-account ${sa_name} ${key_path}
+while getopts 'p:a:k:' flag; do
+  case "${flag}" in
+    p) project="${OPTARG}" ;;
+    a) sa_name="${OPTARG}" ;;
+    k) key_json="${OPTARG}" ;;
+    *) print_usage
+       exit 1 ;;
+  esac
+done
+
+# if the user provided a key, we don't need to create an SA
+if [ "${key_json}" = "" ]; then
+  if [ "${service_account}" = "" ]; then
+    if [ "${project}" = "" ]; then
+      echo "Autodetecting project, use -p to override"
+      project=$(gcloud config get-value project)
+    fi
+
+    sa_name_prefix=create-gke-secret-${RANDOM}
+    sa_name="${sa_name_prefix}@${project}.iam.gserviceaccount.com"
+
+    echo "creating a GCP ServiceAccount (${sa_name}) for Project ${project}"
+    current_context=$(kubectl config current-context)
+    gcloud iam service-accounts create ${sa_name_prefix} \
+      --project ${project} \
+      --description "gcr.io admin for ${current_context}" \
+      --display-name "${current_context}"
+
+    echo "adding role roles/storage.admin binding to ServiceAccount"
+    gcloud projects add-iam-policy-binding ${project} \
+        --member "serviceAccount:${sa_name}" \
+        --role "roles/storage.admin"
+  fi
+
+  temp_dir=$(mktemp -d)
+  key_path=${temp_dir}/key.json
+
+  echo "Creating service account key"
+  gcloud iam service-accounts keys create \
+    --iam-account ${sa_name} ${key_path}
+  secret_name=kf-gcr-key-${RANDOM}
+  key_json=$(cat ${key_path})
+  rm -rf ${temp_dir}
+fi
 
 echo "creating K8s Secret"
 secret_name=kf-gcr-key-${RANDOM}
 kubectl -nkf create secret docker-registry ${secret_name} \
   --docker-username=_json_key \
   --docker-server https://gcr.io \
-  --docker-password="$(cat ${key_path})"
+  --docker-password="${key_json}"
 
 echo "creating K8s ConfigMap to point to Secret"
 cat <<EOF | kubectl apply -f -


### PR DESCRIPTION
<!-- Include the issue number below -->

## Proposed Changes

* Use Terraform to manage the key for authenticating to GCR.
* Reduce the number of subnetworks created by Terraform.
