### PR TITLE
Unpin GcloudSDK version previously set to 417.0.1 to work around artifact registry bug

### DIFF
--- a/ci/cloudbuild/test.yaml
+++ b/ci/cloudbuild/test.yaml
@@ -102,7 +102,7 @@ substitutions:
   _SELF_SIGNED_CERTS_BROKER_URL: ''
 
   _KO_IMAGE: 'gcr.io/kf-releases/ko:latest'
-  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:417.0.1-alpine"
+  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
   _GOLANG_IMAGE: 'golang:1.20'
 
 steps:


### PR DESCRIPTION
## Proposed Changes

* Unpins the Gcloud SDK version used for CI/CD test runs
