### PR TITLE
Update e2e test result naming scheme for better testgrid compatibility

### DIFF
--- a/ci/cloudbuild/release-and-test.yaml
+++ b/ci/cloudbuild/release-and-test.yaml
@@ -24,7 +24,7 @@ options:
   machineType: "N1_HIGHCPU_8"
 
 substitutions:
-  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
+  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:417.0.1-alpine"
   _RELEASE_BUCKET: ""
   _EXPORT_BUCKET: ""
   _EXPORT_JOB_NAME: ""

--- a/ci/cloudbuild/test.yaml
+++ b/ci/cloudbuild/test.yaml
@@ -102,7 +102,7 @@ substitutions:
   _SELF_SIGNED_CERTS_BROKER_URL: ''
 
   _KO_IMAGE: 'gcr.io/kf-releases/ko:latest'
-  _CLOUDSDK_IMAGE: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
+  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:417.0.1-alpine"
   _GOLANG_IMAGE: 'golang:1.20'
 
 steps:

--- a/hack/prow/e2e-test.sh
+++ b/hack/prow/e2e-test.sh
@@ -37,12 +37,11 @@ _EXPORT_REPO="${EXPORT_REPO:-google/kf}"
 
 # Create Kf release
 git_sha=${COMMIT_SHA:-$(git rev-parse HEAD)}
-build_id=${BUILD_ID:-$(git rev-parse --short $git_sha)}
-release_id="$(date +%s)-$build_id"
+release_id="$(date +%s)-$(git rev-parse --short $git_sha)"
 
-# Determine the path to export results to and store the latest build ID
-export_path=gs://${_EXPORT_BUCKET}/logs/${_EXPORT_JOB_NAME}/$build_id
-[ ! -z "${_EXPORT_BUCKET}" ] && echo $build_id | gsutil cp - gs://${_EXPORT_BUCKET}/logs/${_EXPORT_JOB_NAME}/latest-build.txt
+# Determine the path to export results to and store the latest release ID
+export_path=gs://${_EXPORT_BUCKET}/logs/${_EXPORT_JOB_NAME}/$release_id
+[ ! -z "${_EXPORT_BUCKET}" ] && echo $release_id | gsutil cp - gs://${_EXPORT_BUCKET}/logs/${_EXPORT_JOB_NAME}/latest-build.txt
 
 # Write 'started.json' to report start of job to testgrid
 [ ! -z "${_EXPORT_BUCKET}" ] && jq -n \
@@ -67,6 +66,7 @@ function finish {
               --argjson metadata "$( \
                   jq -n \
                       --arg "Commit" $git_sha \
+                      --arg "Build" "$BUILD_ID" \
                       '$ARGS.named' \
               )" \
               '$ARGS.named' | gsutil cp - ${export_path}/finished.json


### PR DESCRIPTION
## Proposed Changes

* Prefix e2e test run IDs with the date
* Include cloudbuild ID in metadata for testgrid to ensure results can be linked to a specific cloudbuild execution now that the naming scheme does not reflect the Cloudbuild run.

## Description

Prefixing E2E test run IDs with the date improves testgrid compatibility. Testgrid assumes new runs will have lexographically greater IDs. Improving run ordering ensures that testgrid correctly detects new results. 