### PR TITLE
cmd/controller-init: add config-secrets if not present

### DIFF
--- a/cmd/controller-init/main.go
+++ b/cmd/controller-init/main.go
@@ -74,7 +74,7 @@ func main() {
 		if err != nil {
 			logger.Fatalw("Failed to get the corev1 client set", zap.Error(err))
 		}
-		_, err := corev1Client.
+		_, err = corev1Client.
 			ConfigMaps(v1alpha1.KfNamespace).
 			Get(sourceconfig.SecretsConfigName, metav1.GetOptions{})
 

--- a/cmd/controller-init/main.go
+++ b/cmd/controller-init/main.go
@@ -94,8 +94,8 @@ func main() {
 		logger.Fatalw("Failed to get the istio client set", zap.Error(err))
 	}
 
-	// Clean out virtualservices in the kf namespace. VirtualServices should
-	// be in the namespace they were created in.
+	// Clean out VirtualServices in the kf namespace. VirtualServices should
+	// be in the namespace as their associated RouteClaim.
 	//
 	// NOTE: Older versions of Kf stored VirtualServices in the Kf namespace
 	// to emulate a non-existent ClusterVirtualService. Newer versions of Kf


### PR DESCRIPTION

Note: This one has to wait for #892 to be merged

<!-- Include the issue number below -->
Fixes #890

## Proposed Changes

* Create placeholder ConfigMap (`config-secrets`) if missing from kf namespace
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed bug where controller enters crashloop when kf is first installed
```
