### PR TITLE
Add setting to not track conditions of VirtualService when reconciling

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -164,7 +164,7 @@ data:
     # the time when the processes are forcibly halted with a kill signal.
     terminationGracePeriodSeconds: 120
     # When set to true, Route status will be updated with VirtualService conditions.
-    routeTrackVirtualService: "false"
+    routeTrackVirtualService: "true"
 
     # The following images are used to execute builds. They SHOULD NOT be
     # modified except in rare circumstances.
@@ -235,5 +235,5 @@ data:
   appCPUMin: "100m"
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
-  routeTrackVirtualService: "false"
+  routeTrackVirtualService: "true"
 

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -164,7 +164,7 @@ data:
     # the time when the processes are forcibly halted with a kill signal.
     terminationGracePeriodSeconds: 120
     # When set to true, Route status will be updated with VirtualService conditions.
-    routeTrackVirtualService: "true"
+    routeTrackVirtualService: "false"
 
     # The following images are used to execute builds. They SHOULD NOT be
     # modified except in rare circumstances.
@@ -235,5 +235,5 @@ data:
   appCPUMin: "100m"
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
-  routeTrackVirtualService: "true"
+  routeTrackVirtualService: "false"
 

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -163,6 +163,8 @@ data:
     # The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and
     # the time when the processes are forcibly halted with a kill signal.
     terminationGracePeriodSeconds: 120
+    # When set to true, Route status will be updated with VirtualService conditions.
+    routeTrackVirtualService: "false"
 
     # The following images are used to execute builds. They SHOULD NOT be
     # modified except in rare circumstances.
@@ -233,4 +235,5 @@ data:
   appCPUMin: "100m"
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
+  routeTrackVirtualService: "false"
 

--- a/operator/pkg/apis/kfsystem/kf/defaults.go
+++ b/operator/pkg/apis/kfsystem/kf/defaults.go
@@ -43,6 +43,7 @@ const (
 	appCPUMinKey                     = "appCPUMin"
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
+	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
 
 	// Images used for build purposes
 
@@ -140,6 +141,9 @@ type DefaultsConfig struct {
 	// The grace period is the duration in seconds after the processes running in the pod are sent
 	// a termination signal and the time when the processes are forcibly halted with a kill signal.
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// RouteTrackVirtualService when set to true, will update Route status with VirtualService conditions.
+	RouteTrackVirtualService bool `json:"routeTrackVirtualService,omitempty"`
 }
 
 // BuiltinDefaultsConfig creates a defaults configuration with default values.
@@ -247,6 +251,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		appCPUMinKey:                     &defaultsConfig.AppCPUMin,
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
+		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
 	}
 
 	if !leaveEmpty {

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -1,10 +1,10 @@
-// Copyright 2022 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -1,10 +1,10 @@
-// Copyright 2019 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -43,6 +43,7 @@ const (
 	appCPUMinKey                     = "appCPUMin"
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
+	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
 
 	// Images used for build purposes
 
@@ -140,6 +141,9 @@ type DefaultsConfig struct {
 	// The grace period is the duration in seconds after the processes running in the pod are sent
 	// a termination signal and the time when the processes are forcibly halted with a kill signal.
 	TerminationGracePeriodSeconds *int64 `json:"terminationGracePeriodSeconds,omitempty"`
+
+	// RouteTrackVirtualService when set to true, will update Route status with VirtualService conditions.
+	RouteTrackVirtualService bool `json:"routeTrackVirtualService,omitempty"`
 }
 
 // BuiltinDefaultsConfig creates a defaults configuration with default values.
@@ -247,6 +251,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		appCPUMinKey:                     &defaultsConfig.AppCPUMin,
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
+		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
 	}
 
 	if !leaveEmpty {

--- a/pkg/apis/kf/config/defaults_test.go
+++ b/pkg/apis/kf/config/defaults_test.go
@@ -50,6 +50,7 @@ func TestPatchConfigMap(t *testing.T) {
 		appCPUPerGBOfRAMKey,
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
+		routeTrackVirtualServiceKey,
 	}
 	_, configMap := cmtesting.ConfigMapsFromTestFile(t, DefaultsConfigTestName, allowedPredefinedKey...)
 	// sanity check the configmap, add more assertions below when new fields

--- a/pkg/apis/kf/config/store_test.go
+++ b/pkg/apis/kf/config/store_test.go
@@ -56,6 +56,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 		appCPUPerGBOfRAMKey,
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
+		routeTrackVirtualServiceKey,
 	}
 	_, configMap := cmtesting.ConfigMapsFromTestFile(t, DefaultsConfigName, allowedPredefinedKey...)
 	// sanity check the configmap, add more assertions below when new fields

--- a/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
@@ -669,7 +669,7 @@ func TestAppStatus_PropagateRouteStatus(t *testing.T) {
 		route.Status.PropagateRouteSpecFields(qrb.Source)
 		route.Status.PropagateVirtualService(&networking.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{Name: "some-vs"},
-		}, nil)
+		}, nil, true)
 		route.Status.PropagateBindings([]RouteDestination{qrb.Destination})
 		route.Status.PropagateSpaceDomain(&SpaceDomain{
 			Domain: qrb.Source.Domain,

--- a/pkg/reconciler/route/reconciler.go
+++ b/pkg/reconciler/route/reconciler.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
+	pkgreconciler "knative.dev/pkg/reconciler"
 )
 
 // Reconciler reconciles a Route object with the K8s cluster.
@@ -49,7 +50,7 @@ type Reconciler struct {
 	spaceLister                  kflisters.SpaceLister
 	serviceInstanceBindingLister kflisters.ServiceInstanceBindingLister
 
-	kfConfigStore *config.Store
+	kfConfigStore pkgreconciler.ConfigStore
 }
 
 // Check that our Reconciler implements controller.Reconciler
@@ -58,7 +59,6 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 // Reconcile is called by knative/pkg when a new event is observed by one of the
 // watchers in the controller.
 func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
-	ctx = r.kfConfigStore.ToContext(ctx)
 	namespace, domain, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
@@ -89,6 +89,7 @@ func (r *Reconciler) ApplyChanges(
 	domain string,
 ) error {
 	logger := logging.FromContext(ctx)
+	ctx = r.kfConfigStore.ToContext(ctx)
 
 	// Check that the domain is valid for the Space
 	var spaceDomain *v1alpha1.SpaceDomain

--- a/pkg/reconciler/route/resources/virtual_service.go
+++ b/pkg/reconciler/route/resources/virtual_service.go
@@ -199,7 +199,7 @@ func buildHTTPRoutes(routes v1alpha1.RouteSpecFieldsSlice, appBindings map[strin
 		}
 
 		if len(appDestinations) == 0 {
-			// no apps bound to this path, return http route with fault for path
+			// no apps bound to this path, return http route with default for path
 			rsfHTTPRoutes = append(rsfHTTPRoutes, buildDefaultHTTPRoute(*pathMatchers))
 		} else {
 			// Build HTTP Routes with `x-kf-app` header for matching specific app requests.


### PR DESCRIPTION
Default to not track conditions of VirtualService when reconciling Routes.
Status change is causing too much updates to VirtualService.
