### PR TITLE
Increase memory and CPU for controller/webhook.

### DIFF
--- a/config/controller.yaml
+++ b/config/controller.yaml
@@ -49,8 +49,8 @@ spec:
             cpu: 256m
             memory: 256Mi
           limits:
-            cpu: 1000m
-            memory: 1000Mi
+            cpu: 2000m
+            memory: 2Gi
         # We use a livenessProbe instead of a readinessProbe because if the
         # health check fails, then it will restart the pod (instead of not
         # signaling it at all). This is necessary for Workload Identity.

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -44,14 +44,12 @@ spec:
         # and substituted here.
         image: ko://github.com/google/kf/v2/cmd/webhook
         resources:
-          # Request 2x what we saw running e2e
           requests:
-            cpu: 20m
-            memory: 20Mi
-          # Limit to 10x the request (20x the observed peak during e2e)
-          limits:
-            cpu: 200m
+            cpu: 256m
             memory: 256Mi
+          limits:
+            cpu: 2000m
+            memory: 2Gi
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging


### PR DESCRIPTION
Customers are seeing throttling with the current setup for the webhook. When these were created they operated on smaller resources (before K8s started copying lots of data into the metadata to track field ownership) so they're both likely due for a refresh.