### PR TITLE
Make ClusterRole `EnsureExists`

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -15,7 +15,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   annotations:
-    operator.knative.dev/mode: Reconcile
+    operator.knative.dev/mode: EnsureExists
   name: kf-admin
 aggregationRule:
   clusterRoleSelectors:


### PR DESCRIPTION
Kf controller populates rules for the clusterole, which is conflicting with Kf operator

