### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/pkg/apis/kf/v1alpha1/serviceinstance_lifecycle.go
+++ b/pkg/apis/kf/v1alpha1/serviceinstance_lifecycle.go
@@ -121,7 +121,7 @@ func (status *ServiceInstanceStatus) PropagateDeploymentStatus(deployment *appsv
 	}
 
 	if deployment.Generation > deployment.Status.ObservedGeneration {
-		status.manage().MarkUnknown(ServiceInstanceConditionBackingResourceReady, "GenerationOutOfDate", fmt.Sprintf("waiting for deployment spec update to be observed"))
+		status.manage().MarkUnknown(ServiceInstanceConditionBackingResourceReady, "GenerationOutOfDate", "waiting for deployment spec update to be observed")
 		return
 	}
 

--- a/pkg/kf/commands/config/config_test.go
+++ b/pkg/kf/commands/config/config_test.go
@@ -219,7 +219,7 @@ func TestFeatureFlagWarning(t *testing.T) {
 				delete(ns.Annotations, v1alpha1.FeatureFlagsAnnotation)
 				return ns
 			}()),
-			expectedOut: fmt.Sprintf("WARN Unable to read feature flags from server.\n"),
+			expectedOut: "WARN Unable to read feature flags from server.\n",
 		},
 		"bad flags": {
 			namespace: (func() *v1.Namespace {

--- a/pkg/kf/commands/service-bindings/bind-service.go
+++ b/pkg/kf/commands/service-bindings/bind-service.go
@@ -129,7 +129,7 @@ func NewBindServiceCommand(p *config.KfParams, client serviceinstancebindings.Cl
 				utils.SuggestNextAction(utils.NextAction{
 					Description: "List bindings",
 					Commands: []string{
-						fmt.Sprint("kf bindings"),
+						"kf bindings",
 					},
 				})
 				return nil


### PR DESCRIPTION
<!-- Include the issue number below -->
Fixes #

## Proposed Changes

*
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
