### PR TITLE
Fix SIGTERM propagation and mount cleanup using NFS

### DIFF
--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.appstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.appstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.buildstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.buildstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.commonservicebrokerstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.commonservicebrokerstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.routestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.routestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancebindingstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancebindingstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.sourcepackagestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.sourcepackagestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.spacestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.spacestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskschedulestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskschedulestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/builds/zz_generated.client.go
+++ b/pkg/kf/builds/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/configmaps/zz_generated.client.go
+++ b/pkg/kf/configmaps/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/internal/genericcli/zz_generated_options.go
+++ b/pkg/kf/internal/genericcli/zz_generated_options.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/logs/options.go
+++ b/pkg/kf/logs/options.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/networkpolicies/zz_generated.client.go
+++ b/pkg/kf/networkpolicies/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/routes/zz_generated.client.go
+++ b/pkg/kf/routes/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/secrets/zz_generated.client.go
+++ b/pkg/kf/secrets/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/service-brokers/cluster/zz_generated.client.go
+++ b/pkg/kf/service-brokers/cluster/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/service-brokers/namespaced/zz_generated.client.go
+++ b/pkg/kf/service-brokers/namespaced/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/serviceinstancebindings/zz_generated.client.go
+++ b/pkg/kf/serviceinstancebindings/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/serviceinstances/zz_generated.client.go
+++ b/pkg/kf/serviceinstances/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/sourcepackages/zz_generated.client.go
+++ b/pkg/kf/sourcepackages/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/spaces/zz_generated.client.go
+++ b/pkg/kf/spaces/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/tasks/zz_generated.client.go
+++ b/pkg/kf/tasks/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reconciler/apiservercerts/zz_generated.fakelister.apiservice_test.go
+++ b/pkg/reconciler/apiservercerts/zz_generated.fakelister.apiservice_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reconciler/apiservercerts/zz_generated.fakelister.secret_test.go
+++ b/pkg/reconciler/apiservercerts/zz_generated.fakelister.secret_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Proposed Changes

* Change entrypoint script used with NFS mounts to `exec` the user provided entrypoint so that it always runs as PID 1 which is the process that receives SIGTERM on container shutdown.
* Update fusermount in prestop hook to use `-uz` flag when unmounting container, lazy unmount allows shutdown to continue even if the filesystem is still in use. The filesystem is lazily released and kernel data structures are free'd when the last files are closed after the container stops. 

## Release Notes

`Fixed` SIGTERM does not propagate to application prior to container shutdown/restart when using NFS mounts.
