### PR TITLE
Added controller metrics logging.

### DIFF
--- a/pkg/reconciler/apiservercerts/controller.go
+++ b/pkg/reconciler/apiservercerts/controller.go
@@ -20,6 +20,7 @@ import (
 	apiserviceclient "github.com/google/kf/v2/pkg/client/kube-aggregator/injection/client"
 	apiserviceinformer "github.com/google/kf/v2/pkg/client/kube-aggregator/injection/informers/apiregistration/v1/apiservice"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"github.com/google/kf/v2/pkg/system"
 	"k8s.io/client-go/tools/cache"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
@@ -42,7 +43,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		apiServiceClientSet: apiserviceclient.Get(ctx),
 	}
 
-	impl := controller.NewContext(ctx, r, controller.ControllerOptions{WorkQueueName: "APIServices", Logger: logger})
+	impl := controller.NewContext(ctx, r, controller.ControllerOptions{
+		WorkQueueName: "APIServices",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -29,6 +29,7 @@ import (
 	spaceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/space"
 	kflisters "github.com/google/kf/v2/pkg/client/kf/listers/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,7 +98,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		go adxBuildInformer.Informer().Run(ctx.Done())
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "Apps", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "Apps",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/build/controller.go
+++ b/pkg/reconciler/build/controller.go
@@ -28,6 +28,7 @@ import (
 	kflisters "github.com/google/kf/v2/pkg/client/kf/listers/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/reconciler"
 	"github.com/google/kf/v2/pkg/reconciler/build/config"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	tektonclient "github.com/tektoncd/pipeline/pkg/client/injection/client"
 	taskruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/taskrun"
 	"k8s.io/apimachinery/pkg/labels"
@@ -59,7 +60,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		tektonClient:        tektonClient.TektonV1beta1(),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "Builds", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "Builds",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up ConfigMap receivers")
 

--- a/pkg/reconciler/clusterservicebroker/controller.go
+++ b/pkg/reconciler/clusterservicebroker/controller.go
@@ -21,6 +21,7 @@ import (
 	kfclusterservicebrokerinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/clusterservicebroker"
 	kfserviceinstanceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/serviceinstance"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"k8s.io/client-go/tools/cache"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
@@ -42,7 +43,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		kfServiceInstanceLister:      serviceInstanceInformer.Lister(),
 	}
 
-	impl := controller.NewContext(ctx, r, controller.ControllerOptions{WorkQueueName: "ClusterServiceBrokers", Logger: logger})
+	impl := controller.NewContext(ctx, r, controller.ControllerOptions{
+		WorkQueueName: "ClusterServiceBrokers",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("setting up event handlers")
 	clusterServiceBrokerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/featureflag/controller.go
+++ b/pkg/reconciler/featureflag/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/kf/v2/pkg/apis/kf/config"
 	"github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"k8s.io/client-go/tools/cache"
 	namespaceinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
 	"knative.dev/pkg/configmap"
@@ -40,7 +41,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	logger.Info("Setting up event handlers")
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "FeatureFlag", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "FeatureFlag",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	// Run the reconciler every 5 minutes to update the status of feature flags (e.g., route services).
 	namespaceInformer.Informer().AddEventHandlerWithResyncPeriod(cache.FilteringResourceEventHandler{

--- a/pkg/reconciler/reconcilerutil/stats.go
+++ b/pkg/reconciler/reconcilerutil/stats.go
@@ -1,0 +1,130 @@
+package reconcilerutil
+
+import (
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/controller"
+)
+
+var (
+	reportFrequency = 30 * time.Second
+)
+
+// StructuredStatsReporter logs events
+type StructuredStatsReporter struct {
+	// Logger to write structured output to.
+	// Must be set before Report functions are called.
+	Logger *zap.SugaredLogger
+
+	// Clock is an optional clock.
+	Clock func() time.Time
+
+	// Reporting data.
+	lastReportNanos atomic.Int64
+
+	// Queue monitoring data.
+	currentQueueDepth atomic.Int64
+
+	// Reconcliation monitoring data.
+	successfulReconciliations atomic.Uint64
+	failedReconciliations     atomic.Uint64
+	unknownReconciliations    atomic.Uint64
+	reconciliationTimeMS      atomic.Int64
+}
+
+var _ controller.StatsReporter = (*StructuredStatsReporter)(nil)
+
+// now uses the system clock or the overridden clock
+func (s *StructuredStatsReporter) now() time.Time {
+	if s.Clock == nil {
+		return time.Now()
+	}
+
+	return s.Clock()
+}
+
+// ReportQueueDepth reports the queue depth metric
+func (s *StructuredStatsReporter) ReportQueueDepth(v int64) error {
+	s.currentQueueDepth.Store(v)
+
+	s.MaybeReport()
+
+	return nil
+}
+
+// ReportReconcile reports the count and latency metrics for a reconcile operation
+func (s *StructuredStatsReporter) ReportReconcile(duration time.Duration, success string, key types.NamespacedName) error {
+	s.reconciliationTimeMS.Add(duration.Milliseconds())
+
+	switch success {
+	case "true":
+		s.successfulReconciliations.Add(1)
+	case "false":
+		s.failedReconciliations.Add(1)
+	default:
+		s.unknownReconciliations.Add(1)
+	}
+
+	s.MaybeReport()
+
+	return nil
+}
+
+// MaybeReport writes a report to the logger if it hasn't been done recently.
+// Returns true if the report was triggered and the internal state was updated.
+func (s *StructuredStatsReporter) MaybeReport() bool {
+	// The StatsReporter interface doesn't provide any guarantees about how
+	// ReportXXX functions will be called, so it's safest to assume multiple
+	// threads might be calling simultaneously. Atomics are safer because
+	// they won't deadlock even if they have a small window where race conditions
+	// can happen.
+
+	// Rate limit the reporting.
+	currentTime := s.now()
+	lastReportNanos := s.lastReportNanos.Load()
+	currentNanos := currentTime.UnixNano()
+	reportWindow := time.Duration(currentNanos - lastReportNanos)
+
+	if reportWindow < reportFrequency {
+		// Last report was too recent.
+		return false
+	}
+
+	if !s.lastReportNanos.CompareAndSwap(lastReportNanos, currentNanos) {
+		// A different thread is reporting.
+		return false
+	}
+
+	currentQueueDepth := s.currentQueueDepth.Load()
+	successfulReconciliations := s.successfulReconciliations.Swap(0)
+	failedReconciliations := s.failedReconciliations.Swap(0)
+	unknownReconciliations := s.unknownReconciliations.Swap(0)
+	timeSpentReconcilingMS := s.reconciliationTimeMS.Swap(0)
+
+	totalReconciliations := successfulReconciliations + failedReconciliations + unknownReconciliations
+
+	var averageMSPerReconciliation float64
+	var reconciliationsPerSecond float64
+	if totalReconciliations > 0 {
+		averageMSPerReconciliation = float64(timeSpentReconcilingMS) / float64(totalReconciliations)
+		reconciliationsPerSecond = float64(totalReconciliations) / reportWindow.Seconds()
+	}
+
+	if logger := s.Logger; logger != nil {
+		logger.With(
+			"currentQueueDepth", currentQueueDepth,
+			"averageMSPerReconciliation", averageMSPerReconciliation,
+			"reconciliationsPerSecond", reconciliationsPerSecond,
+			"statuses", map[string]uint64{
+				"success": successfulReconciliations,
+				"failure": failedReconciliations,
+				"unknown": unknownReconciliations,
+			},
+		).Info("Controller Statistics")
+	}
+
+	return true
+}

--- a/pkg/reconciler/reconcilerutil/stats_test.go
+++ b/pkg/reconciler/reconcilerutil/stats_test.go
@@ -1,0 +1,287 @@
+package reconcilerutil
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/kf/v2/pkg/kf/testutil"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{
+		time: time.Unix(0, 0),
+	}
+}
+
+type fakeClock struct {
+	time time.Time
+}
+
+// Now returns the current internal time of the fake clock.
+func (fc *fakeClock) Now() time.Time {
+	return fc.time
+}
+
+// AdvanceReport advances to the next reporting time.
+func (fc *fakeClock) AdvanceReport() {
+	fc.time = fc.time.Add(reportFrequency)
+}
+
+func TestStructuredStatsReporter_now(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults to system clock", func(t *testing.T) {
+		s := &StructuredStatsReporter{
+			Clock: nil,
+		}
+
+		var times []time.Time
+
+		// Alternate time sources
+		for i := 0; i < 5; i++ {
+			times = append(times, time.Now())
+			time.Sleep(50 * time.Millisecond)
+
+			times = append(times, s.now())
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		// Expect time to be strictly increasing.
+		for i := 1; i < len(times); i++ {
+			if times[i-1].Compare(times[i]) >= 0 {
+				t.Fatalf(
+					"Times aren't increasing time %d (%q) was after %d (%q)",
+					i-1, times[i-1],
+					i, times[i])
+			}
+		}
+	})
+
+	t.Run("clock can be overridden", func(t *testing.T) {
+		var count int64
+		s := &StructuredStatsReporter{
+			Clock: func() time.Time {
+				count++
+				return time.Unix(count, 0)
+			},
+		}
+
+		for i := int64(1); i < 100; i++ {
+			nowUnix := s.now().Unix()
+			if nowUnix != i {
+				t.Fatalf(
+					"Expected time at step %d to be %d got %d",
+					i-1,
+					i,
+					nowUnix,
+				)
+			}
+		}
+	})
+}
+
+type bytesBufferSyncer struct {
+	bytes.Buffer
+}
+
+func (*bytesBufferSyncer) Sync() error {
+	return nil
+}
+
+func scenarioOutput(scenario func(*StructuredStatsReporter, *fakeClock)) (report string, generated bool) {
+	// Initialize
+	clock := newFakeClock()
+	buf := &bytesBufferSyncer{}
+	encoderCfg := zapcore.EncoderConfig{
+		MessageKey:     "msg",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		EncodeLevel:    zapcore.LowercaseLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
+	}
+	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderCfg), buf, zap.DebugLevel)
+	sugaredLogger := zap.New(core).WithOptions().Sugar()
+	reporter := &StructuredStatsReporter{
+		Logger: sugaredLogger,
+		Clock:  clock.Now,
+	}
+
+	// Run scenario
+	scenario(reporter, clock)
+
+	// Get output
+	clock.AdvanceReport()
+	generated = reporter.MaybeReport()
+	return string(buf.Bytes()), generated
+}
+
+func TestStructuredStatsReporter_ReportQueueDepth(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		scenario          func(*StructuredStatsReporter, *fakeClock)
+		expectLogContains string
+	}{
+		"last queue depth wins": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				reporter.ReportQueueDepth(200)
+				reporter.ReportQueueDepth(100)
+				reporter.ReportQueueDepth(50)
+			},
+			expectLogContains: `"currentQueueDepth":50`,
+		},
+		"empty queue depth is zero": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				// No reports
+			},
+			expectLogContains: `"currentQueueDepth":0`,
+		},
+		"queue depth remains after report": {
+			scenario: func(reporter *StructuredStatsReporter, clock *fakeClock) {
+				log := reporter.Logger
+				reporter.Logger = nil
+
+				reporter.ReportQueueDepth(200)
+				clock.AdvanceReport()
+				reporter.MaybeReport()
+
+				reporter.Logger = log
+			},
+			expectLogContains: `"currentQueueDepth":200`,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			output, generated := scenarioOutput(tc.scenario)
+			testutil.AssertTrue(t, "report generated", generated)
+			testutil.AssertContainsAll(t, output, []string{tc.expectLogContains})
+		})
+	}
+}
+
+func TestStructuredStatsReporter_ReportReconcile(t *testing.T) {
+	t.Parallel()
+
+	blankName := types.NamespacedName{}
+
+	cases := map[string]struct {
+		scenario        func(*StructuredStatsReporter, *fakeClock)
+		expectedOutputs []string
+	}{
+		"2 reconciliations per second": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				for i := 0; i < (int(reportFrequency)/int(time.Second))*2; i++ {
+					reporter.ReportReconcile(time.Second*5, "true", blankName)
+				}
+			},
+			expectedOutputs: []string{
+				`"reconciliationsPerSecond":2`,
+			},
+		},
+		"mean reconciliation time reported": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				reporter.ReportReconcile(time.Second*0, "true", blankName)
+				reporter.ReportReconcile(time.Second*10, "true", blankName)
+			},
+			expectedOutputs: []string{
+				`"averageMSPerReconciliation":5000`,
+			},
+		},
+		"type tallys are correct": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				for i := 0; i < 3; i++ {
+					reporter.ReportReconcile(time.Second*0, "true", blankName)
+				}
+				for i := 0; i < 4; i++ {
+					reporter.ReportReconcile(time.Second*0, "false", blankName)
+				}
+				for i := 0; i < 5; i++ {
+					reporter.ReportReconcile(time.Second*0, "x", blankName)
+				}
+			},
+			expectedOutputs: []string{
+				`"success":3`,
+				`"failure":4`,
+				`"unknown":5`,
+			},
+		},
+		"no reports": {
+			scenario: func(reporter *StructuredStatsReporter, _ *fakeClock) {
+				// No reports
+			},
+			expectedOutputs: []string{
+				`"reconciliationsPerSecond":0`,
+				`"averageMSPerReconciliation":0`,
+				`"statuses":{"failure":0,"success":0,"unknown":0}`,
+			},
+		},
+		"values reset after report": {
+			scenario: func(reporter *StructuredStatsReporter, clock *fakeClock) {
+				log := reporter.Logger
+				reporter.Logger = nil
+
+				reporter.ReportReconcile(time.Second*1, "true", blankName)
+				reporter.ReportReconcile(time.Second*1, "false", blankName)
+				reporter.ReportReconcile(time.Second*1, "x", blankName)
+
+				clock.AdvanceReport()
+				reporter.MaybeReport()
+
+				reporter.Logger = log
+			},
+			expectedOutputs: []string{
+				`"reconciliationsPerSecond":0`,
+				`"averageMSPerReconciliation":0`,
+				`"statuses":{"failure":0,"success":0,"unknown":0}`,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			output, generated := scenarioOutput(tc.scenario)
+			testutil.AssertTrue(t, "report generated", generated)
+			testutil.AssertContainsAll(t, output, tc.expectedOutputs)
+		})
+	}
+}
+
+func TestStructuredStatsReporter_MaybeReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil logger still succeeds", func(t *testing.T) {
+		reporter := &StructuredStatsReporter{
+			Logger: nil,
+		}
+
+		resp := reporter.MaybeReport()
+		testutil.AssertTrue(t, "response", resp)
+	})
+
+	t.Run("values reset after report", func(t *testing.T) {
+		out, generated := scenarioOutput(func(reporter *StructuredStatsReporter, clock *fakeClock) {
+			tmpLogger := reporter.Logger
+			reporter.Logger = nil
+
+			reporter.ReportQueueDepth(100)
+			clock.AdvanceReport()
+			reporter.MaybeReport()
+
+			reporter.Logger = tmpLogger
+		})
+		testutil.AssertTrue(t, "report generated", generated)
+		testutil.AssertContainsAll(t, out, []string{
+			`"currentQueueDepth":100`,
+			`"reconciliationsPerSecond":0`,
+			`"averageMSPerReconciliation":0`,
+			`"statuses":{"failure":0,"success":0,"unknown":0}`,
+		})
+	})
+
+}

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -28,6 +28,7 @@ import (
 	networkingclient "github.com/google/kf/v2/pkg/client/networking/injection/client"
 	virtualserviceinformer "github.com/google/kf/v2/pkg/client/networking/injection/informers/networking/v1alpha3/virtualservice"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"github.com/google/kf/v2/pkg/reconciler/route/resources"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
@@ -63,7 +64,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		kfConfigStore:                kfConfigStore,
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "Routes", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "Routes",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/servicebroker/controller.go
+++ b/pkg/reconciler/servicebroker/controller.go
@@ -21,6 +21,7 @@ import (
 	kfservicebrokerinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/servicebroker"
 	kfserviceinstanceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/serviceinstance"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"k8s.io/client-go/tools/cache"
 	secretinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/secret"
 	"knative.dev/pkg/configmap"
@@ -42,7 +43,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		kfServiceInstanceLister: serviceInstanceInformer.Lister(),
 	}
 
-	impl := controller.NewContext(ctx, r, controller.ControllerOptions{WorkQueueName: "ServiceBrokers", Logger: logger})
+	impl := controller.NewContext(ctx, r, controller.ControllerOptions{
+		WorkQueueName: "ServiceBrokers",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("setting up event handlers")
 	serviceBrokerInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/serviceinstance/controller.go
+++ b/pkg/reconciler/serviceinstance/controller.go
@@ -23,6 +23,7 @@ import (
 	kfserviceinstanceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/serviceinstance"
 	spaceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/space"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"k8s.io/client-go/tools/cache"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
 	persistentvolumeinformer "knative.dev/pkg/client/injection/kube/informers/core/v1/persistentvolume"
@@ -59,7 +60,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		k8sServiceLister:   k8sServiceInformer.Lister(),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "ServiceInstances", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "ServiceInstances",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/serviceinstancebinding/controller.go
+++ b/pkg/reconciler/serviceinstancebinding/controller.go
@@ -25,6 +25,7 @@ import (
 	spaceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/space"
 	kflisters "github.com/google/kf/v2/pkg/client/kf/listers/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -52,7 +53,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		appLister:          appInformer.Lister(),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "ServiceInstanceBindings", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "ServiceInstanceBindings",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 

--- a/pkg/reconciler/space/controller.go
+++ b/pkg/reconciler/space/controller.go
@@ -102,7 +102,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		iamClientSet:             dynamicClient.Resource(*gsaPoliciesGVR),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "Spaces", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "Spaces",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up event handlers")
 	// Watch for changes in sub-resources so we can sync accordingly

--- a/pkg/reconciler/task/controller.go
+++ b/pkg/reconciler/task/controller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/kf/v2/pkg/apis/kf/config"
 	kfv1alpha1 "github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
 	appinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/app"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 
 	spaceinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/space"
 	taskinformer "github.com/google/kf/v2/pkg/client/kf/injection/informers/kf/v1alpha1/task"
@@ -55,7 +56,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		tektonClient:  tektonClient.TektonV1beta1(),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "tasks", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "tasks",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	logger.Info("Setting up ConfigMap receivers")
 	configsToResync := []interface{}{

--- a/pkg/reconciler/taskschedule/controller.go
+++ b/pkg/reconciler/taskschedule/controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/google/kf/v2/pkg/reconciler"
+	"github.com/google/kf/v2/pkg/reconciler/reconcilerutil"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 
@@ -41,7 +42,11 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		taskLister:         taskInformer.Lister(),
 	}
 
-	impl := controller.NewContext(ctx, c, controller.ControllerOptions{WorkQueueName: "taskschedules", Logger: logger})
+	impl := controller.NewContext(ctx, c, controller.ControllerOptions{
+		WorkQueueName: "taskschedules",
+		Logger:        logger,
+		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+	})
 
 	// Enqueue all TaskSchedules every 10 seconds to check cron intervals and
 	// spawn Tasks


### PR DESCRIPTION
This PR adds controller metrics logging to all standard Kf controllers. Logs are written to the same loggers the controllers use periodically and hook into the queue system to report on current depth, frequency, etc.