### PR TITLE
Don't wait for placeholder creation during push.

### DIFF
--- a/pkg/kf/apps/push.go
+++ b/pkg/kf/apps/push.go
@@ -292,10 +292,7 @@ func (p *pusher) CreatePlaceholderApp(ctx context.Context, appName string, opts 
 			return nil, fmt.Errorf("couldn't create App placeholder: %v", err)
 		}
 
-		// Wait for ready.
-		if _, err := p.appsClient.WaitForConditionReadyTrue(ctx, cfg.Space, appName, 1*time.Second); err != nil {
-			return nil, fmt.Errorf("couldn't wait for App placeholder: %v", err)
-		}
+		// Don't wait for ready, it's not a prerequisite for pushing.
 		logger.Info("Placeholder App created.")
 		return app, nil
 

--- a/pkg/kf/apps/push_test.go
+++ b/pkg/kf/apps/push_test.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"errors"
 	"io"
-	"knative.dev/pkg/kmeta"
 	"testing"
+
+	"knative.dev/pkg/kmeta"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/kf/v2/pkg/apis/kf/config"
@@ -1123,11 +1124,6 @@ func Test_pusher_CreatePlaceholderApp(t *testing.T) {
 					Create(gomock.Any(), mockAppNamespace, gomock.Any()).
 					Return(nil, nil).
 					Times(1)
-
-				mocks.appsClient.EXPECT().
-					WaitForConditionReadyTrue(gomock.Any(), mockAppNamespace, mockAppName, gomock.Any()).
-					Return(nil, nil).
-					Times(1)
 			},
 		},
 		"creates a valid placeholder App": {
@@ -1148,33 +1144,7 @@ func Test_pusher_CreatePlaceholderApp(t *testing.T) {
 
 						return app, nil
 					}).MinTimes(1)
-
-				mocks.appsClient.EXPECT().
-					WaitForConditionReadyTrue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, nil).
-					AnyTimes()
 			},
-		},
-		"fails if App wait fails": {
-			appName: mockAppName,
-			opts:    mockPushOptions,
-			setup: func(t *testing.T, mocks *mocks) {
-				mocks.appsClient.EXPECT().
-					Get(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, notFoundError).
-					AnyTimes()
-
-				mocks.appsClient.EXPECT().
-					Create(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, nil).
-					AnyTimes()
-
-				mocks.appsClient.EXPECT().
-					WaitForConditionReadyTrue(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(nil, errors.New("test failure")).
-					AnyTimes()
-			},
-			wantErr: errors.New("couldn't wait for App placeholder: test failure"),
 		},
 		"fails if placeholder can't be created": {
 			appName: mockAppName,


### PR DESCRIPTION
This step shouldn't actually be necessary and just slows down push because it requires a full extra reconciliation.