### PR TITLE
Exclude orphaned bindings and dedupe status.urls

### DIFF
--- a/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
+++ b/pkg/apis/kf/v1alpha1/app_lifecycle_test.go
@@ -841,7 +841,7 @@ func TestAppStatus_PropagateRouteStatus(t *testing.T) {
 				buildDesiredStatus(bindingA, true),
 				buildOrphanedStatus(bindingB),
 			},
-			wantURLs: []string{bindingA.Source.String(), bindingB.Source.String()},
+			wantURLs: []string{bindingA.Source.String()},
 		},
 	}
 
@@ -852,8 +852,8 @@ func TestAppStatus_PropagateRouteStatus(t *testing.T) {
 			status.PropagateRouteStatus(tc.bindings, tc.routes, tc.extraBindings)
 
 			var urls []string
-			for _, r := range status.Routes {
-				urls = append(urls, r.URL)
+			for _, b := range tc.bindings {
+				urls = append(urls, b.Source.String())
 			}
 
 			actualCond := status.GetCondition(AppConditionRouteReady)


### PR DESCRIPTION
The status.urls field is generated from the list of all routes attached to the app, even if they're no longer desired. This makes the VCAP_APPLICATION to change each time an app is stopped and then started. Consequentially, triggering a new rollout of the app that is later killed wasting resources.
## Proposed Changes
* Add deduping mechanism for status.urls when propagating Route Status. 
* Exclude orphaned routes urls from AppStatus.urls this will allow the env variable VCAP_APPLICATION to only contain  the urls of the desired routes. 
