### PR TITLE
moved to release channels on GKE

### DIFF
--- a/ci/concourse/pipelines/nightly-release-pipeline.yml
+++ b/ci/concourse/pipelines/nightly-release-pipeline.yml
@@ -77,7 +77,7 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      gke_version: 1.13.11-gke.11
+      release_channel: REGULAR
     env:
       GOOGLE_CREDENTIALS: *service_account_json
 - name: nightly-build-trigger

--- a/ci/concourse/pipelines/pr-unipipeline.yml
+++ b/ci/concourse/pipelines/pr-unipipeline.yml
@@ -158,7 +158,7 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      gke_version: 1.13.11-gke.11
+      release_channel: REGULAR
     env:
       GOOGLE_CREDENTIALS: *service_account_json
 

--- a/ci/concourse/pipelines/release-pipeline.yml
+++ b/ci/concourse/pipelines/release-pipeline.yml
@@ -93,7 +93,7 @@ resources:
       credentials: *service_account_json
     vars:
       project: *gcp_project_id
-      gke_version: 1.13.11-gke.11
+      release_channel: REGULAR
     env:
       GOOGLE_CREDENTIALS: *service_account_json
 jobs:

--- a/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_install_gke.md
+++ b/docs/kf.dev/content/en/docs/general-info/kf-cli/commands/kf_install_gke.md
@@ -37,6 +37,7 @@ kf install gke [subcommand] [flags]
       --interactive                   Make the command interactive
       --kf-version string             Kf release version to use
       --project-id string             GCP project ID to use
+      --release-channel string        Release channel the GKE cluster will be created with (default "standard")
       --space-domain string           Kf space's default domain
       --space-name string             Kf space name to create/target use
   -v, --verbose                       Make the operation more chatty

--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -38,7 +38,6 @@ const (
 	defaultMaxPodsPerNode = "110"
 	addons                = "HorizontalPodAutoscaling,HttpLoadBalancing,Istio,CloudRun"
 	defaultReleaseChannel = "STABLE"
-	defaultGKEVersion     = "1.13.11-gke.14"
 )
 
 // NewGKECommand creates a command that can install kf to GKE+Cloud Run.

--- a/pkg/kf/commands/install/gke/gke.go
+++ b/pkg/kf/commands/install/gke/gke.go
@@ -37,7 +37,8 @@ const (
 	numNodes              = "3"
 	defaultMaxPodsPerNode = "110"
 	addons                = "HorizontalPodAutoscaling,HttpLoadBalancing,Istio,CloudRun"
-	defaultGKEVersion     = "1.13.11-gke.11"
+	defaultReleaseChannel = "STABLE"
+	defaultGKEVersion     = "1.13.11-gke.14"
 )
 
 // NewGKECommand creates a command that can install kf to GKE+Cloud Run.
@@ -107,6 +108,7 @@ func buildGraph() *cli.InteractiveNode {
 		flags.StringVar(&gkeCfg.zone, "cluster-zone", "us-central1-a", "Zone the GKE cluster is in or will be created in")
 		flags.StringVar(&gkeCfg.network, "cluster-network", "default", "Network the GKE cluster is in or will be created in")
 		flags.StringVar(&gkeCfg.machineType, "cluster-machine-type", "n1-standard-4", "Machine type the GKE cluster will be created with")
+		flags.StringVar(&gkeCfg.releaseChannel, "release-channel", "standard", "Release channel the GKE cluster will be created with")
 		flags.StringVar(&masterIP, "cluster-master-ip", "public", "GKE's master Server IP to target (public|internal)")
 		flags.BoolVar(&createCluster, "create-cluster", false, "Create a new GKE cluster")
 
@@ -421,6 +423,7 @@ type gkeConfig struct {
 	zone           string
 	network        string
 	machineType    string
+	releaseChannel string
 }
 
 func gkeClusterConfig(
@@ -527,6 +530,21 @@ func gkeClusterConfig(
 		}
 	}
 
+	// Release Channel
+	_, wantSpecificVersion := os.LookupEnv(GKEVersionEnvVar)
+	if cfg.releaseChannel == "" && !wantSpecificVersion {
+		availableReleaseChannels := []cli.Option{
+			{Value: "rapid", Label: "Rapid - use for testing only, not covered by SLA"},
+			{Value: "regular", Label: "Regular - GA quality, updated every few weeks"},
+			{Value: "stable", Label: "Stable - stability above all else, updated every few months"},
+		}
+
+		_, cfg.releaseChannel, err = cli.OptionPrompt(ctx, "Release channel (recommended: 'Regular')", availableReleaseChannels...)
+		if err != nil {
+			return gkeConfig{}, err
+		}
+	}
+
 	return cfg, nil
 }
 
@@ -560,9 +578,7 @@ func buildGKECluster(
 	if gkeClusterVersion, ok := os.LookupEnv(GKEVersionEnvVar); ok {
 		args = append(args, "--cluster-version", gkeClusterVersion)
 	} else {
-		cli.Logf(ctx, "Setting the GKE version to be %q, override it by setting the environment variable %s", defaultGKEVersion, GKEVersionEnvVar)
-		args = append(args, "--cluster-version", defaultGKEVersion)
-
+		args = append(args, "--release-channel", gkeCfg.releaseChannel)
 	}
 
 	if gkeCfg.network != "" {


### PR DESCRIPTION
<!-- Include the issue number below -->
## Proposed Changes

* Move the Terraform to use GKE Release channels
* Move the installer to allow release channel selection

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Added the ability for the installer to pick a release channel.
```
