### PR TITLE
Allow start commands to be displayed.

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -158,6 +158,10 @@ data:
     appCPUPerGBOfRAM: "100m"
     # Absolute minimum amount of CPU to give an app. Expressed as a Kubernetes quantity.
     appCPUMin: "100m"
+    # AppDisableStartCommandLookup disables the App reconciler from looking
+    # up the start command for Apps which requires fetching the container
+    # configuration for every App.
+    appDisableStartCommandLookup: "false"
     # Maximum time in seconds for a deployment to make progress before it is considered to be failed
     progressDeadlineSeconds: "600"
     # The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and
@@ -238,6 +242,7 @@ data:
     enable_appdevexperience_builds: false
   appCPUPerGBOfRAM: "100m"
   appCPUMin: "100m"
+  appDisableStartCommandLookup: "false"
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
   routeTrackVirtualService: "false"

--- a/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
+++ b/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
@@ -188,6 +188,26 @@ kubectl patch \
     -p="[{'op':'add','path':'/spec/kf/config/terminationGracePeriodSeconds','value':200}]"
 ```
 
+## Enable/Disable App Start Command Lookup
+
+Allows enabling/disbaling start command lookup in the App reconciler.
+This behavior requires the reconciler to fetch contianer configuration for every app from the container registry
+and enables displaying the start command on `kf push` and in `kf app`.
+
+Enabling this behavior on a large cluster may make the reconcilation times for Apps slow.
+
+Values for `appDisableStartCommandLookup`:
+
+* `false` Enable start command lookup. (Default)
+* `true` Disable start command lookup.
+
+```sh
+kubectl patch \
+    kfsystem kfsystem \
+    --type='json' \
+    -p="[{'op':'add','path':'/spec/kf/config/appDisableStartCommandLookup','value':true}]"
+```
+
 ## Set default Kf Task timeout
 
 Kf uses Tekton TaskRuns as its mechanism to run Kf Tasks. 

--- a/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
+++ b/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
@@ -191,7 +191,7 @@ kubectl patch \
 ## Enable/Disable App Start Command Lookup
 
 Allows enabling/disbaling start command lookup in the App reconciler.
-This behavior requires the reconciler to fetch contianer configuration for every app from the container registry
+This behavior requires the reconciler to fetch container configuration for every app from the container registry
 and enables displaying the start command on `kf push` and in `kf app`.
 
 Enabling this behavior on a large cluster may make the reconcilation times for Apps slow.

--- a/operator/pkg/apis/kfsystem/kf/defaults.go
+++ b/operator/pkg/apis/kfsystem/kf/defaults.go
@@ -41,6 +41,7 @@ const (
 	buildNodeSelectorsKey            = "buildNodeSelectors"
 	appCPUPerGBOfRAMKey              = "appCPUPerGBOfRAM"
 	appCPUMinKey                     = "appCPUMin"
+	appDisableStartCommandLookupKey  = "appDisableStartCommandLookup"
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
@@ -134,6 +135,11 @@ type DefaultsConfig struct {
 
 	// Minimum amount of CPU to assign an app.
 	AppCPUMin *resource.Quantity `json:"appCPUMin,omitempty"`
+
+	// AppDisableStartCommandLookup disables the App reconciler from looking
+	// up the start command for Apps which requires fetching the container
+	// configuration for every App.
+	AppDisableStartCommandLookup bool `json:"appDisableStartCommandLookup,omitempty"`
 
 	// ProgressDeadlineSeconds contains the maximum time in seconds for a deployment to make progress before it
 	// is considered to be failed.
@@ -255,6 +261,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		buildNodeSelectorsKey:            &defaultsConfig.BuildNodeSelectors,
 		appCPUPerGBOfRAMKey:              &defaultsConfig.AppCPUPerGBOfRAM,
 		appCPUMinKey:                     &defaultsConfig.AppCPUMin,
+		appDisableStartCommandLookupKey:  &defaultsConfig.AppDisableStartCommandLookup,
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -41,6 +41,7 @@ const (
 	buildNodeSelectorsKey            = "buildNodeSelectors"
 	appCPUPerGBOfRAMKey              = "appCPUPerGBOfRAM"
 	appCPUMinKey                     = "appCPUMin"
+	appDisableStartCommandLookupKey  = "appDisableStartCommandLookup"
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
@@ -134,6 +135,11 @@ type DefaultsConfig struct {
 
 	// Minimum amount of CPU to assign an app.
 	AppCPUMin *resource.Quantity `json:"appCPUMin,omitempty"`
+
+	// AppDisableStartCommandLookup disables the App reconciler from looking
+	// up the start command for Apps which requires fetching the container
+	// configuration for every App.
+	AppDisableStartCommandLookup bool `json:"appDisableStartCommandLookup,omitempty"`
 
 	// ProgressDeadlineSeconds contains the maximum time in seconds for a deployment to make progress before it
 	// is considered to be failed.
@@ -255,6 +261,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		buildNodeSelectorsKey:            &defaultsConfig.BuildNodeSelectors,
 		appCPUPerGBOfRAMKey:              &defaultsConfig.AppCPUPerGBOfRAM,
 		appCPUMinKey:                     &defaultsConfig.AppCPUMin,
+		appDisableStartCommandLookupKey:  &defaultsConfig.AppDisableStartCommandLookup,
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,

--- a/pkg/apis/kf/config/defaults_test.go
+++ b/pkg/apis/kf/config/defaults_test.go
@@ -48,6 +48,7 @@ func TestPatchConfigMap(t *testing.T) {
 		nopImageKey,
 		appCPUMinKey,
 		appCPUPerGBOfRAMKey,
+		appDisableStartCommandLookupKey,
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,

--- a/pkg/apis/kf/config/store_test.go
+++ b/pkg/apis/kf/config/store_test.go
@@ -54,6 +54,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 		nopImageKey,
 		appCPUMinKey,
 		appCPUPerGBOfRAMKey,
+		appDisableStartCommandLookupKey,
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,

--- a/pkg/reconciler/app/reconciler.go
+++ b/pkg/reconciler/app/reconciler.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
+	"reflect"
+	"sort"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	containerregistryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/kf/v2/pkg/dockerutil"
-	"math"
-	"reflect"
-	"sort"
 
 	kfconfig "github.com/google/kf/v2/pkg/apis/kf/config"
 	"github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
@@ -604,40 +605,52 @@ func (r *Reconciler) ApplyChanges(ctx context.Context, app *v1alpha1.App) error 
 
 	// Sync start commands, populate container and buildpack start commands in app status.
 	{
-		logger.Debug("reconciling start commands")
-		startCommands := app.Status.StartCommands
-		if startCommands.Image != app.Status.Image && app.Status.Image != DefaultPlaceHolderBuildImage {
-			startCommands.Image = app.Status.Image
-			containerConfig, err := r.fetchContainerCommand(app)
-			if err != nil {
-				startCommands.Error = err.Error()
-			}
+		configDefaults, err := kfconfig.FromContext(ctx).Defaults()
+		if err != nil {
+			return fmt.Errorf("failed to read config-defaults: %v", err)
+		}
 
-			if app.Spec.Build.Image != nil {
-				startCommands.Container = containerConfig.Config.Entrypoint
-			} else {
-				buildName := app.Status.BuildStatusFields.BuildName
-
-				buildConfig, err := r.buildLister.Builds(app.GetNamespace()).Get(buildName)
-				if err != nil {
-					return err
-				}
-
-				startCommands.Container = containerConfig.Config.Entrypoint
-
-				if buildConfig.Spec.Name == v1alpha1.BuildpackV2BuildTaskName {
-					startCommands.Buildpack = []string{containerConfig.Config.Labels["StartCommand"]}
-				}
-			}
-
-			app.Status.PropagateStartCommandStatus(startCommands)
+		if !configDefaults.AppDisableStartCommandLookup {
+			logger.Debug("reconciling start commands")
+			r.updateStartCommand(app, fetchContainerCommand)
 		}
 	}
 	return nil
 }
 
-func (r *Reconciler) fetchContainerCommand(app *v1alpha1.App) (*containerregistryv1.ConfigFile, error) {
-	imageRef, err := name.ParseReference(app.Status.Image, name.WeakValidation)
+type ImageConfigFetcher func(image string) (*containerregistryv1.ConfigFile, error)
+
+func (*Reconciler) updateStartCommand(app *v1alpha1.App, fetcher ImageConfigFetcher) {
+	if app.Status.Image == app.Status.StartCommands.Image ||
+		app.Status.Image == DefaultPlaceHolderBuildImage ||
+		app.Status.Image == "" {
+		// Don't lookup start commands if we've already cached them or expect them not to exist.
+		return
+	}
+
+	startCommands := v1alpha1.StartCommandStatus{
+		// The image is set to prevent repeatedly looking up the values for the same image.
+		Image: app.Status.Image,
+	}
+
+	containerConfig, err := fetcher(app.Status.Image)
+	if err != nil {
+		startCommands.Error = err.Error()
+	} else {
+		startCommands.Container = containerConfig.Config.Entrypoint
+
+		// Look for a special label set by the buildpack that might contain the
+		// start command for v2 buildpacks.
+		if maybeStartCommand, ok := containerConfig.Config.Labels["StartCommand"]; ok {
+			startCommands.Buildpack = []string{maybeStartCommand}
+		}
+	}
+
+	app.Status.PropagateStartCommandStatus(startCommands)
+}
+
+func fetchContainerCommand(image string) (*containerregistryv1.ConfigFile, error) {
+	imageRef, err := name.ParseReference(image, name.WeakValidation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/reconciler/app/reconciler_test.go
+++ b/pkg/reconciler/app/reconciler_test.go
@@ -15,10 +15,12 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
+	containerregistryv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/kf/testutil"
 	v1 "k8s.io/api/core/v1"
@@ -238,6 +240,181 @@ func TestBuildsToGC(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			actual := buildsToGC(tc.builds, tc.maxBuilds)
 			testutil.AssertEqual(t, "builds", tc.wantBuilds, actual)
+		})
+	}
+}
+
+func TestReconciler_updateStartCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		app         *v1alpha1.App
+		imageConfig *containerregistryv1.ConfigFile
+		imageErr    error
+
+		wantStartCommandStatus v1alpha1.StartCommandStatus
+	}{
+		"empty app doesn't update status": {
+			app:      &v1alpha1.App{},
+			imageErr: errors.New("should not happen"),
+
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{},
+		},
+		"nop image doesn't update status": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "gcr.io/kf-releases/nop:nop",
+					},
+				},
+			},
+			imageErr:               errors.New("should not happen"),
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{},
+		},
+		"empty image doesn't update status": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "",
+					},
+				},
+			},
+			imageErr:               errors.New("should not happen"),
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{},
+		},
+		"matching image doesn't update status": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v1",
+					},
+					StartCommands: v1alpha1.StartCommandStatus{
+						Image: "example.com/image:v1",
+						Error: "old error",
+					},
+				},
+			},
+			imageErr: errors.New("new error"),
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image: "example.com/image:v1",
+				Error: "old error",
+			},
+		},
+		"mismatched image updates status error": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v2",
+					},
+					StartCommands: v1alpha1.StartCommandStatus{
+						Image: "example.com/image:v1",
+						Error: "old error",
+					},
+				},
+			},
+			imageErr: errors.New("new error"),
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image: "example.com/image:v2",
+				Error: "new error",
+			},
+		},
+		"mismatched image updates status": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v2",
+					},
+					StartCommands: v1alpha1.StartCommandStatus{
+						Image: "example.com/image:v1",
+						Error: "old error",
+					},
+				},
+			},
+			imageConfig: &containerregistryv1.ConfigFile{
+				Config: containerregistryv1.Config{
+					Entrypoint: []string{"/bin/sh", "-c"},
+				},
+			},
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image:     "example.com/image:v2",
+				Container: []string{"/bin/sh", "-c"},
+			},
+		},
+		"no command on image": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v2",
+					},
+				},
+			},
+			imageConfig: &containerregistryv1.ConfigFile{},
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image:     "example.com/image:v2",
+				Container: nil,
+			},
+		},
+		"v2 bulidpack no entrypoint": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v2",
+					},
+				},
+			},
+			imageConfig: &containerregistryv1.ConfigFile{
+				Config: containerregistryv1.Config{
+					Labels: map[string]string{
+						"StartCommand": "java -jar some-file.jar",
+					},
+				},
+			},
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image:     "example.com/image:v2",
+				Container: nil,
+				Buildpack: []string{"java -jar some-file.jar"},
+			},
+		},
+		"v2 bulidpack with entrypoint": {
+			app: &v1alpha1.App{
+				Status: v1alpha1.AppStatus{
+					BuildStatusFields: v1alpha1.BuildStatusFields{
+						Image: "example.com/image:v2",
+					},
+				},
+			},
+			imageConfig: &containerregistryv1.ConfigFile{
+				Config: containerregistryv1.Config{
+					Entrypoint: []string{"/lifecycle/launcher"},
+					Labels: map[string]string{
+						"StartCommand": "java -jar some-file.jar",
+					},
+				},
+			},
+			wantStartCommandStatus: v1alpha1.StartCommandStatus{
+				Image:     "example.com/image:v2",
+				Container: []string{"/lifecycle/launcher"},
+				Buildpack: []string{"java -jar some-file.jar"},
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			r := &Reconciler{}
+
+			var mockImageFetcher ImageConfigFetcher = func(string) (*containerregistryv1.ConfigFile, error) {
+				return tc.imageConfig, tc.imageErr
+			}
+
+			r.updateStartCommand(tc.app, mockImageFetcher)
+
+			testutil.AssertEqual(
+				t,
+				"status.startCommands",
+				tc.wantStartCommandStatus,
+				tc.app.Status.StartCommands,
+			)
 		})
 	}
 }


### PR DESCRIPTION
This fixes the existing start command behavior which panics.

It additionally adds the following:

* Tests for the different start command lookup scenarios.
* A way to enable/disable the behavior.

I've validated by installing in a cluster and trying with apps with the global value enabled and disabled and was able to reproduce the panic in the old code with the tests and confirm that it no longer occurs.