### PR TITLE
Cpu limits

### DIFF
--- a/docs/content/en/docs/v2.11/developer/build-and-deploy/manifest.md
+++ b/docs/content/en/docs/v2.11/developer/build-and-deploy/manifest.md
@@ -28,7 +28,8 @@ The following fields are valid for objects under `applications`:
 | `services`                   | `string[]` | A list of service instance names to automatically bind to the app. |
 | `disk_quota`                 | `quantity` | The amount of disk the application should get. Defaults to 1GiB. |
 | `memory`                     | `quantity` | The amount of RAM to provide the app. Defaults to 1GiB. |
-| `cpu` †                      | `quantity` | The amount of CPU to provide the application. Defaults to 0.1 (1/10th of a CPU). |
+| `cpu` †                      | `quantity` | The amount of CPU to provide the application. Defaults to 1/10th of a CPU. |
+| `cpu-limit` †                | `quantity` | The maximum amount of CPU to provide the application. Defaults to unlimited. |
 | `instances`                  | `int`      | The number of instances of the app to run. Defaults to 1. |
 | `routes`                     | `object`   | A list of routes the app should listen on. See the Route Fields section for more. |
 | `no-route`                   | `boolean`  | If set to true, the application will not be routable. |
@@ -169,7 +170,7 @@ applications:
   # use less disk and memory than default
   disk_quota: 512M
   memory: 512M
-  # bump up the CPU
+  # Give the app a minimum of 2/10ths of a CPU
   cpu: 200m
   instances: 3
   # make the app listen on three routes
@@ -205,6 +206,7 @@ applications:
     ENVIRONMENT: PRODUCTION
   disk_quota: 1G
   memory: 1G
+  # Give the app a minimum of 2 full CPUs
   cpu: 2000m
   instances: 1
   routes:

--- a/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
+++ b/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
@@ -4,11 +4,11 @@ description: "Learn to set resources on apps."
 weight: 20
 ---
 
-When you create an app, you can optionallyl specify how much of each resource each instance
+When you create an app, you can optionally specify how much of each resource an instance
 of the application will receive when it runs.
 
 Kf simplifies the Kubernetes model of resources and provides defaults that should work for
-most I/O bound appliations out of the box.
+most I/O bound applications out of the box.
 
 ## Resource types
 
@@ -44,7 +44,7 @@ applications:
 
 Memory and ephemeral storage are both set to 1Gi if not specified.
 
-CPU defautls to one of the following
+CPU defaults to one of the following
 
 * 1/10th of a CPU if the platform operator hasn't overridden it.
 * A CPU value proportionally scaled by the amount of memory requested.

--- a/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
+++ b/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
@@ -75,7 +75,7 @@ your application.
 ## Best practices
 
 * All applications should set memory and disk quotas.
-* CPU intensive applications should set a CPU and limit to guarantee they'll have the resources they need without
+* CPU intensive applications should set a CPU request and limit to guarantee they'll have the resources they need without
   starving other apps.
 * I/O bound applications shouldn't set a CPU limit so they can burst during startup.
 

--- a/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
+++ b/docs/content/en/docs/v2.11/developer/scaling/resource-management.md
@@ -1,0 +1,84 @@
+---
+title: Managing Resources for Apps
+description: "Learn to set resources on apps."
+weight: 20
+---
+
+When you create an app, you can optionallyl specify how much of each resource each instance
+of the application will receive when it runs.
+
+Kf simplifies the Kubernetes model of resources and provides defaults that should work for
+most I/O bound appliations out of the box.
+
+## Resource types
+
+Kf supports three types of resources, memory, CPU, and ephemeral disk.
+
+* Memory specifies the amount of RAM an application receives when running. If it exceeds this amount
+  then the container is restarted.
+* Ephemeral disk specifies how much an application can write to a local disk. If an application exceeds
+  this amount then it may not be able to write more.
+* CPU specifies the number of CPUs an application receives when running.
+
+### Manifest
+
+Resources are specified using four values in the manifest:
+
+* `memory` sets the guaranteed minimum an app will receive and the maximum it's permitted to use.
+* `disk_quota` sets the guaranteed minimum an app will receive and the maximum it's permitted to use.
+* `cpu` sets the guaranteed minimum an app will receive.
+* `cpu-limit` sets the maximum CPU an app can use.
+
+Example:
+
+```yaml
+applications:
+- name: "example"
+  disk_quota: 512M
+  memory: 512M
+  cpu: 200m
+  cpu-limit: 2000m
+```
+
+### Defaults
+
+Memory and ephemeral storage are both set to 1Gi if not specified.
+
+CPU defautls to one of the following
+
+* 1/10th of a CPU if the platform operator hasn't overridden it.
+* A CPU value proportionally scaled by the amount of memory requested.
+* A minimum CPU value set by the platform operator.
+
+## Resource units
+
+### Memory and disk
+
+Cloud Foundry used the units `T`, `G`, `M`, and `K` to represent powers of two. 
+Kubernetes uses the units `Ei`, `Pi`, `Gi`, `Mi`, and `Ki` for the same.
+
+Kf allows you to specify memory and disk in either units.
+
+### CPU
+
+Kf and Kubernetes use the unit `m` for CPU, representing milli-CPU cores (thousandths of a core).
+
+## Sidecar overhead
+
+When Kf schedules your app's container as a Kubernetes Pod, it may bundle additional containers to your app
+to provide additional functionality. It's likely your application will also have an Istio sidecar which is
+responsible for networking.
+
+These containers will supply their own resource requests and limits and are overhead associated with running
+your application.
+
+## Best practices
+
+* All applications should set memory and disk quotas.
+* CPU intensive applications should set a CPU and limit to guarantee they'll have the resources they need without
+  starving other apps.
+* I/O bound applications shouldn't set a CPU limit so they can burst during startup.
+
+## Additional reading
+
+* Learn how [Kubernetes defines resources and schedules apps based on resource use](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)

--- a/pkg/apis/kf/v1alpha1/app_defaults.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	DefaultMem     = resource.MustParse("1Gi")
-	DefaultStorage = resource.MustParse("1Gi")
+	defaultStorage = resource.MustParse("1Gi")
 
 	// CPU isn't defaulted in Cloud Foundry so we assume apps are I/O bound
 	// and roughly 10 should run on a single core machine.
-	DefaultCPU = resource.MustParse("100m")
+	defaultCPU = resource.MustParse("100m")
 )
 
 const (
@@ -175,11 +175,11 @@ func SetKfAppContainerDefaults(_ context.Context, container *corev1.Container) {
 	}
 
 	if _, exists := container.Resources.Requests[corev1.ResourceEphemeralStorage]; !exists {
-		container.Resources.Requests[corev1.ResourceEphemeralStorage] = DefaultStorage
+		container.Resources.Requests[corev1.ResourceEphemeralStorage] = defaultStorage
 	}
 
 	if _, exists := container.Resources.Requests[corev1.ResourceCPU]; !exists {
-		container.Resources.Requests[corev1.ResourceCPU] = DefaultCPU
+		container.Resources.Requests[corev1.ResourceCPU] = defaultCPU
 	}
 
 	// Set limits if they've not been set for a value.

--- a/pkg/apis/kf/v1alpha1/app_defaults.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	defaultMem     = resource.MustParse("1Gi")
-	defaultStorage = resource.MustParse("1Gi")
+	DefaultMem     = resource.MustParse("1Gi")
+	DefaultStorage = resource.MustParse("1Gi")
 
 	// CPU isn't defaulted in Cloud Foundry so we assume apps are I/O bound
 	// and roughly 10 should run on a single core machine.
-	defaultCPU = resource.MustParse("100m")
+	DefaultCPU = resource.MustParse("100m")
 )
 
 const (
@@ -171,15 +171,15 @@ func SetKfAppContainerDefaults(_ context.Context, container *corev1.Container) {
 	}
 
 	if _, exists := container.Resources.Requests[corev1.ResourceMemory]; !exists {
-		container.Resources.Requests[corev1.ResourceMemory] = defaultMem
+		container.Resources.Requests[corev1.ResourceMemory] = DefaultMem
 	}
 
 	if _, exists := container.Resources.Requests[corev1.ResourceEphemeralStorage]; !exists {
-		container.Resources.Requests[corev1.ResourceEphemeralStorage] = defaultStorage
+		container.Resources.Requests[corev1.ResourceEphemeralStorage] = DefaultStorage
 	}
 
 	if _, exists := container.Resources.Requests[corev1.ResourceCPU]; !exists {
-		container.Resources.Requests[corev1.ResourceCPU] = defaultCPU
+		container.Resources.Requests[corev1.ResourceCPU] = DefaultCPU
 	}
 
 	// Set limits if they've not been set for a value.
@@ -190,7 +190,9 @@ func SetKfAppContainerDefaults(_ context.Context, container *corev1.Container) {
 	for _, key := range []v1.ResourceName{
 		corev1.ResourceMemory,
 		corev1.ResourceEphemeralStorage,
-		corev1.ResourceCPU,
+
+		// No upper bound for CPU is set by default. Users must explicitly
+		// set CPU in the manifest to cap it if they want.
 	} {
 		if _, exists := container.Resources.Limits[key]; !exists {
 			container.Resources.Limits[key] = container.Resources.Requests[key]

--- a/pkg/apis/kf/v1alpha1/app_defaults_test.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults_test.go
@@ -226,11 +226,11 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						corev1.ResourceCPU:              defaultCPU,
-						corev1.ResourceMemory:           defaultMem,
+						corev1.ResourceMemory:           DefaultMem,
 						corev1.ResourceEphemeralStorage: defaultStorage,
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceMemory:           defaultMem,
+						corev1.ResourceMemory:           DefaultMem,
 						corev1.ResourceEphemeralStorage: defaultStorage,
 					},
 				},

--- a/pkg/apis/kf/v1alpha1/app_defaults_test.go
+++ b/pkg/apis/kf/v1alpha1/app_defaults_test.go
@@ -230,7 +230,6 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 						corev1.ResourceEphemeralStorage: defaultStorage,
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              defaultCPU,
 						corev1.ResourceMemory:           defaultMem,
 						corev1.ResourceEphemeralStorage: defaultStorage,
 					},
@@ -373,7 +372,6 @@ func TestSetKfAppContainerDefaults(t *testing.T) {
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:              resource.MustParse("2"),
 						corev1.ResourceMemory:           resource.MustParse("2Gi"),
 						corev1.ResourceEphemeralStorage: resource.MustParse("2Gi"),
 					},

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_health_check_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_but_no_health_check_container.golden
@@ -9,7 +9,6 @@
     ],
     "resources": {
         "limits": {
-            "cpu": "1",
             "ephemeral-storage": "1Gi",
             "memory": "512Mi"
         },

--- a/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_with_the_properties_container.golden
+++ b/pkg/kf/commands/exporttok8s/testdata/golden/testgetcontainer_have_manifest_with_the_properties_container.golden
@@ -9,7 +9,6 @@
     ],
     "resources": {
         "limits": {
-            "cpu": "1",
             "ephemeral-storage": "1Gi",
             "memory": "512Mi"
         },

--- a/pkg/kf/manifest/manifest.go
+++ b/pkg/kf/manifest/manifest.go
@@ -90,8 +90,8 @@ type ApplicationMetadata struct {
 
 // KfApplicationExtension holds fields that aren't officially in cf
 type KfApplicationExtension struct {
-	// TODO(#95): These aren't CF proper. How do we expose these in the manifest?
 	CPU        string              `json:"cpu,omitempty"`
+	CPULimit   string              `json:"cpu-limit,omitempty"`
 	NoStart    *bool               `json:"no-start,omitempty"`
 	Entrypoint string              `json:"entrypoint,omitempty"`
 	Args       []string            `json:"args,omitempty"`

--- a/pkg/kf/manifest/manifest_conversion_test.go
+++ b/pkg/kf/manifest/manifest_conversion_test.go
@@ -116,7 +116,7 @@ func TestApplication_ToResourceRequirements(t *testing.T) {
 			runtimeConfig: defaultRuntimeConfig,
 			expectedReqs:  &corev1.ResourceRequirements{},
 		},
-		"min CPU mone specified": {
+		"min CPU none specified": {
 			source: Application{},
 			runtimeConfig: &v1alpha1.SpaceStatusRuntimeConfig{
 				AppCPUMin: resourcePtr(resource.MustParse("2000m")),
@@ -231,7 +231,7 @@ func TestApplication_ToResourceRequirements(t *testing.T) {
 			},
 			expectedErr: errors.New(`cpu-limit: "1m" must be greater than request: "256m"`),
 		},
-		"just cpu-limit ": {
+		"just cpu-limit": {
 			source: Application{
 				KfApplicationExtension: KfApplicationExtension{
 					CPULimit: "5000m",

--- a/pkg/kf/manifest/manifest_test.go
+++ b/pkg/kf/manifest/manifest_test.go
@@ -228,6 +228,30 @@ applications:
 				},
 			},
 		},
+		"resources": {
+			fileContent: `---
+applications:
+- name: MY-APP
+  memory: 4G
+  cpu: 1000m
+  disk_quota: 1G
+  cpu-limit: 2000m
+`,
+			expected: &manifest.Manifest{
+				RelativePathRoot: relativePathRoot,
+				Applications: []manifest.Application{
+					{
+						Name:      "MY-APP",
+						DiskQuota: "1G",
+						Memory:    "4G",
+						KfApplicationExtension: manifest.KfApplicationExtension{
+							CPU:      "1000m",
+							CPULimit: "2000m",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
This change reverts the previous change that forced apps defining a CPU in the manifest to use that as both lower and upper bound.

It restores the behavior that by default apps will have no upper-bound and instead will only get the lower-bound if they set CPU.

Apps that want to set an upper-bound should use the new cpu-limit property instead.

There's also a new document outlining how resources work in Kf to
explain the caveats around setting CPUs.
