### PR TITLE
Fixes for issues in 1.18 pre-release

### DIFF
--- a/docs/content/en/docs/v2.11/cli/generated/kf-xargs-apps.md
+++ b/docs/content/en/docs/v2.11/cli/generated/kf-xargs-apps.md
@@ -1,0 +1,79 @@
+---
+title: "kf xargs-apps"
+weight: 100
+description: "Run a command for every App."
+---
+### Name
+
+<code translate="no">kf xargs-apps</code> - Run a command for every App.
+
+### Synopsis
+
+<pre translate="no">kf xargs-apps [flags]</pre>
+
+### Description
+
+Run a command for every App in targeted spaces.
+
+### Examples
+
+<pre translate="no">
+# Example: restart all apps in all spaces
+kf xargs-apps --all-namespaces -- kf restart {{.Name}} --space {{.Space}}
+
+# Example: restage all apps in all spaces
+kf xargs-apps --all-namespaces -- kf restage {{.Name}} --space {{.Space}}
+
+# Example: stop all apps in spaces &#39;space1&#39; and &#39;space2&#39;
+kf xargs-apps --space space1,space2 -- kf stop {{.Name}} --space {{.Space}}
+
+# Example: use kubectl to label all apps in the default space
+kf xargs-apps -- kubectl label apps -n {{.Space}} {{.Name}} environment=prod</pre>
+
+### Flags
+
+<dl>
+<dt><code translate="no">--all-namespaces</code></dt>
+<dd><p>Enables targeting all spaces in the cluster.</p>
+</dd>
+<dt><code translate="no">--dry-run</code></dt>
+<dd><p>Enables dry-run mode, commands are printed but will not be executed. (default true)</p>
+</dd>
+<dt><code translate="no">-h, --help</code></dt>
+<dd><p>help for xargs-apps</p>
+</dd>
+<dt><code translate="no">--resource-concurrency=<var translate="no">int</var></code></dt>
+<dd><p>Number of apps within a space that may be operated on in parallel. Total concurrency will be upto space-concurrency * app-concurrency. -1 for no limit. (default 1)</p>
+</dd>
+<dt><code translate="no">--space-concurrency=<var translate="no">int</var></code></dt>
+<dd><p>Number of spaces that may be operated on in parallel. -1 for no limit. (default -1)</p>
+</dd>
+</dl>
+
+
+### Inherited flags
+
+These flags are inherited from parent commands.
+
+<dl>
+<dt><code translate="no">--as=<var translate="no">string</var></code></dt>
+<dd><p>Username to impersonate for the operation.</p>
+</dd>
+<dt><code translate="no">--as-group=<var translate="no">strings</var></code></dt>
+<dd><p>Group to impersonate for the operation. Include this flag multiple times to specify multiple groups.</p>
+</dd>
+<dt><code translate="no">--config=<var translate="no">string</var></code></dt>
+<dd><p>Path to the Kf config file to use for CLI requests.</p>
+</dd>
+<dt><code translate="no">--kubeconfig=<var translate="no">string</var></code></dt>
+<dd><p>Path to the kubeconfig file to use for CLI requests.</p>
+</dd>
+<dt><code translate="no">--log-http</code></dt>
+<dd><p>Log HTTP requests to standard error.</p>
+</dd>
+<dt><code translate="no">--space=<var translate="no">string</var></code></dt>
+<dd><p>Space to run the command against. This flag overrides the currently targeted Space.</p>
+</dd>
+</dl>
+
+

--- a/pkg/kf/commands/apps/xargs_apps.go
+++ b/pkg/kf/commands/apps/xargs_apps.go
@@ -20,7 +20,7 @@ kf xargs-apps --space space1,space2 -- kf stop {{.Name}} --space {{.Space}}
 # Example: use kubectl to label all apps in the default space
 kf xargs-apps -- kubectl label apps -n {{.Space}} {{.Name}} environment=prod`
 
-// NewAppsCommand allows users to list apps.
+// NewXargsAppsCommand allows users to list apps.
 func NewXargsAppsCommand(p *config.KfParams, client spaces.Client) *cobra.Command {
 	return genericcli.NewXargsCommand(
 		apps.NewResourceInfo(),

--- a/pkg/kf/commands/apps/xargs_apps.go
+++ b/pkg/kf/commands/apps/xargs_apps.go
@@ -9,11 +9,14 @@ import (
 )
 
 const examples = `# Example: restart all apps in all spaces
-kf xargs-apps --all-spaces -- kf restart {{.Name}} --space {{.Space}}
+kf xargs-apps --all-namespaces -- kf restart {{.Name}} --space {{.Space}}
+
 # Example: restage all apps in all spaces
-kf xargs-apps --all-spaces -- kf restage {{.Name}} --space {{.Space}}
+kf xargs-apps --all-namespaces -- kf restage {{.Name}} --space {{.Space}}
+
 # Example: stop all apps in spaces 'space1' and 'space2'
 kf xargs-apps --space space1,space2 -- kf stop {{.Name}} --space {{.Space}}
+
 # Example: use kubectl to label all apps in the default space
 kf xargs-apps -- kubectl label apps -n {{.Space}} {{.Name}} environment=prod`
 

--- a/pkg/kf/commands/dependencies/dependencies.go
+++ b/pkg/kf/commands/dependencies/dependencies.go
@@ -117,7 +117,7 @@ func newDependencies() []dependency {
 		{
 			Name:       "Anthos Service Mesh",
 			ShortNames: []string{"asm"},
-			InfoURL:    "/service-mesh/docs/gke-install-overview",
+			InfoURL:    "https://cloud.google.com/service-mesh/docs/gke-install-overview",
 			// This version is fetched from the asmcli script. It needs to be
 			// updated by hand until we have a programtic way to fetch it.
 			ResolveVersion: staticVersionResolver("1.16.4-asm.2+config1"),
@@ -129,7 +129,7 @@ func newDependencies() []dependency {
 		{
 			Name:       "Config Connector",
 			ShortNames: []string{"kcc"},
-			InfoURL:    "/config-connector/docs/how-to/advanced-install",
+			InfoURL:    "https://cloud.google.com//config-connector/docs/how-to/advanced-install",
 			// This version needs to be updated by hand until we have a
 			// programtic way to fetch it.
 			ResolveVersion: staticVersionResolver("1.66.0"),

--- a/pkg/kf/commands/root.go
+++ b/pkg/kf/commands/root.go
@@ -132,7 +132,6 @@ func NewRawKfCommand() *cobra.Command {
 				InjectPush(p),
 				InjectDelete(p),
 				InjectApps(p),
-				InjectXargsApps(p),
 				InjectGetApp(p),
 				InjectStart(p),
 				InjectStop(p),
@@ -281,6 +280,10 @@ func NewRawKfCommand() *cobra.Command {
 		utils.ExperimentalCommandGroup(
 			"Buildpacks",
 			InjectWrapV2Buildpack(p),
+		),
+		utils.ExperimentalCommandGroup(
+			"Bulk Actions",
+			InjectXargsApps(p),
 		),
 		{
 			Name: "Other Commands",

--- a/pkg/kf/internal/genericcli/xargs.go
+++ b/pkg/kf/internal/genericcli/xargs.go
@@ -60,7 +60,7 @@ func NewXargsCommand(t Type, p *config.KfParams, spacesClient spaces.Client, opt
 	if options.Short() != "" {
 		short = options.Short()
 	} else {
-		short = fmt.Sprintf("Run a command for every %s.", options.PluralFriendlyName())
+		short = fmt.Sprintf("Run a command for every %s.", t.FriendlyName())
 	}
 
 	var long string
@@ -73,15 +73,15 @@ func NewXargsCommand(t Type, p *config.KfParams, spacesClient spaces.Client, opt
 	}
 
 	cmd := &cobra.Command{
-		Use:          strings.TrimSpace(fmt.Sprintf("%s", options.CommandName())),
-		Aliases:      options.Aliases(),
-		Short:        short,
-		Long:         long,
-		Example:      example,
-		Args:         cobra.MinimumNArgs(1),
-		SilenceUsage: true,
+		Use:     strings.TrimSpace(fmt.Sprintf("%s", options.CommandName())),
+		Aliases: options.Aliases(),
+		Short:   short,
+		Long:    long,
+		Example: example,
+		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+			cmd.SilenceUsage = true
 
 			if err := p.ValidateSpaceTargeted(); err != nil {
 				return err
@@ -96,9 +96,9 @@ func NewXargsCommand(t Type, p *config.KfParams, spacesClient spaces.Client, opt
 			}
 
 			if flags.allSpaces {
-				logger.Infof("Xargs %s in all spaces", options.PluralFriendlyName())
+				logger.Infof("# Xargs %s in all spaces", options.PluralFriendlyName())
 			} else if t.Namespaced() {
-				logger.Infof("Xargs %s in space: %s", options.PluralFriendlyName(), p.Space)
+				logger.Infof("# Xargs %s in space: %s", options.PluralFriendlyName(), p.Space)
 			}
 
 			labelSelector := labels.Set{}

--- a/pkg/kf/internal/genericcli/xargs.go
+++ b/pkg/kf/internal/genericcli/xargs.go
@@ -73,15 +73,15 @@ func NewXargsCommand(t Type, p *config.KfParams, spacesClient spaces.Client, opt
 	}
 
 	cmd := &cobra.Command{
-		Use:     strings.TrimSpace(fmt.Sprintf("%s", options.CommandName())),
-		Aliases: options.Aliases(),
-		Short:   short,
-		Long:    long,
-		Example: example,
-		Args:    cobra.MinimumNArgs(1),
+		Use:          strings.TrimSpace(fmt.Sprintf("%s", options.CommandName())),
+		Aliases:      options.Aliases(),
+		Short:        short,
+		Long:         long,
+		Example:      example,
+		Args:         cobra.MinimumNArgs(1),
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			cmd.SilenceUsage = true
 
 			if err := p.ValidateSpaceTargeted(); err != nil {
 				return err

--- a/pkg/kf/internal/genericcli/xargs_test.go
+++ b/pkg/kf/internal/genericcli/xargs_test.go
@@ -53,14 +53,14 @@ func TestXargsCommand_docs(t *testing.T) {
 		"general": {
 			genericType: typ,
 			wantUse:     "xargs-mycustomtypes",
-			wantShort:   "Run a command for every MyCustomTypes.",
+			wantShort:   "Run a command for every MyCustomType.",
 			wantLong:    "Run a command for every MyCustomType in targeted spaces.",
 			wantExample: "kf xargs-mycustomtypes",
 		},
 		"with custom example": {
 			genericType: typ,
 			wantUse:     "xargs-mycustomtypes",
-			wantShort:   "Run a command for every MyCustomTypes.",
+			wantShort:   "Run a command for every MyCustomType.",
 			wantLong:    "Run a command for every MyCustomType in targeted spaces.",
 			wantExample: "a custom example",
 			opts: []XargsOption{
@@ -70,7 +70,7 @@ func TestXargsCommand_docs(t *testing.T) {
 		"with aliases": {
 			genericType: typ,
 			wantUse:     "xargs-mycustomtypes",
-			wantShort:   "Run a command for every MyCustomTypes.",
+			wantShort:   "Run a command for every MyCustomType.",
 			wantLong:    "Run a command for every MyCustomType in targeted spaces.",
 			wantExample: "kf xargs-mycustomtypes",
 			wantAliases: []string{"a", "b"},
@@ -157,7 +157,7 @@ func TestNewXargsCommand(t *testing.T) {
 					Namespace("my-ns").
 					Create(ctx, obj, metav1.CreateOptions{})
 			},
-			wantOut: "Xargs Apps in space: my-ns\n# Command for space=my-ns App=some-object-name\n'my-ns some-object-name'\n# Run with --dry-run=false to apply.\n",
+			wantOut: "# Xargs Apps in space: my-ns\n# Command for space=my-ns App=some-object-name\n'my-ns some-object-name'\n# Run with --dry-run=false to apply.\n",
 		},
 		"cluster type": {
 			t:    clusterType,
@@ -197,7 +197,7 @@ func TestNewXargsCommand(t *testing.T) {
 			setup: func(ctx context.Context, t *testing.T, mocks *mocks) {
 				mocks.p.Space = "ns1,ns2"
 			},
-			wantOut: "Xargs Apps in space: ns1,ns2\n# Command for space=ns1 App=app1\n'ns1 app1'\n# Command for space=ns1 App=app2\n'ns1 app2'\n# Command for space=ns2 App=app3\n'ns2 app3'\n# Command for space=ns2 App=app4\n'ns2 app4'\n# Run with --dry-run=false to apply.\n",
+			wantOut: "# Xargs Apps in space: ns1,ns2\n# Command for space=ns1 App=app1\n'ns1 app1'\n# Command for space=ns1 App=app2\n'ns1 app2'\n# Command for space=ns2 App=app3\n'ns2 app3'\n# Command for space=ns2 App=app4\n'ns2 app4'\n# Run with --dry-run=false to apply.\n",
 		},
 	}
 

--- a/pkg/reconciler/garbagecollector/controller.go
+++ b/pkg/reconciler/garbagecollector/controller.go
@@ -31,7 +31,7 @@ const GarbageCollectionInterval time.Duration = 5 * time.Minute
 
 // NewController creates a new controller capable of reconciling Kf Apps.
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := reconciler.NewControllerLogger(ctx, "apps.kf.dev")
+	logger := reconciler.NewControllerLogger(ctx, "garbagecollector.kf.dev")
 
 	// Get informers off context
 	buildInformer := buildinformer.Get(ctx)

--- a/pkg/reconciler/garbagecollector/reconciler.go
+++ b/pkg/reconciler/garbagecollector/reconciler.go
@@ -60,6 +60,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 
 func (r *Reconciler) garbageCollectApp(ctx context.Context, namespace, name string) (err error) {
 	logger := logging.FromContext(ctx)
+	ctx = r.kfConfigStore.ToContext(ctx)
+
 	app, err := r.appLister.Apps(namespace).Get(name)
 	switch {
 	case apierrs.IsNotFound(err):


### PR DESCRIPTION
* Generated docs for xargs-apps
* Fixed pluralization in xargs-apps
* Fixed incorrect examples in xargs-apps
* Changed xargs-apps into an experimental subcommand
* Added extra comment in xargs-apps to allow exporting as a command
* Fixed garbagecollector logging name
* Added config watcher to garbagecollector logger to prevent a panic
