### PR TITLE
Increase concurrency of app and route reconcilers.

### DIFF
--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -102,6 +102,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		WorkQueueName: "Apps",
 		Logger:        logger,
 		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+		Concurrency:   10,
 	})
 
 	logger.Info("Setting up event handlers")

--- a/pkg/reconciler/route/controller.go
+++ b/pkg/reconciler/route/controller.go
@@ -68,6 +68,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		WorkQueueName: "Routes",
 		Logger:        logger,
 		Reporter:      &reconcilerutil.StructuredStatsReporter{Logger: logger},
+		Concurrency:   10,
 	})
 
 	logger.Info("Setting up event handlers")


### PR DESCRIPTION
These are the two big reconcilers we have which should experience the greatest amount of churn yet should still be relatively safe for increasing, the default number of goroutines  handling is 2. 10 is an arbitrary number but doesn't seem like it's too high.