### PR TITLE
Support startup probe

### DIFF
--- a/docs/content/en/docs/v2.11/developer/build-and-deploy/manifest.md
+++ b/docs/content/en/docs/v2.11/developer/build-and-deploy/manifest.md
@@ -36,10 +36,14 @@ The following fields are valid for objects under `applications`:
 | `timeout`                    | `int`      | The number of seconds to wait for the app to become healthy. |
 | `health-check-type`          | `string`   | The type of health-check to use `port`, `process`, `none`, or `http`. Default: `port` |
 | `health-check-http-endpoint` | `string`   | The endpoint to target as part of the health-check. Only valid if `health-check-type` is `http`. |
+| `health-check-invocation-timeout` | `int` | Timeout in seconds for an individual health check probe to complete. Default: `1`. |
 | `command`                    | `string`   | The command that starts the app. If supplied, this will be passed to the container entrypoint. |
 | `entrypoint` †               | `string`   | Overrides the app container's entrypoint. |
 | `args` †                     | `string[]` | Overrides the arguments the app container. |
 | `ports` †                    | `object`   | A list of ports to expose on the container. If supplied, the first entry in this list is used as the default port. |
+| `startupProbe` †             | [`probe`](#probe-fields)  | Sets the app container's startup probe. |
+| `livenessProbe` †            | [`probe`](#probe-fields)  | Sets the app container's liveness probe. |
+| `readinessProbe` †           | [`probe`](#probe-fields)  | Sets the app container's readiness probe. |
 | `metadata`                   | `object`   | Additional tags for applications and their underlying resources. | 
 
 † Unique to Kf
@@ -91,6 +95,46 @@ The following fields are valid for `application.metadata` objects:
 {{< note >}}Kf's metadata overrides custom metadata for certain resources to ensure platform elements like
 routing and logging continue to work.{{< /note >}}
 
+## Probe fields {#probe-fields}
+
+Probes allow a subset of functionality from
+[Kubernetes probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+A probe must contain one action and other settings.
+
+| Field | Type  | Description | 
+| ---   | ---   | ---         |
+| `failureThreshold` | `int` | Minimum consecutive failures for the probe to be considered failed. |
+| `initialDelaySeconds` | `int` | Number of seconds to wait after container initialization to start the probe. |
+| `periodSeconds` | `int` | How often (in seconds) to perform the probe. |
+| `successThreshold` | `int` | Minimum consecutive successes for the probe to be considered successful. |
+| `timeoutSeconds` | `int` | Number of seconds after a single invocation of the probe times out. |
+| `tcpSocket` | [`TCPSocketAction` object](#tcpsocketaction) | **Action** specifying a request to a TCP port. |
+| `httpGet` | [`HTTPGetAction` object](#httpgetaction) | **Action** specifying a request to a TCP port. |
+
+### TCPSocketAction fields {#tcpsocketaction}
+
+Describes an action based on TCP requests.
+
+| Field | Type  | Description | 
+| ---   | ---   | ---         |
+| `host` | `string` | Host to connect to, defaults to the App's IP. |
+
+{{< note >}}The port will automatically be set to match the App's default port.{{< /note >}}
+
+
+### HTTPGetAction fields {#httpgetaction}
+
+Describes an action based on HTTP get requests.
+
+| Field | Type  | Description | 
+| ---   | ---   | ---         |
+| `host` | `string` | Host to connect to, defaults to the App's IP. |
+| `path` | `string` | Path to access on the HTTP server. |
+| `scheme` | `string` | Scheme to use when connecting to the host. Default: `http` |
+| `httpHeaders` | array of `{"name": <string>, "value": <string>}` objects  | Additional headers to send. |
+
+{{< note >}}The port will automatically be set to match the App's default port.{{< /note >}}
 
 ## Examples
 

--- a/pkg/apis/kf/k8s_fieldmask.go
+++ b/pkg/apis/kf/k8s_fieldmask.go
@@ -44,6 +44,7 @@ func containerMask(in corev1.Container) (out corev1.Container) {
 	out.Resources = in.Resources
 	out.LivenessProbe = in.LivenessProbe
 	out.ReadinessProbe = in.ReadinessProbe
+	out.StartupProbe = in.StartupProbe
 
 	// Explicitly disallowed fields.
 	// These are optional, but provided here for clarity.

--- a/pkg/apis/kf/k8s_fieldmask_test.go
+++ b/pkg/apis/kf/k8s_fieldmask_test.go
@@ -62,6 +62,7 @@ func TestContainerMask(t *testing.T) {
 		Resources:      corev1.ResourceRequirements{},
 		LivenessProbe:  &corev1.Probe{},
 		ReadinessProbe: &corev1.Probe{},
+		StartupProbe:   &corev1.Probe{},
 	}
 	in := corev1.Container{
 		Name:           "foo",
@@ -73,6 +74,7 @@ func TestContainerMask(t *testing.T) {
 		Resources:      corev1.ResourceRequirements{},
 		LivenessProbe:  &corev1.Probe{},
 		ReadinessProbe: &corev1.Probe{},
+		StartupProbe:   &corev1.Probe{},
 
 		Image:                    "python",
 		EnvFrom:                  []corev1.EnvFromSource{{}},

--- a/pkg/apis/kf/k8s_validation.go
+++ b/pkg/apis/kf/k8s_validation.go
@@ -180,7 +180,7 @@ func ValidateContainerProbe(probe *corev1.Probe) *apis.FieldError {
 	handler := probe.ProbeHandler
 	errs = errs.Also(apis.CheckDisallowedFields(handler, containerProbeHandlerMask(handler)))
 
-	// XXX: the checks here should match the probes in containerProbeHandlerMask
+	// NOTE: the checks here should match the probes in containerProbeHandlerMask
 	suppliedHandlers := sets.NewString()
 	if handler.HTTPGet != nil {
 		suppliedHandlers.Insert("httpGet")

--- a/pkg/apis/kf/k8s_validation.go
+++ b/pkg/apis/kf/k8s_validation.go
@@ -83,6 +83,7 @@ func ValidateContainer(container corev1.Container) *apis.FieldError {
 	errs = errs.Also(ValidateContainerResources(container.Resources).ViaField("resources"))
 	errs = errs.Also(ValidateContainerProbe(container.LivenessProbe).ViaField("livenessProbe"))
 	errs = errs.Also(ValidateContainerProbe(container.ReadinessProbe).ViaField("readinessProbe"))
+	errs = errs.Also(ValidateContainerProbe(container.StartupProbe).ViaField("startupProbe"))
 
 	return errs
 }
@@ -179,7 +180,17 @@ func ValidateContainerProbe(probe *corev1.Probe) *apis.FieldError {
 	handler := probe.ProbeHandler
 	errs = errs.Also(apis.CheckDisallowedFields(handler, containerProbeHandlerMask(handler)))
 
+	// XXX: the checks here should match the probes in containerProbeHandlerMask
+	suppliedHandlers := sets.NewString()
+	if handler.HTTPGet != nil {
+		suppliedHandlers.Insert("httpGet")
+	}
+	if handler.TCPSocket != nil {
+		suppliedHandlers.Insert("tcpSocket")
+	}
 	switch {
+	case suppliedHandlers.Len() > 1:
+		errs = errs.Also(apis.ErrMultipleOneOf(suppliedHandlers.List()...))
 	case handler.HTTPGet != nil:
 		masked := containerProbeHandlerHTTPGetActionMask(*handler.HTTPGet)
 		errs = errs.Also(apis.CheckDisallowedFields(*handler.HTTPGet, masked)).ViaField("httpGet")

--- a/pkg/apis/kf/k8s_validation_test.go
+++ b/pkg/apis/kf/k8s_validation_test.go
@@ -382,6 +382,18 @@ func TestValidateContainerProbe(t *testing.T) {
 			field: goodTCPContainerProbe(),
 			want:  nil,
 		},
+		"multiple probe handlers invalid": {
+			field: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/",
+					},
+					TCPSocket: &corev1.TCPSocketAction{},
+				},
+			},
+			want: apis.ErrMultipleOneOf("tcpSocket", "httpGet"),
+		},
 		"exec not allowed": {
 			field: badContainerProbe(),
 			want:  apis.ErrDisallowedFields("exec"),

--- a/pkg/kf/commands/exporttok8s/exporttok8s.go
+++ b/pkg/kf/commands/exporttok8s/exporttok8s.go
@@ -513,14 +513,19 @@ func getContainer(app *manifest.Application) (*corev1.Container, error) {
 		return nil, err
 	}
 
-	probe := container.ReadinessProbe
+	// Kf usually adds the default port server-side.
 	if len(container.Ports) == 0 {
-		rewriteProbe(probe, resources.DefaultUserPort)
 		container.Ports = append(container.Ports, corev1.ContainerPort{
 			Name:          resources.UserPortName,
 			ContainerPort: resources.DefaultUserPort,
 		})
-	} else {
+	}
+
+	for _, probe := range []*corev1.Probe{
+		container.ReadinessProbe,
+		container.LivenessProbe,
+		container.StartupProbe,
+	} {
 		rewriteProbe(probe, container.Ports[0].ContainerPort)
 	}
 

--- a/pkg/kf/commands/exporttok8s/exporttok8s_test.go
+++ b/pkg/kf/commands/exporttok8s/exporttok8s_test.go
@@ -8,12 +8,9 @@ import (
 
 	"github.com/google/kf/v2/pkg/kf/manifest"
 	"github.com/google/kf/v2/pkg/kf/testutil"
-	"github.com/google/kf/v2/pkg/reconciler/app/resources"
 	tektonv1beta1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/yaml"
 )
 
@@ -153,45 +150,10 @@ func TestGetParams(t *testing.T) {
 func TestGetContainer(t *testing.T) {
 
 	cases := map[string]struct {
-		appManifest       *manifest.Manifest
-		expectedContainer *corev1.Container
+		appManifest *manifest.Manifest
 	}{
 		"no manifest": {
 			appManifest: nil,
-			expectedContainer: &corev1.Container{
-				Name:  "test-app",
-				Image: "placeholder",
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          resources.UserPortName,
-						ContainerPort: resources.DefaultUserPort,
-					},
-				},
-				ReadinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      0,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-				LivenessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      0,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-			},
 		},
 		"have manifest with the properties": {
 			appManifest: &manifest.Manifest{
@@ -206,52 +168,6 @@ func TestGetContainer(t *testing.T) {
 					},
 				},
 			},
-			expectedContainer: &corev1.Container{
-				Name:  "test-app",
-				Image: "placeholder",
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          resources.UserPortName,
-						ContainerPort: resources.DefaultUserPort,
-					},
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						"cpu":               getResourceQuantity("1"),
-						"ephemeral-storage": getResourceQuantity(manifest.CFToSIUnits("1024M")),
-						"memory":            getResourceQuantity(manifest.CFToSIUnits("512M")),
-					},
-					Limits: corev1.ResourceList{
-						"cpu":               getResourceQuantity("1"),
-						"ephemeral-storage": getResourceQuantity(manifest.CFToSIUnits("1024M")),
-						"memory":            getResourceQuantity(manifest.CFToSIUnits("512M")),
-					},
-				},
-				ReadinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      60,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-				LivenessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      60,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-			},
 		},
 		"have manifest but no health check": {
 			appManifest: &manifest.Manifest{
@@ -262,51 +178,6 @@ func TestGetContainer(t *testing.T) {
 						Memory:                 "512M",
 						KfApplicationExtension: manifest.KfApplicationExtension{CPU: "1"},
 					},
-				},
-			},
-			expectedContainer: &corev1.Container{
-				Name:  "test-app",
-				Image: "placeholder",
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          resources.UserPortName,
-						ContainerPort: resources.DefaultUserPort},
-				},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						"cpu":               getResourceQuantity("1"),
-						"ephemeral-storage": getResourceQuantity(manifest.CFToSIUnits("1024M")),
-						"memory":            getResourceQuantity(manifest.CFToSIUnits("512M")),
-					},
-					Limits: corev1.ResourceList{
-						"cpu":               getResourceQuantity("1"),
-						"ephemeral-storage": getResourceQuantity(manifest.CFToSIUnits("1024M")),
-						"memory":            getResourceQuantity(manifest.CFToSIUnits("512M")),
-					},
-				},
-				ReadinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      0,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-				LivenessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						TCPSocket: &corev1.TCPSocketAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      0,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
 				},
 			},
 		},
@@ -321,39 +192,6 @@ func TestGetContainer(t *testing.T) {
 					},
 				},
 			},
-			expectedContainer: &corev1.Container{
-				Name:  "test-app",
-				Image: "placeholder",
-				Ports: []corev1.ContainerPort{
-					{
-						Name:          resources.UserPortName,
-						ContainerPort: resources.DefaultUserPort},
-				},
-				ReadinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      60,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-				LivenessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port: intstr.FromInt(int(resources.DefaultUserPort)),
-						},
-					},
-					InitialDelaySeconds: 0,
-					TimeoutSeconds:      60,
-					PeriodSeconds:       0,
-					SuccessThreshold:    1,
-					FailureThreshold:    0,
-				},
-			},
 		},
 	}
 
@@ -362,6 +200,7 @@ func TestGetContainer(t *testing.T) {
 			if tc.appManifest != nil {
 				manifestYaml, _ := yaml.Marshal(tc.appManifest)
 				os.WriteFile("manifest.yml", manifestYaml, os.ModePerm)
+				defer os.Remove("manifest.yml")
 			}
 
 			var app *manifest.Application
@@ -372,17 +211,13 @@ func TestGetContainer(t *testing.T) {
 			} else {
 				app, _ = tc.appManifest.App("test-app")
 			}
-			gotContainer, err := getContainer(app)
 
+			gotContainer, err := getContainer(app)
 			if err != nil {
 				t.Fatalf("wanted err: %v, got: %v", nil, err)
+			} else {
+				testutil.AssertGoldenJSON(t, "container", gotContainer)
 			}
-
-			if tc.appManifest != nil {
-				os.Remove("manifest.yml")
-			}
-
-			testutil.AssertEqual(t, "", tc.expectedContainer, gotContainer)
 		})
 	}
 }

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_cpu_diskquota_memory_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_cpu_diskquota_memory_container.golden
@@ -1,0 +1,38 @@
+{
+    "name": "test-app",
+    "image": "placeholder",
+    "ports": [
+        {
+            "name": "http-user-port",
+            "containerPort": 8080
+        }
+    ],
+    "resources": {},
+    "livenessProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "readinessProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "startupProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 2,
+        "successThreshold": 1,
+        "failureThreshold": 30
+    }
+}

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_health_check_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_health_check_container.golden
@@ -1,0 +1,49 @@
+{
+    "name": "test-app",
+    "image": "placeholder",
+    "ports": [
+        {
+            "name": "http-user-port",
+            "containerPort": 8080
+        }
+    ],
+    "resources": {
+        "limits": {
+            "cpu": "1",
+            "ephemeral-storage": "1Gi",
+            "memory": "512Mi"
+        },
+        "requests": {
+            "cpu": "1",
+            "ephemeral-storage": "1Gi",
+            "memory": "512Mi"
+        }
+    },
+    "livenessProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "readinessProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "startupProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 2,
+        "successThreshold": 1,
+        "failureThreshold": 30
+    }
+}

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_with_the_properties_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_with_the_properties_container.golden
@@ -1,0 +1,49 @@
+{
+    "name": "test-app",
+    "image": "placeholder",
+    "ports": [
+        {
+            "name": "http-user-port",
+            "containerPort": 8080
+        }
+    ],
+    "resources": {
+        "limits": {
+            "cpu": "1",
+            "ephemeral-storage": "1Gi",
+            "memory": "512Mi"
+        },
+        "requests": {
+            "cpu": "1",
+            "ephemeral-storage": "1Gi",
+            "memory": "512Mi"
+        }
+    },
+    "livenessProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "readinessProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "startupProbe": {
+        "httpGet": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 2,
+        "successThreshold": 1,
+        "failureThreshold": 30
+    }
+}

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_no_manifest_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_no_manifest_container.golden
@@ -1,0 +1,38 @@
+{
+    "name": "test-app",
+    "image": "placeholder",
+    "ports": [
+        {
+            "name": "http-user-port",
+            "containerPort": 8080
+        }
+    ],
+    "resources": {},
+    "livenessProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "readinessProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 30,
+        "successThreshold": 1,
+        "failureThreshold": 1
+    },
+    "startupProbe": {
+        "tcpSocket": {
+            "port": 8080
+        },
+        "timeoutSeconds": 1,
+        "periodSeconds": 2,
+        "successThreshold": 1,
+        "failureThreshold": 30
+    }
+}

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/internal/envutil"
 	"github.com/imdario/mergo"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/logging"
@@ -68,6 +69,10 @@ type Application struct {
 	// get requests to determine liveness if HealthCheckType is http.
 	HealthCheckHTTPEndpoint string `json:"health-check-http-endpoint,omitempty"`
 
+	// HealthCheckInvocationTimeout is the timeout in seconds for individual
+	// health check requests for HTTP and port health checks. By default this is 1.
+	HealthCheckInvocationTimeout int `json:"health-check-invocation-timeout,omitempty"`
+
 	// Metadata contains additional tags for applications and their underlying
 	// resources.
 	Metadata ApplicationMetadata `json:"metadata,omitempty"`
@@ -93,6 +98,13 @@ type KfApplicationExtension struct {
 	Dockerfile Dockerfile          `json:"dockerfile,omitempty"`
 	Build      *v1alpha1.BuildSpec `json:"build,omitempty"`
 	Ports      AppPortList         `json:"ports,omitempty"`
+
+	// Allow developers access to the underlying K8s probes because
+	// CF is extremely limiting in this respect.
+
+	StartupProbe   *corev1.Probe `json:"startupProbe,omitempty"`
+	LivenessProbe  *corev1.Probe `json:"livenessProbe,omitempty"`
+	ReadinessProbe *corev1.Probe `json:"readinessProbe,omitempty"`
 }
 
 // AppPort represents an open port on an App.

--- a/pkg/reconciler/app/resources/deployment.go
+++ b/pkg/reconciler/app/resources/deployment.go
@@ -175,6 +175,7 @@ func makePodSpec(app *v1alpha1.App, space *v1alpha1.Space) (*corev1.PodSpec, err
 	// If the client provides probes, we should fill in the port for them.
 	rewriteUserProbe(userContainer.LivenessProbe, userPort)
 	rewriteUserProbe(userContainer.ReadinessProbe, userPort)
+	rewriteUserProbe(userContainer.StartupProbe, userPort)
 
 	spec.ServiceAccountName = app.Status.ServiceAccountName
 	// This need to be removed after we implement server side apply.

--- a/pkg/reconciler/app/resources/deployment_test.go
+++ b/pkg/reconciler/app/resources/deployment_test.go
@@ -368,6 +368,13 @@ func Test_makePodSpec(t *testing.T) {
 											TCPSocket: &corev1.TCPSocketAction{},
 										},
 									},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/v1/livez",
+											},
+										},
+									},
 								},
 							},
 						},
@@ -439,6 +446,14 @@ func Test_makePodSpec(t *testing.T) {
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(9999),
+									},
+								},
+							},
+							StartupProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/v1/livez",
 										Port: intstr.FromInt(9999),
 									},
 								},

--- a/samples/apps/slowpoke/go.mod
+++ b/samples/apps/slowpoke/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/kf/v2/samples/apps/envs
+
+go 1.15

--- a/samples/apps/slowpoke/main.go
+++ b/samples/apps/slowpoke/main.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+)
+
+func main() {
+	bindDelay := lookupEnvSeconds("BIND_DELAY", 0)
+	healthDelay := lookupEnvSeconds("HEALTH_DELAY", 0) + bindDelay
+	healthProbeLatency := lookupEnvSeconds("HEALTH_PROBE_LATENCY", 0)
+
+	log.Println("Bind delay (from startup)", bindDelay)
+	log.Println("Health delay (from startup)", healthDelay)
+	log.Println("Health latency", healthProbeLatency)
+
+	startTime := time.Now()
+	log.Println("Start at", startTime)
+	log.Println("Bind will happen at", startTime.Add(bindDelay))
+	healthyTime := startTime.Add(healthDelay)
+	log.Println("Health will happen at", healthyTime)
+
+	time.Sleep(bindDelay)
+
+	log.Fatal(http.ListenAndServe(hostPort(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("Got request, waiting %s\n", healthProbeLatency)
+		time.Sleep(healthProbeLatency)
+
+		if time.Now().Before(healthyTime) {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, "Time before: %q", healthyTime)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	})))
+}
+
+func lookupEnvSeconds(key string, defaultValue int) time.Duration {
+	keyStr, ok := os.LookupEnv(key)
+	if !ok {
+		return time.Duration(defaultValue) * time.Second
+	}
+
+	envVal, err := strconv.Atoi(keyStr)
+	if err != nil {
+		panic(err)
+	}
+	return time.Duration(envVal) * time.Second
+}
+
+func hostPort() string {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	return fmt.Sprintf(":%s", port)
+}

--- a/samples/apps/slowpoke/manifest.yaml
+++ b/samples/apps/slowpoke/manifest.yaml
@@ -1,0 +1,26 @@
+applications:
+- name: slowpoke
+  env:
+    BIND_DELAY: "10"
+    HEALTH_DELAY: "20"
+    HEALTH_PROBE_LATENCY: "5"
+  startupProbe:
+    initialDelaySeconds: 1
+    successThreshold: 1
+    failureThreshold: 5
+    periodSeconds: 2
+    tcpSocket: {}
+  livenessProbe:
+    failureThreshold: 2
+    successThreshold: 1
+    periodSeconds: 10
+    httpGet:
+      path: "/"
+    timeoutSeconds: 6
+  readinessProbe:
+    failureThreshold: 10
+    successThreshold: 1
+    periodSeconds: 1
+    httpGet:
+      path: "/"
+    timeoutSeconds: 6


### PR DESCRIPTION
Kf was originally written before K8s supported startupProbe. Now that it does, we can better match what Diego does. Diego starts with a quick probe that repeatedly checks until the app reports health the first time then switches to a less frequent probe.

Under the old logic Kf used the timeout in the probes and retries to try and achieve a pseudo-startupProbe which may have left zombie routes for too long after an application had crashed. This PR aims to clean all this up by doing the following:

* Allowing the use of startupProbes in the app's container template.
* Defaulting the startupProbe port number to match the app's primary port.
* Updating the client-side logic that sets up probes to match Diego.
* Allowing developers to override this with new manifest fields.
* Adding support for a new CF manifest attribute introduced in CAPI v3.
* Improving the validation and error messages for the app manifest.
