### PR TITLE
Fix segment fault with mapfs

### DIFF
--- a/docs/content/en/docs/v2.11/examples/deploying-docker-apps-with-nfs-mapfs.md
+++ b/docs/content/en/docs/v2.11/examples/deploying-docker-apps-with-nfs-mapfs.md
@@ -34,7 +34,7 @@ First, you'll need to update your Dockerfile to add the `mapfs` binary to your a
 
 ```dockerfile
 # Get the mapfs binrary from a version of Kf.
-FROM gcr.io/kf-releases/fusesidecar:v2.11.2 as builder
+FROM gcr.io/kf-releases/fusesidecar:v2.11.14 as builder
 COPY --from=builder --chown=root:vcap /bin/mapfs /bin/mapfs
 
 # Allow users other than root to use fuse.

--- a/pkg/reconciler/build/resources/builtin_tasks.go
+++ b/pkg/reconciler/build/resources/builtin_tasks.go
@@ -156,7 +156,7 @@ chmod a+x /workspace/entrypoint.bash
 start_cmd=$(cat /tmp/result.json | jq .process_types.web)
 
 cat << EOF > /workspace/Dockerfile
-FROM gcr.io/kf-releases/fusesidecar:v2.11.2 as builder
+FROM gcr.io/kf-releases/fusesidecar:v2.11.14 as builder
 
 FROM $(inputs.params.RUN_IMAGE)
 COPY launcher /lifecycle/launcher

--- a/third_party/mapfs/src/mapfs/mapfs.go
+++ b/third_party/mapfs/src/mapfs/mapfs.go
@@ -288,6 +288,8 @@ func (fs *mapFileSystem) StatFs(name string) *fuse.StatfsOut {
 	}
 
 	stats := fs.FileSystem.StatFs(name)
-	stats.Bfree = stats.Blocks
+	if stats != nil {
+		stats.Bfree = stats.Blocks
+	}
 	return stats
 }


### PR DESCRIPTION
Fix segment fault with mapfs, fusesidecar image is released separately to gcr.io/kf-releases/fusesidecar:v2.11.14

