### PR TITLE
Fix default substitutions for post submit workflow

### DIFF
--- a/ci/cloudbuild/release-and-test.yaml
+++ b/ci/cloudbuild/release-and-test.yaml
@@ -26,7 +26,7 @@ options:
 substitutions:
   _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
   _RELEASE_BUCKET: ""
-  _EXPORT_BUCKET: "gs://kf-int-build-artifacts/test-results"
+  _EXPORT_BUCKET: ""
   _EXPORT_JOB_NAME: ""
 
 steps:


### PR DESCRIPTION
## Proposed Changes

* Post submit workflows fail due to misconfigured attempts to write results to testgrid. Testgrid results are only expected for daily runs.