### PR TITLE
Add default-enabled async_if_stopped cli flag

### DIFF
--- a/pkg/kf/commands/apps/scale.go
+++ b/pkg/kf/commands/apps/scale.go
@@ -34,7 +34,7 @@ func NewScaleCommand(
 	client apps.Client,
 ) *cobra.Command {
 	var (
-		async utils.AsyncFlags
+		async utils.AsyncIfStoppedFlags
 
 		instances int32
 	)
@@ -106,12 +106,14 @@ func NewScaleCommand(
 				return nil
 			}
 
-			if _, err := client.Transform(cmd.Context(), p.Space, appName, mutator); err != nil {
+			app, err := client.Transform(cmd.Context(), p.Space, appName, mutator)
+			if err != nil {
 				return fmt.Errorf("failed to scale App: %s", err)
 			}
 
+			stopped := app != nil && app.Spec.Instances.Stopped
 			action := fmt.Sprintf("Scaling App %q in Space %q", appName, p.Space)
-			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+			return async.AwaitAndLog(stopped, cmd.OutOrStdout(), action, func() error {
 				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
 				return err
 			})

--- a/pkg/kf/commands/apps/scale_test.go
+++ b/pkg/kf/commands/apps/scale_test.go
@@ -65,6 +65,17 @@ func TestNewScaleCommand(t *testing.T) {
 				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
+		"call does not wait when app is stopped": {
+			Args:  []string{"my-app", "--instances=3"},
+			Space: "some-namespace",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&v1alpha1.App{
+					Spec: v1alpha1.AppSpec{
+						Instances: v1alpha1.AppSpecInstances{Stopped: true},
+					},
+				}, nil)
+			},
+		},
 		"no app name": {
 			Space:       "default",
 			Args:        []string{},

--- a/pkg/kf/commands/apps/set_env_test.go
+++ b/pkg/kf/commands/apps/set_env_test.go
@@ -86,6 +86,17 @@ func TestSetEnvCommand(t *testing.T) {
 				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			},
 		},
+		"call does not wait if app is stopped": {
+			Args:  []string{"app-name", "NAME", "VALUE"},
+			Space: "some-namespace",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&v1alpha1.App{
+					Spec: v1alpha1.AppSpec{
+						Instances: v1alpha1.AppSpecInstances{Stopped: true},
+					},
+				}, nil)
+			},
+		},
 	} {
 		t.Run(tn, func(t *testing.T) {
 			ctrl := gomock.NewController(t)

--- a/pkg/kf/commands/apps/unset_env.go
+++ b/pkg/kf/commands/apps/unset_env.go
@@ -29,7 +29,7 @@ import (
 
 // NewUnsetEnvCommand creates a SetEnv command.
 func NewUnsetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
-	var async utils.AsyncFlags
+	var async utils.AsyncIfStoppedFlags
 
 	cmd := &cobra.Command{
 		Use:   "unset-env APP_NAME ENV_VAR_NAME",
@@ -54,7 +54,7 @@ func NewUnsetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
 			appName := args[0]
 			name := args[1]
 
-			_, err := client.Transform(cmd.Context(), p.Space, appName, func(app *v1alpha1.App) error {
+			app, err := client.Transform(cmd.Context(), p.Space, appName, func(app *v1alpha1.App) error {
 				kfapp := (*apps.KfApp)(app)
 				kfapp.DeleteEnvVars([]string{name})
 
@@ -65,8 +65,9 @@ func NewUnsetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
 				return fmt.Errorf("failed to unset environment variable on App: %s", err)
 			}
 
+			stopped := app != nil && app.Spec.Instances.Stopped
 			action := fmt.Sprintf("Unsetting environment variable on App %q in Space %q", appName, p.Space)
-			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+			return async.AwaitAndLog(stopped, cmd.OutOrStdout(), action, func() error {
 				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
 				return err
 			})

--- a/pkg/kf/commands/apps/unset_env_test.go
+++ b/pkg/kf/commands/apps/unset_env_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	v1alpha1 "github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
 	"github.com/google/kf/v2/pkg/internal/envutil"
 	"github.com/google/kf/v2/pkg/kf/apps"
 	"github.com/google/kf/v2/pkg/kf/apps/fake"
@@ -86,6 +87,17 @@ func TestUnsetEnvCommand(t *testing.T) {
 			Space: "some-namespace",
 			Setup: func(t *testing.T, fake *fake.FakeClient) {
 				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
+			},
+		},
+		"call does not wait when app is stopped": {
+			Args:  []string{"app-name", "NAME"},
+			Space: "some-namespace",
+			Setup: func(t *testing.T, fake *fake.FakeClient) {
+				fake.EXPECT().Transform(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&v1alpha1.App{
+					Spec: v1alpha1.AppSpec{
+						Instances: v1alpha1.AppSpecInstances{Stopped: true},
+					},
+				}, nil)
 			},
 		},
 	} {

--- a/pkg/kf/commands/autoscaling/delete_autoscaling_rules.go
+++ b/pkg/kf/commands/autoscaling/delete_autoscaling_rules.go
@@ -32,7 +32,7 @@ func NewDeleteAutoscalingRules(
 	p *config.KfParams,
 	client apps.Client,
 ) *cobra.Command {
-	var async utils.AsyncFlags
+	var async utils.AsyncIfStoppedFlags
 
 	cmd := &cobra.Command{
 		Use:               "delete-autoscaling-rules APP_NAME",
@@ -53,12 +53,14 @@ func NewDeleteAutoscalingRules(
 				return nil
 			}
 
-			if _, err := client.Transform(cmd.Context(), p.Space, appName, mutator); err != nil {
+			app, err := client.Transform(cmd.Context(), p.Space, appName, mutator)
+			if err != nil {
 				return fmt.Errorf("failed to delete all autoscaling rules for App: %s", err)
 			}
 
+			stopped := app != nil && (app.Spec.Instances.Stopped || !app.Spec.Instances.Autoscaling.Enabled)
 			action := fmt.Sprintf("Deleting all autoscaling rules for App %q in Space %q", appName, p.Space)
-			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+			return async.AwaitAndLog(stopped, cmd.OutOrStdout(), action, func() error {
 				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
 				return err
 			})

--- a/pkg/kf/commands/autoscaling/disable_autoscaling.go
+++ b/pkg/kf/commands/autoscaling/disable_autoscaling.go
@@ -33,7 +33,7 @@ func NewDisableAutoscaling(
 	p *config.KfParams,
 	client apps.Client,
 ) *cobra.Command {
-	var async utils.AsyncFlags
+	var async utils.AsyncIfStoppedFlags
 
 	cmd := &cobra.Command{
 		Use:               "disable-autoscaling APP_NAME",
@@ -68,8 +68,9 @@ func NewDisableAutoscaling(
 				return fmt.Errorf("failed to disable autoscaling for App: %s", err)
 			}
 
+			stopped := app != nil && app.Spec.Instances.Stopped
 			action := fmt.Sprintf("Disabling autoscaling for App %q in Space %q", appName, p.Space)
-			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+			return async.AwaitAndLog(stopped, cmd.OutOrStdout(), action, func() error {
 				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
 				return err
 			})

--- a/pkg/kf/commands/autoscaling/enable_autoscaling.go
+++ b/pkg/kf/commands/autoscaling/enable_autoscaling.go
@@ -33,7 +33,7 @@ func NewEnableAutoscaling(
 	p *config.KfParams,
 	client apps.Client,
 ) *cobra.Command {
-	var async utils.AsyncFlags
+	var async utils.AsyncIfStoppedFlags
 
 	cmd := &cobra.Command{
 		Use:   "enable-autoscaling APP_NAME",
@@ -101,8 +101,9 @@ func NewEnableAutoscaling(
 				return fmt.Errorf("failed to enable autoscaling for App: %s", err)
 			}
 
+			stopped := app != nil && app.Spec.Instances.Stopped
 			action := fmt.Sprintf("Enabling autoscaling for App %q in Space %q", appName, p.Space)
-			return async.AwaitAndLog(cmd.OutOrStdout(), action, func() error {
+			return async.AwaitAndLog(stopped, cmd.OutOrStdout(), action, func() error {
 				_, err := client.WaitForConditionKnativeServiceReadyTrue(context.Background(), p.Space, appName, 1*time.Second)
 				return err
 			})

--- a/pkg/kf/commands/cluster/config_cluster.go
+++ b/pkg/kf/commands/cluster/config_cluster.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/kf/v2/pkg/kf/commands/completion"
 	"github.com/google/kf/v2/pkg/kf/commands/config"
 	"github.com/google/kf/v2/pkg/kf/configmaps"
-	utils "github.com/google/kf/v2/pkg/kf/internal/utils/cli"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/kmp"
@@ -87,8 +86,6 @@ func (cm configMutator) exampleCommands() string {
 }
 
 func (cm configMutator) toCommand(p *config.KfParams, client configmaps.Client) *cobra.Command {
-	var async utils.AsyncFlags
-
 	cmd := &cobra.Command{
 		Use:               fmt.Sprintf("%s %s", cm.Name, strings.Join(cm.Args, " ")),
 		Short:             cm.Short,
@@ -114,7 +111,6 @@ func (cm configMutator) toCommand(p *config.KfParams, client configmaps.Client) 
 			return nil
 		},
 	}
-	async.Add(cmd)
 
 	return cmd
 }


### PR DESCRIPTION

## Proposed Changes

* Introduce async_if_stopped flag which allows commands to terminate without waiting only if they are operating on an app that is in the stopped state.

## Release Notes

`Added` async_if_stopped flag to commands that can terminate asynchronously if the app they operate on is in the stopped state.

## Example
i.e. with the `scale` command kf will now return very quickly if the app is stopped
```
kf scale myapp --instances 3

Scale:
  Stopped?:  true
  Replicas:  3
Scaling App "nginx-sample" in Space "gareth" asynchronously because app is stopped
```