### PR TITLE
Log waits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+zz_generated* linguist-generated

--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -262,6 +262,9 @@ func (p *pusher) Push(ctx context.Context, appName string, opts ...PushOption) e
 func (p *pusher) CreatePlaceholderApp(ctx context.Context, appName string, opts ...PushOption) (*v1alpha1.App, error) {
 	cfg := PushOptionDefaults().Extend(opts).toConfig()
 	logger := logging.FromContext(ctx)
+	if out := cfg.Output; out != nil {
+		ctx = WithConditionReporter(ctx, utils.StatusUpdateConditionReporter(out))
+	}
 
 	logger.Infof("Checking for existing App named %q...", appName)
 	app, err := p.appsClient.Get(ctx, cfg.Space, appName)

--- a/pkg/kf/builds/zz_generated.client.go
+++ b/pkg/kf/builds/zz_generated.client.go
@@ -217,7 +217,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.Build, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.Build, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -230,7 +247,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.Builds(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -245,7 +262,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.Build, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.Build, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -260,7 +277,7 @@ func ConditionDeleted(_ *v1alpha1.Build, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.Build, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.Build, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}

--- a/pkg/kf/commands/apps/start.go
+++ b/pkg/kf/commands/apps/start.go
@@ -65,7 +65,11 @@ func NewStartCommand(
 
 			action := fmt.Sprintf("Starting app %q in space %q", appName, p.Space)
 			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
-				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
+				ctx := apps.WithConditionReporter(
+					context.Background(),
+					utils.StatusUpdateConditionReporter(cmd.OutOrStdout()),
+				)
+				_, err := client.WaitForConditionKnativeServiceReadyTrue(ctx, p.Space, appName, 1*time.Second)
 				return err
 			})
 		},

--- a/pkg/kf/commands/apps/stop.go
+++ b/pkg/kf/commands/apps/stop.go
@@ -66,7 +66,11 @@ func NewStopCommand(
 
 			action := fmt.Sprintf("Stopping App %q in Space %q", appName, p.Space)
 			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
-				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
+				ctx := apps.WithConditionReporter(
+					context.Background(),
+					utils.StatusUpdateConditionReporter(cmd.OutOrStdout()),
+				)
+				_, err := client.WaitForConditionKnativeServiceReadyTrue(ctx, p.Space, appName, 1*time.Second)
 				return err
 			})
 		},

--- a/pkg/kf/configmaps/zz_generated.client.go
+++ b/pkg/kf/configmaps/zz_generated.client.go
@@ -217,7 +217,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1.ConfigMap, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1.ConfigMap, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -230,7 +247,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -245,7 +262,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1.ConfigMap, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1.ConfigMap, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -260,7 +277,7 @@ func ConditionDeleted(_ *v1.ConfigMap, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1.ConfigMap, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1.ConfigMap, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}

--- a/pkg/kf/internal/tools/clientgen/genclient.go
+++ b/pkg/kf/internal/tools/clientgen/genclient.go
@@ -53,7 +53,6 @@ func main() {
 
 	formatted, err := format.Source(buf)
 	if err != nil {
-		log.Println(string(buf))
 		log.Fatal(err)
 		return
 	}

--- a/pkg/kf/internal/tools/clientgen/genclient.go
+++ b/pkg/kf/internal/tools/clientgen/genclient.go
@@ -53,6 +53,7 @@ func main() {
 
 	formatted, err := format.Source(buf)
 	if err != nil {
+		log.Println(string(buf))
 		log.Fatal(err)
 		return
 	}

--- a/pkg/kf/internal/tools/clientgen/gentest/client_test.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/client_test.go
@@ -191,7 +191,7 @@ func TestConditionDeleted(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			actualDone, actualErr := ConditionDeleted(nil, tc.apiErr)
+			actualDone, actualErr := ConditionDeleted(context.TODO(), nil, tc.apiErr)
 
 			testutil.AssertErrorsEqual(t, tc.wantErr, actualErr)
 			testutil.AssertEqual(t, "done", tc.wantDone, actualDone)
@@ -274,7 +274,7 @@ func TestWrapPredicate(t *testing.T) {
 				called = true
 				return tc.predicateResponse
 			})
-			actualDone, actualErr := wrapped(&v1.Pod{
+			actualDone, actualErr := wrapped(context.TODO(), &v1.Pod{
 				Status: v1.PodStatus{
 					Conditions: tc.conditions,
 				},
@@ -348,7 +348,7 @@ func TestCheckConditionTrue(t *testing.T) {
 				},
 			}
 
-			actualDone, actualErr := checkConditionTrue(pod, tc.err, ConditionReady)
+			actualDone, actualErr := checkConditionTrue(context.TODO(), pod, tc.err, ConditionReady)
 
 			testutil.AssertErrorsEqual(t, tc.wantErr, actualErr)
 			testutil.AssertEqual(t, "done", tc.wantDone, actualDone)

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -249,7 +249,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1.Pod, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1.Pod, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -262,7 +279,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.Pods(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -277,7 +294,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1.Pod, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1.Pod, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -292,7 +309,7 @@ func ConditionDeleted(_ *v1.Pod, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1.Pod, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1.Pod, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -314,13 +331,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1.Pod, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1.Pod, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -331,6 +354,7 @@ func checkConditionTrue(obj *v1.Pod, err error, condition apis.ConditionType) (b
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -341,13 +365,15 @@ func checkConditionTrue(obj *v1.Pod, err error, condition apis.ConditionType) (b
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready  Ready} to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1.Pod, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1.Pod, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.
@@ -357,8 +383,8 @@ func (core *coreClient) WaitForConditionReadyTrue(ctx context.Context, namespace
 
 // ConditionInitializedTrue is a ConditionFuncE that waits for Condition{Initialized v1.PodInitialized } to
 // become true and fails with an error if the condition becomes false.
-func ConditionInitializedTrue(obj *v1.Pod, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionInitialized)
+func ConditionInitializedTrue(ctx context.Context, obj *v1.Pod, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionInitialized)
 }
 
 // WaitForConditionInitializedTrue is a utility function that combines waitForE with ConditionInitializedTrue.

--- a/pkg/kf/internal/utils/cli/colors.go
+++ b/pkg/kf/internal/utils/cli/colors.go
@@ -14,7 +14,7 @@ var (
 	// Heading is the color for headings.
 	Heading = color.New(color.FgWhite, color.Bold)
 	// Muted is the color for headings you want muted.
-	Muted = color.New(color.FgWhite, color.Bold)
+	Muted = color.New(color.FgBlue)
 	// TipColor is the color to show for tips.
 	TipColor = color.New(color.FgGreen, color.Bold)
 )

--- a/pkg/kf/internal/utils/cli/utils.go
+++ b/pkg/kf/internal/utils/cli/utils.go
@@ -264,3 +264,18 @@ func ExperimentalCommandGroup(name string, cmds ...*cobra.Command) group.Command
 		Commands: cmds,
 	}
 }
+
+// StatusUpdateConditionReporter creates a function that prints deltas
+// between two status updates.
+func StatusUpdateConditionReporter(w io.Writer) func(message string) {
+	var lastMessage string
+
+	prefix := Muted.Sprint("[status update]")
+
+	return func(msg string) {
+		if msg != lastMessage {
+			fmt.Fprintf(w, "%s %s\n", prefix, msg)
+			lastMessage = msg
+		}
+	}
+}

--- a/pkg/kf/internal/utils/cli/utils_test.go
+++ b/pkg/kf/internal/utils/cli/utils_test.go
@@ -271,3 +271,14 @@ func TestAddPreviewWarning(t *testing.T) {
 		})
 	}
 }
+
+func ExampleStatusUpdateConditionReporter() {
+	reporter := StatusUpdateConditionReporter(os.Stdout)
+
+	reporter("Foo")
+	reporter("Bar")
+	reporter("Bar")
+
+	// Expected: [status update] Foo
+	// [status update] Bar
+}

--- a/pkg/kf/networkpolicies/zz_generated.client.go
+++ b/pkg/kf/networkpolicies/zz_generated.client.go
@@ -217,7 +217,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1.NetworkPolicy, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1.NetworkPolicy, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -230,7 +247,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -245,7 +262,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1.NetworkPolicy, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1.NetworkPolicy, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -260,7 +277,7 @@ func ConditionDeleted(_ *v1.NetworkPolicy, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1.NetworkPolicy, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1.NetworkPolicy, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}

--- a/pkg/kf/routes/zz_generated.client.go
+++ b/pkg/kf/routes/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.Route, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.Route, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.Routes(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.Route, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.Route, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.Route, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.Route, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.Route, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.Route, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.Route, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.Route, err error, condition apis.Condition
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.Route, err error, condition apis.Condition
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.RouteConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.Route, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.Route, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.

--- a/pkg/kf/service-brokers/cluster/zz_generated.client.go
+++ b/pkg/kf/service-brokers/cluster/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, name string, interval time.
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.ClusterServiceBroker, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.ClusterServiceBroker, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, name string, interval time
 
 	for {
 		instance, err = core.kclient.ClusterServiceBrokers().Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, name string, interval time
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.ClusterServiceBroker, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.ClusterServiceBroker, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.ClusterServiceBroker, apiErr error) (bool, err
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.ClusterServiceBroker, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.ClusterServiceBroker, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, name string, interv
 	return core.waitForE(ctx, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.ClusterServiceBroker, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.ClusterServiceBroker, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.ClusterServiceBroker, err error, condition
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.ClusterServiceBroker, err error, condition
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.CommonServiceBrokerConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.ClusterServiceBroker, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.ClusterServiceBroker, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.

--- a/pkg/kf/service-brokers/namespaced/zz_generated.client.go
+++ b/pkg/kf/service-brokers/namespaced/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.ServiceBroker, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.ServiceBroker, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.ServiceBrokers(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.ServiceBroker, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.ServiceBroker, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.ServiceBroker, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.ServiceBroker, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.ServiceBroker, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.ServiceBroker, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.ServiceBroker, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.ServiceBroker, err error, condition apis.C
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.ServiceBroker, err error, condition apis.C
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.CommonServiceBrokerConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.ServiceBroker, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.ServiceBroker, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.

--- a/pkg/kf/serviceinstancebindings/zz_generated.client.go
+++ b/pkg/kf/serviceinstancebindings/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.ServiceInstanceBinding, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.ServiceInstanceBinding, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.ServiceInstanceBindings(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.ServiceInstanceBinding, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.ServiceInstanceBinding, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.ServiceInstanceBinding, apiErr error) (bool, e
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.ServiceInstanceBinding, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.ServiceInstanceBinding, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.ServiceInstanceBinding, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.ServiceInstanceBinding, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.ServiceInstanceBinding, err error, conditi
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.ServiceInstanceBinding, err error, conditi
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.ServiceInstanceBindingConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.ServiceInstanceBinding, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.ServiceInstanceBinding, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.

--- a/pkg/kf/serviceinstances/zz_generated.client.go
+++ b/pkg/kf/serviceinstances/zz_generated.client.go
@@ -249,7 +249,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.ServiceInstance, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.ServiceInstance, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -262,7 +279,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.ServiceInstances(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -277,7 +294,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.ServiceInstance, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.ServiceInstance, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -292,7 +309,7 @@ func ConditionDeleted(_ *v1alpha1.ServiceInstance, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.ServiceInstance, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.ServiceInstance, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -314,13 +331,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.ServiceInstance, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.ServiceInstance, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -331,6 +354,7 @@ func checkConditionTrue(obj *v1alpha1.ServiceInstance, err error, condition apis
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -341,13 +365,15 @@ func checkConditionTrue(obj *v1alpha1.ServiceInstance, err error, condition apis
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.ServiceInstanceConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.ServiceInstance, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.ServiceInstance, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.
@@ -357,8 +383,8 @@ func (core *coreClient) WaitForConditionReadyTrue(ctx context.Context, namespace
 
 // ConditionParamsSecretReadyTrue is a ConditionFuncE that waits for Condition{ParamsSecretReady v1alpha1.ServiceInstanceConditionParamsSecretReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionParamsSecretReadyTrue(obj *v1alpha1.ServiceInstance, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionParamsSecretReady)
+func ConditionParamsSecretReadyTrue(ctx context.Context, obj *v1alpha1.ServiceInstance, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionParamsSecretReady)
 }
 
 // WaitForConditionParamsSecretReadyTrue is a utility function that combines waitForE with ConditionParamsSecretReadyTrue.

--- a/pkg/kf/sourcepackages/zz_generated.client.go
+++ b/pkg/kf/sourcepackages/zz_generated.client.go
@@ -249,7 +249,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.SourcePackage, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.SourcePackage, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -262,7 +279,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.SourcePackages(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -277,7 +294,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.SourcePackage, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.SourcePackage, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -292,7 +309,7 @@ func ConditionDeleted(_ *v1alpha1.SourcePackage, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.SourcePackage, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.SourcePackage, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -314,13 +331,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.SourcePackage, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.SourcePackage, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -331,6 +354,7 @@ func checkConditionTrue(obj *v1alpha1.SourcePackage, err error, condition apis.C
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -341,13 +365,15 @@ func checkConditionTrue(obj *v1alpha1.SourcePackage, err error, condition apis.C
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.SourcePackageConditionSucceeded } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.SourcePackage, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.SourcePackage, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.
@@ -357,8 +383,8 @@ func (core *coreClient) WaitForConditionReadyTrue(ctx context.Context, namespace
 
 // ConditionUploadReadyTrue is a ConditionFuncE that waits for Condition{UploadReady v1alpha1.SourcePackageConditionUploadReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionUploadReadyTrue(obj *v1alpha1.SourcePackage, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionUploadReady)
+func ConditionUploadReadyTrue(ctx context.Context, obj *v1alpha1.SourcePackage, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionUploadReady)
 }
 
 // WaitForConditionUploadReadyTrue is a utility function that combines waitForE with ConditionUploadReadyTrue.

--- a/pkg/kf/spaces/zz_generated.client.go
+++ b/pkg/kf/spaces/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, name string, interval time.
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.Space, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.Space, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, name string, interval time
 
 	for {
 		instance, err = core.kclient.Spaces().Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, name string, interval time
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.Space, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.Space, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.Space, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.Space, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.Space, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, name string, interv
 	return core.waitForE(ctx, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.Space, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.Space, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.Space, err error, condition apis.Condition
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.Space, err error, condition apis.Condition
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.SpaceConditionReady } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.Space, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.Space, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.

--- a/pkg/kf/tasks/zz_generated.client.go
+++ b/pkg/kf/tasks/zz_generated.client.go
@@ -247,7 +247,24 @@ func (core *coreClient) WaitFor(ctx context.Context, namespace string, name stri
 //
 // This function MAY retrieve a nil instance and an apiErr. It's up to the
 // function to decide how to handle the apiErr.
-type ConditionFuncE func(instance *v1alpha1.Task, apiErr error) (done bool, err error)
+type ConditionFuncE func(ctx context.Context, instance *v1alpha1.Task, apiErr error) (done bool, err error)
+
+// ConditionReporter reports on changes to conditions while waiting.
+type ConditionReporter func(message string)
+type conditionReporterKey struct{}
+
+// WithConditionReporter adds a callback to condition waits.
+func WithConditionReporter(ctx context.Context, reporter ConditionReporter) context.Context {
+	return context.WithValue(ctx, conditionReporterKey{}, reporter)
+}
+
+func maybeGetConditionReporter(ctx context.Context) ConditionReporter {
+	if v := ctx.Value(conditionReporterKey{}); v != nil {
+		return v.(ConditionReporter)
+	}
+
+	return nil
+}
 
 // waitForE polls for the given object every interval until the condition
 // function becomes done or the timeout expires. The first poll occurs
@@ -260,7 +277,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 	for {
 		instance, err = core.kclient.Tasks(namespace).Get(ctx, name, metav1.GetOptions{})
-		if done, err = condition(instance, err); done {
+		if done, err = condition(ctx, instance, err); done {
 			return
 		}
 
@@ -275,7 +292,7 @@ func (core *coreClient) waitForE(ctx context.Context, namespace string, name str
 
 // ConditionDeleted is a ConditionFuncE that succeeds if the error returned by
 // the cluster was a not found error.
-func ConditionDeleted(_ *v1alpha1.Task, apiErr error) (bool, error) {
+func ConditionDeleted(ctx context.Context, _ *v1alpha1.Task, apiErr error) (bool, error) {
 	if apiErr != nil {
 		if apierrors.IsNotFound(apiErr) {
 			apiErr = nil
@@ -290,7 +307,7 @@ func ConditionDeleted(_ *v1alpha1.Task, apiErr error) (bool, error) {
 // wrapPredicate converts a predicate to a ConditionFuncE that fails if the
 // error is not nil or if the Status has a False condition.
 func wrapPredicate(condition Predicate) ConditionFuncE {
-	return func(obj *v1alpha1.Task, err error) (bool, error) {
+	return func(ctx context.Context, obj *v1alpha1.Task, err error) (bool, error) {
 		if err != nil {
 			return true, err
 		}
@@ -312,13 +329,19 @@ func (core *coreClient) WaitForDeletion(ctx context.Context, namespace string, n
 	return core.waitForE(ctx, namespace, name, interval, ConditionDeleted)
 }
 
-func checkConditionTrue(obj *v1alpha1.Task, err error, condition apis.ConditionType) (bool, error) {
+func checkConditionTrue(ctx context.Context, obj *v1alpha1.Task, err error, condition apis.ConditionType) (bool, error) {
+	conditionReporter := func(_ string) {}
+	if reporter := maybeGetConditionReporter(ctx); reporter != nil {
+		conditionReporter = reporter
+	}
+
 	if err != nil {
 		return true, err
 	}
 
 	// don't propagate old statuses
 	if !ObservedGenerationMatchesGeneration(obj) {
+		conditionReporter("Waiting for object to be reconciled (generation out of sync)")
 		return false, nil
 	}
 
@@ -329,6 +352,7 @@ func checkConditionTrue(obj *v1alpha1.Task, err error, condition apis.ConditionT
 				return true, nil
 
 			case cond.IsUnknown():
+				conditionReporter(fmt.Sprintf("Last Transition Time: %s Reason: %q Message: %s", cond.LastTransitionTime.Inner, cond.Reason, cond.Message))
 				return false, nil
 
 			default:
@@ -339,13 +363,15 @@ func checkConditionTrue(obj *v1alpha1.Task, err error, condition apis.ConditionT
 		}
 	}
 
+	conditionReporter(fmt.Sprintf("Condition %q not found", condition))
+
 	return false, nil
 }
 
 // ConditionReadyTrue is a ConditionFuncE that waits for Condition{Ready v1alpha1.TaskConditionSucceeded } to
 // become true and fails with an error if the condition becomes false.
-func ConditionReadyTrue(obj *v1alpha1.Task, err error) (bool, error) {
-	return checkConditionTrue(obj, err, ConditionReady)
+func ConditionReadyTrue(ctx context.Context, obj *v1alpha1.Task, err error) (bool, error) {
+	return checkConditionTrue(ctx, obj, err, ConditionReady)
 }
 
 // WaitForConditionReadyTrue is a utility function that combines waitForE with ConditionReadyTrue.


### PR DESCRIPTION
Add logging for waits in start/stop and support in all clients.

Example of output with this feature:

```
$ kf stop echo
Stopping App "echo" in Space "joseph"...
[status update] Waiting for object to be reconciled (generation out of sync)
[status update] Last Transition Time: 0001-01-01 00:00:00 +0000 UTC Reason: "GenerationOutOfDate" Message: waiting for deployment spec update to be observed
Success

$ kf start echo
Starting app "echo" in space "joseph"...
[status update] Waiting for object to be reconciled (generation out of sync)
[status update] Last Transition Time: 0001-01-01 00:00:00 +0000 UTC Reason: "InitializingPods" Message: waiting for deployment "echo" rollout to finish: 0 of 1 updated replicas are available
Success
```