### PR TITLE
Allow for requests with Host header to be routed by ignoring any speified port as part of the header value

### DIFF
--- a/cmd/generate-release/scripts/Dockerfile.deployer
+++ b/cmd/generate-release/scripts/Dockerfile.deployer
@@ -2,6 +2,9 @@ FROM gcr.io/google.com/cloudsdktool/cloud-sdk
 WORKDIR /kf
 COPY bin bin
 
+# Required env variables https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
+ENV USE_GKE_GCLOUD_AUTH_PLUGIN=True
+
 # Copy scripts
 COPY ./cmd/generate-release/scripts /builder
 

--- a/cmd/generate-release/scripts/install-asm.bash
+++ b/cmd/generate-release/scripts/install-asm.bash
@@ -23,9 +23,9 @@ fi
 
 # Necessary to download ASM tarball
 apt-get update -y
-apt-get install -y gnutls-bin google-cloud-sdk-kpt jq
+apt-get install -y jq
 
-curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_1.14 >asmcli
+curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_1.15 >asmcli
 chmod +x asmcli
 
 gcloud container clusters get-credentials "${CLUSTER_NAME}" \

--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -254,6 +254,7 @@ data:
   progressDeadlineSeconds: "600"
   terminationGracePeriodSeconds: "30"
   routeTrackVirtualService: "false"
+  routeHostIgnoringPort: "false"
   routeDisableRetries: "false"
   taskDefaultTimeoutMinutes: "-1"
   taskDisableVolumeMounts: "false"

--- a/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
+++ b/docs/content/en/docs/v2.11/operator/customizing/customizing-features.md
@@ -68,6 +68,28 @@ kubectl patch \
     -p="[{'op':'add','path':'/spec/kf/config/routeDisableRetries','value':true}]"
 ```
 
+## Enable or Disable Routing Hosts Ignoring Any Port Numbers
+
+Allows enabling/disabling routing hosts ignoring any specified port number.
+By default hosts are matched using the exact value specified in the route Host
+(e.g a request with a Host header value of example.com:443 does not match with preconfigured route Host example.com). By enabling,
+ports are ignored and only hosts are used (e.g example.com:443 matches example.com)
+
+Note: Feature will only work in clusters with istio 1.15+. In older versions it will function as though it where disabled.
+
+Values for `routeHostIgnoringPort`:
+
+* `false` Will match the Host header in request to the exact configured route Host. (Default)
+* `true` Will use regexp to match to the configured route Host ignoring 
+any port specified in the Host header of the request.
+
+```sh
+kubectl patch \
+    kfsystem kfsystem \
+    --type='json' \
+    -p="[{'op':'add','path':'/spec/kf/config/routeHostIgnoringPort','value':true}]"
+```
+
 ## Build Pod Resource Limits
 
 The default pod resource size can be increased from the default to accommodate very large builds. The units for the value are in `Mi` or `Gi`.

--- a/operator/pkg/apis/kfsystem/kf/defaults.go
+++ b/operator/pkg/apis/kfsystem/kf/defaults.go
@@ -46,6 +46,7 @@ const (
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
 	routeDisableRetriesKey           = "routeDisableRetries"
+	routeHostIgnoringPortKey         = "routeHostIgnoringPort"
 	taskDefaultTimeoutMinutesKey     = "taskDefaultTimeoutMinutes"
 	taskDisableVolumeMountsKey       = "taskDisableVolumeMounts"
 
@@ -157,6 +158,11 @@ type DefaultsConfig struct {
 	// RouteDisableRetries disables retries in the VirtualServices that route traffic to apps.
 	// By default, Kf leaves the value unset and it's inherited from Istio.
 	RouteDisableRetries bool `json:"routeDisableRetries,omitempty"`
+
+	// RouteHostIgnoringPort determines whether requests are routed ignoring any ports in the Host header.
+	// By default (false value), the Host header value has to match exactly the preconfigured route host.
+	// e.g By default example.com:443 does not match with a route configured with a Host of example.com.
+	RouteHostIgnoringPort bool `json:"routeHostIgnoringPort,omitempty"`
 
 	// TaskDefaultTimeoutMinutes sets the cluster-wide timeout for tasks.
 	// If the value is null, the timeout is inherited from Tekton.
@@ -277,6 +283,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
 		routeDisableRetriesKey:           &defaultsConfig.RouteDisableRetries,
+		routeHostIgnoringPortKey:         &defaultsConfig.RouteHostIgnoringPort,
 		taskDefaultTimeoutMinutesKey:     &defaultsConfig.TaskDefaultTimeoutMinutes,
 		taskDisableVolumeMountsKey:       &defaultsConfig.TaskDisableVolumeMounts,
 	}

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -46,6 +46,7 @@ const (
 	terminationGracePeriodSecondsKey = "terminationGracePeriodSeconds"
 	routeTrackVirtualServiceKey      = "routeTrackVirtualService"
 	routeDisableRetriesKey           = "routeDisableRetries"
+	routeHostIgnoringPortKey         = "routeHostIgnoringPort"
 	taskDefaultTimeoutMinutesKey     = "taskDefaultTimeoutMinutes"
 	taskDisableVolumeMountsKey       = "taskDisableVolumeMounts"
 
@@ -157,6 +158,11 @@ type DefaultsConfig struct {
 	// RouteDisbaleRetries disables retries in the VirtualServices that route traffic to apps.
 	// By default, Kf leaves the value unset and it's inherited from Istio.
 	RouteDisableRetries bool `json:"routeDisableRetries,omitempty"`
+
+	// RouteHostIgnoringPort determines whether requests are routed ignoring any ports in the Host header.
+	// By default (false value), the Host header value has to match exactly the preconfigured route host.
+	// e.g By default example.com:443 does not match with a route configured with a Host of example.com.
+	RouteHostIgnoringPort bool `json:"routeHostIgnoringPort,omitempty"`
 
 	// TaskDefaultTimeoutMinutes sets the cluster-wide timeout for tasks.
 	// If the value is null, the timeout is inherited from Tekton.
@@ -277,6 +283,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		terminationGracePeriodSecondsKey: &defaultsConfig.TerminationGracePeriodSeconds,
 		routeTrackVirtualServiceKey:      &defaultsConfig.RouteTrackVirtualService,
 		routeDisableRetriesKey:           &defaultsConfig.RouteDisableRetries,
+		routeHostIgnoringPortKey:         &defaultsConfig.RouteHostIgnoringPort,
 		taskDefaultTimeoutMinutesKey:     &defaultsConfig.TaskDefaultTimeoutMinutes,
 		taskDisableVolumeMountsKey:       &defaultsConfig.TaskDisableVolumeMounts,
 	}

--- a/pkg/apis/kf/config/defaults_test.go
+++ b/pkg/apis/kf/config/defaults_test.go
@@ -53,6 +53,7 @@ func TestPatchConfigMap(t *testing.T) {
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,
 		routeDisableRetriesKey,
+		routeHostIgnoringPortKey,
 		taskDefaultTimeoutMinutesKey,
 		taskDisableVolumeMountsKey,
 	}

--- a/pkg/apis/kf/config/store_test.go
+++ b/pkg/apis/kf/config/store_test.go
@@ -59,6 +59,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 		terminationGracePeriodSecondsKey,
 		routeTrackVirtualServiceKey,
 		routeDisableRetriesKey,
+		routeHostIgnoringPortKey,
 		taskDefaultTimeoutMinutesKey,
 		taskDisableVolumeMountsKey,
 	}

--- a/pkg/kf/commands/dependencies/dependencies.go
+++ b/pkg/kf/commands/dependencies/dependencies.go
@@ -120,7 +120,7 @@ func newDependencies() []dependency {
 			InfoURL:    "/service-mesh/docs/gke-install-overview",
 			// This version is fetched from the asmcli script. It needs to be
 			// updated by hand until we have a programtic way to fetch it.
-			ResolveVersion: staticVersionResolver("1.12.0-asm.3+config1"),
+			ResolveVersion: staticVersionResolver("1.15.3-asm.6+config2"),
 			ResolveURL: func(version string) (string, error) {
 				const URL = "https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/releases/tag/%s"
 				return fmt.Sprintf(URL, version), nil

--- a/pkg/reconciler/route/resources/testdata/golden/testmakevirtualservice_route_host_ignoring_port_using_prefix_virtualservice.golden
+++ b/pkg/reconciler/route/resources/testdata/golden/testmakevirtualservice_route_host_ignoring_port_using_prefix_virtualservice.golden
@@ -1,0 +1,155 @@
+# Test:	TestMakeVirtualService/route_host_ignoring_port_using_prefix
+# routeBindings:
+# - destination:
+#     port: 80
+#     serviceName: app-1
+#     weight: 1
+#   source:
+#     domain: example.com
+#     hostname: some-host
+#     path: /some-path
+# routeServiceBindings: null
+# routes:
+# - metadata:
+#     creationTimestamp: null
+#     name: fake-route-some-host-example-co98ab99cdf188e05a65dad35fa162c013
+#     namespace: some-namespace
+#   spec:
+#     domain: example.com
+#     hostname: some-host
+#     path: /some-path
+#   status:
+#     routeService: {}
+#     virtualservice: {}
+# - metadata:
+#     creationTimestamp: null
+#     name: fake-route---example-com--some-2d87148b6c85f95a59ebbfb34341ccef
+#     namespace: some-namespace
+#   spec:
+#     domain: example.com
+#     hostname: '*'
+#     path: /some-path
+#   status:
+#     routeService: {}
+#     virtualservice: {}
+# spaceDomain:
+#   domain: example.com
+#   gatewayName: kf/some-gateway
+
+{
+    "kind": "VirtualService",
+    "apiVersion": "networking.istio.io/v1alpha3",
+    "metadata": {
+        "name": "example-com5ababd603b22780302dd8d83498e5172",
+        "namespace": "some-namespace",
+        "creationTimestamp": null,
+        "labels": {
+            "app.kubernetes.io/component": "virtualservice",
+            "app.kubernetes.io/managed-by": "kf"
+        },
+        "annotations": {
+            "kf.dev/domain": "example.com"
+        },
+        "ownerReferences": [
+            {
+                "apiVersion": "kf.dev/v1alpha1",
+                "kind": "Route",
+                "name": "fake-route---example-com--some-2d87148b6c85f95a59ebbfb34341ccef",
+                "uid": ""
+            },
+            {
+                "apiVersion": "kf.dev/v1alpha1",
+                "kind": "Route",
+                "name": "fake-route-some-host-example-co98ab99cdf188e05a65dad35fa162c013",
+                "uid": ""
+            }
+        ]
+    },
+    "spec": {
+        "hosts": [
+            "*.example.com",
+            "example.com"
+        ],
+        "gateways": [
+            "kf/some-gateway"
+        ],
+        "http": [
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        },
+                        "authority": {
+                            "prefix": "some-host.example.com"
+                        },
+                        "headers": {
+                            "x-kf-app": {
+                                "exact": "app-1"
+                            }
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "app-1",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ]
+            },
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        },
+                        "authority": {
+                            "prefix": "some-host.example.com"
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "app-1",
+                            "port": {
+                                "number": 80
+                            }
+                        },
+                        "weight": 100
+                    }
+                ]
+            },
+            {
+                "match": [
+                    {
+                        "uri": {
+                            "regex": "^/some-path(/.*)?"
+                        }
+                    }
+                ],
+                "route": [
+                    {
+                        "destination": {
+                            "host": "null.invalid"
+                        },
+                        "weight": 100
+                    }
+                ],
+                "fault": {
+                    "abort": {
+                        "httpStatus": 404,
+                        "percentage": {
+                            "value": 100
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/pkg/reconciler/route/resources/virtual_service_test.go
+++ b/pkg/reconciler/route/resources/virtual_service_test.go
@@ -324,6 +324,29 @@ func TestMakeVirtualService(t *testing.T) {
 				RouteDisableRetries: true,
 			},
 		},
+		"route host ignoring port using prefix": {
+			Routes: []*v1alpha1.Route{
+				makeRoute("some-host", "example.com", "/some-path", "some-namespace"),
+				makeRoute("*", "example.com", "/some-path", "some-namespace"),
+			},
+			Bindings: map[string]RouteBindingSlice{
+				makeRouteSpecFieldsStr("some-host", "example.com", "/some-path"): []v1alpha1.RouteDestination{
+					makeAppDestination("app-1", 1),
+				},
+			},
+			RouteServiceBindings: map[string][]v1alpha1.RouteServiceDestination{
+				makeRouteSpecFieldsStr("some-host", "example.com", ""): {
+					makeRouteServiceDestination("some-route-svc", "http", "some-route-service.com", ""),
+				},
+			},
+			SpaceDomain: v1alpha1.SpaceDomain{
+				Domain:      "example.com",
+				GatewayName: "kf/some-gateway",
+			},
+			DefaultsConfig: kfconfig.DefaultsConfig{
+				RouteHostIgnoringPort: true,
+			},
+		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			actualVS, actualErr := MakeVirtualService(


### PR DESCRIPTION
In cf, an http request with a ```Host``` header containing a port number (e.g. example.com:443) is routed by ignoring the port number (e.g. example.com:443 matches to example.com). 

Currently if a port number is included in the ```Host``` header on an http request to kf it will not match with any virtual service.  For parity with cf, kf should ignore port numbers when matching is happening by using a prefix instead of an exact match.

For now the ability to ignore port specified in the ```Host``` header will be implemented behind the routeHostIgnoringPort 
flag.

Istio version 1.15+ is needed for the feature to function correctly