### PR TITLE
Bump webhook cpu limit to 500m

### DIFF
--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -50,7 +50,7 @@ spec:
             memory: 20Mi
           # Limit to 10x the request (20x the observed peak during e2e)
           limits:
-            cpu: 200m
+            cpu: 500m
             memory: 256Mi
         volumeMounts:
         - name: config-logging

--- a/operator/cmd/manager/kodata/kf/2.11/v2.11.5_kf.yaml
+++ b/operator/cmd/manager/kodata/kf/2.11/v2.11.5_kf.yaml
@@ -8256,7 +8256,7 @@ spec:
               memory: 20Mi
             # Limit to 10x the request (20x the observed peak during e2e)
             limits:
-              cpu: 200m
+              cpu: 500m
               memory: 256Mi
           volumeMounts:
             - name: config-logging


### PR DESCRIPTION
## Proposed Changes

* bump webhook cpu limit to 500m
In certain use cases 200m limit is not enough, thus it needs to be increased.
