### PR TITLE
pkg/kf/commands/install/gke: fail when cluster fails to create

### DIFF
--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -134,13 +134,16 @@ func buildGraph() *cli.InteractiveNode {
 					gkeCfg, err = selectCluster(ctx, projectID, gkeCfg)
 				}
 
+				if err != nil {
+					return ctx, nil, err
+				}
+
 				// Target the cluster
 				if err := targetCluster(ctx, projectID, masterIP, gkeCfg); err != nil {
 					return nil, nil, err
 				}
 
-				// NOTE: err might be nil
-				return kf.SetContainerRegistry(ctx, "gcr.io/"+projectID), kfInstallGraph, err
+				return kf.SetContainerRegistry(ctx, "gcr.io/"+projectID), kfInstallGraph, nil
 			}
 	}
 


### PR DESCRIPTION
Previous to this CL, the installer wouldn't return an error if the
clsuter failed to create.

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

* GKE installer fails when the cluster fails to create
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
