### PR TITLE
Fixed nondeterministic volume statues.

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle.go
@@ -302,11 +302,19 @@ func (status *AppStatus) PropagateVolumeBindingsStatus(volumeBindings []*Service
 		})
 	}
 
+	// Make sure status is deterministic.
+	sort.Slice(volumeStatus, func(i, j int) bool {
+		return volumeStatus[i].MountPath < volumeStatus[j].MountPath
+	})
 	status.Volumes = volumeStatus
 }
 
 // PropagateServiceInstanceBindingsStatus updates the service binding readiness status.
 func (status *AppStatus) PropagateServiceInstanceBindingsStatus(bindings []ServiceInstanceBinding) {
+	// Make sure binding sorting is deterministic.
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].Name < bindings[j].Name
+	})
 
 	// Gather binding names
 	var bindingNames []string

--- a/pkg/reconciler/app/resources/deployment.go
+++ b/pkg/reconciler/app/resources/deployment.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -238,6 +239,12 @@ func buildVolumes(volumeStatus []v1alpha1.AppVolumeStatus) ([]corev1.Volume, []c
 	if len(volumeStatus) == 0 {
 		return nil, nil, nil, nil, nil
 	}
+
+	// Make sure the output is deterministic, volume services shouldn't
+	// have dependencies on each other so it should be fine to rearrange.
+	sort.Slice(volumeStatus, func(i, j int) bool {
+		return volumeStatus[i].VolumeName < volumeStatus[j].VolumeName
+	})
 
 	var volumes []corev1.Volume
 	var userVolumeMounts []corev1.VolumeMount

--- a/pkg/reconciler/app/resources/deployment.go
+++ b/pkg/reconciler/app/resources/deployment.go
@@ -243,7 +243,7 @@ func buildVolumes(volumeStatus []v1alpha1.AppVolumeStatus) ([]corev1.Volume, []c
 	// Make sure the output is deterministic, volume services shouldn't
 	// have dependencies on each other so it should be fine to rearrange.
 	sort.Slice(volumeStatus, func(i, j int) bool {
-		return volumeStatus[i].VolumeName < volumeStatus[j].VolumeName
+		return volumeStatus[i].MountPath < volumeStatus[j].MountPath
 	})
 
 	var volumes []corev1.Volume


### PR DESCRIPTION
Volumes were being polled from the k8s api which can cause unsorted lists. If multiple volumes were attached to an application it could cause the application instance to be infinitely reconciled.