### PR TITLE
Allows users to disable retries across the cluster.

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -165,6 +165,9 @@ data:
     terminationGracePeriodSeconds: 120
     # When set to true, Route status will be updated with VirtualService conditions.
     routeTrackVirtualService: "false"
+    # RouteDisableRetries disables retries in the VirtualServices that route traffic to apps.
+    # By default, Kf leaves the value unset and it's inherited from Istio.
+    routeDisableRetries: "false"
 
     # TaskDefaultTimeoutMinutes sets the cluster-wide timeout for tasks.
     # If the value is null, the timeout is inherited from Tekton.
@@ -241,4 +244,5 @@ data:
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
   routeTrackVirtualService: "false"
+  routeDisableRetries: "false"
   taskDefaultTimeoutMinutes: "-1"

--- a/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
+++ b/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
@@ -46,6 +46,28 @@ kfsystem kfsystem \
 -p="[{'op': 'replace', 'path': '/spec/kf/config/buildDisableIstioSidecar', 'value': <var>true</var>}]"
 </pre>
 
+## Enable or Disable Routing Retries
+
+Allows enabling/disbaling retries in the VirtualServices that route traffic to Apps.
+Kf leaves this value unset by default and it's inherited from Istio.
+
+Istio's default retry mechanism attempts to make up for instability inerent in service meshes,
+however allowing retries requires the contents of the payload to be buffered within Envoy. This
+may fail for large payloads and the buffering will need to be disabled at the expense of some
+stability.
+
+Values for `routeDisableRetries`:
+
+* `false` Inherit Istio's retry settings. (Default)
+* `true` Set retries to 0.
+
+```sh
+kubectl patch \
+    kfsystem kfsystem \
+    --type='json' \
+    -p="[{'op':'add','path':'/spec/kf/config/routeDisableRetries','value':true}]"
+```
+
 ## Build Pod Resource Limits
 
 The default pod resource size can be increased from the default to accommodate very large builds. The units for the value are in `Mi` or `Gi`.

--- a/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
+++ b/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
@@ -51,7 +51,7 @@ kfsystem kfsystem \
 Allows enabling/disbaling retries in the VirtualServices that route traffic to Apps.
 Kf leaves this value unset by default and it's inherited from Istio.
 
-Istio's default retry mechanism attempts to make up for instability inerent in service meshes,
+Istio's default retry mechanism attempts to make up for instability inherent in service meshes,
 however allowing retries requires the contents of the payload to be buffered within Envoy. This
 may fail for large payloads and the buffering will need to be disabled at the expense of some
 stability.

--- a/operator/pkg/apis/kfsystem/kf/defaults.go
+++ b/operator/pkg/apis/kfsystem/kf/defaults.go
@@ -44,6 +44,7 @@ const (
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
+	routeDisableRetriesKey           = "routeDisableRetries"
 	taskDefaultTimeoutMinutesKey     = "taskDefaultTimeoutMinutes"
 
 	// Images used for build purposes
@@ -145,6 +146,10 @@ type DefaultsConfig struct {
 
 	// RouteTrackVirtualService when set to true, will update Route status with VirtualService conditions.
 	RouteTrackVirtualService bool `json:"routeTrackVirtualService,omitempty"`
+
+	// RouteDisableRetries disables retries in the VirtualServices that route traffic to apps.
+	// By default, Kf leaves the value unset and it's inherited from Istio.
+	RouteDisableRetries bool `json:"routeDisableRetries,omitempty"`
 
 	// TaskDefaultTimeoutMinutes sets the cluster-wide timeout for tasks.
 	// If the value is null, the timeout is inherited from Tekton.
@@ -258,6 +263,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
+		routeDisableRetriesKey:           &defaultsConfig.RouteDisableRetries,
 		taskDefaultTimeoutMinutesKey:     &defaultsConfig.TaskDefaultTimeoutMinutes,
 	}
 

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -44,6 +44,7 @@ const (
 	progressDeadlineSecondsKey       = "progressDeadlineSeconds"
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
+	routeDisableRetriesKey           = "routeDisableRetries"
 	taskDefaultTimeoutMinutesKey     = "taskDefaultTimeoutMinutes"
 
 	// Images used for build purposes
@@ -145,6 +146,10 @@ type DefaultsConfig struct {
 
 	// RouteTrackVirtualService when set to true, will update Route status with VirtualService conditions.
 	RouteTrackVirtualService bool `json:"routeTrackVirtualService,omitempty"`
+
+	// RouteDisbaleRetries disables retries in the VirtualServices that route traffic to apps.
+	// By default, Kf leaves the value unset and it's inherited from Istio.
+	RouteDisableRetries bool `json:"routeDisableRetries,omitempty"`
 
 	// TaskDefaultTimeoutMinutes sets the cluster-wide timeout for tasks.
 	// If the value is null, the timeout is inherited from Tekton.
@@ -258,6 +263,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		progressDeadlineSecondsKey:       &defaultsConfig.ProgressDeadlineSeconds,
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
+		routeDisableRetriesKey:           &defaultsConfig.RouteDisableRetries,
 		taskDefaultTimeoutMinutesKey:     &defaultsConfig.TaskDefaultTimeoutMinutes,
 	}
 

--- a/pkg/apis/kf/config/defaults_test.go
+++ b/pkg/apis/kf/config/defaults_test.go
@@ -51,6 +51,7 @@ func TestPatchConfigMap(t *testing.T) {
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,
+		routeDisableRetriesKey,
 		taskDefaultTimeoutMinutesKey,
 	}
 	_, configMap := cmtesting.ConfigMapsFromTestFile(t, DefaultsConfigTestName, allowedPredefinedKey...)

--- a/pkg/apis/kf/config/store_test.go
+++ b/pkg/apis/kf/config/store_test.go
@@ -57,6 +57,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 		progressDeadlineSecondsKey,
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,
+		routeDisableRetriesKey,
 		taskDefaultTimeoutMinutesKey,
 	}
 	_, configMap := cmtesting.ConfigMapsFromTestFile(t, DefaultsConfigName, allowedPredefinedKey...)

--- a/pkg/reconciler/route/resources/testdata/golden/testmakevirtualservice_no_retries_applies_everywhere_virtualservice.golden
+++ b/pkg/reconciler/route/resources/testdata/golden/testmakevirtualservice_no_retries_applies_everywhere_virtualservice.golden
@@ -1,0 +1,187 @@
+# Test:	TestMakeVirtualService/no_retries_applies_everywhere
+# routeBindings:
+# - destination:
+#     port: 80
+#     serviceName: app-1
+#     weight: 1
+#   source:
+#     domain: example.com
+#     hostname: some-host
+#     path: /some-path
+# - destination:
+#     port: 80
+#     serviceName: backup-app
+#     weight: 1
+#   source:
+#     domain: example.com
+#     hostname: '*'
+#     path: /some-path
+# routeServiceBindings: null
+# routes:
+# - metadata:
+#     creationTimestamp: null
+#     name: fake-route-some-host-example-co98ab99cdf188e05a65dad35fa162c013
+#     namespace: some-namespace
+#   spec:
+#     domain: example.com
+#     hostname: some-host
+#     path: /some-path
+#   status:
+#     routeService: {}
+#     virtualservice: {}
+# - metadata:
+#     creationTimestamp: null
+#     name: fake-route---example-com--some-2d87148b6c85f95a59ebbfb34341ccef
+#     namespace: some-namespace
+#   spec:
+#     domain: example.com
+#     hostname: '*'
+#     path: /some-path
+#   status:
+#     routeService: {}
+#     virtualservice: {}
+# spaceDomain:
+#   domain: example.com
+#   gatewayName: kf/some-gateway
+
+{
+    "kind": "VirtualService",
+    "apiVersion": "networking.istio.io/v1alpha3",
+    "metadata": {
+        "name": "example-com5ababd603b22780302dd8d83498e5172",
+        "namespace": "some-namespace",
+        "creationTimestamp": null,
+        "labels": {
+            "app.kubernetes.io/component": "virtualservice",
+            "app.kubernetes.io/managed-by": "kf"
+        },
+        "annotations": {
+            "kf.dev/domain": "example.com"
+        },
+        "ownerReferences": [
+            {
+                "apiVersion": "kf.dev/v1alpha1",
+                "kind": "Route",
+                "name": "fake-route---example-com--some-2d87148b6c85f95a59ebbfb34341ccef",
+                "uid": ""
+            },
+            {
+                "apiVersion": "kf.dev/v1alpha1",
+                "kind": "Route",
+                "name": "fake-route-some-host-example-co98ab99cdf188e05a65dad35fa162c013",
+                "uid": ""
+            }
+        ]
+    },
+    "spec": {
+        "hosts": [
+            "*.example.com",
+            "example.com"
+        ],
+        "gateways": [
+            "kf/some-gateway"
+        ],
+        "http": [
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        },
+                        "authority": {
+                            "exact": "some-host.example.com"
+                        },
+                        "headers": {
+                            "x-kf-app": {
+                                "exact": "app-1"
+                            }
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "app-1",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ],
+                "retries": {}
+            },
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        },
+                        "authority": {
+                            "exact": "some-host.example.com"
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "app-1",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ],
+                "retries": {}
+            },
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        },
+                        "headers": {
+                            "x-kf-app": {
+                                "exact": "backup-app"
+                            }
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "backup-app",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ],
+                "retries": {}
+            },
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "backup-app",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ],
+                "retries": {}
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds a new flag that allows disabling of retries in VirtualService routes. This may cause some applications to work better in Kf if they can't handle retries on their requrests and/or return status codes that mirror what is typically sent by HTTP routing infrastructure and cause Istio to retry.

By default, we leave this behavior off because it's recommended to use Istio's settings to hide instability in the mesh.

Ideally this setting could be done per-app, but Istio ony allows it per HTTP destination meaning routes (which can send traffic to multiple apps) don't fit cleanly.