### PR TITLE
Fixed navigation rendering in CLI docs.

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -143,6 +143,8 @@ sidebar_menu_compact = false
 # Set to true to hide the sidebar search box (the top nav search box will still be displayed if search is enabled)
 sidebar_search_disable = false
 sidebar_menu_foldable = true
+# Ensure all pages can fit in the sidebar -- especially important for Kf's CLI docs.
+sidebar_menu_truncate = 10000
 
 # Adds a H2 section titled "Feedback" to the bottom of each doc. The responses are sent to Google Analytics as events.
 # This feature depends on [services.googleAnalytics] and will be disabled if "services.googleAnalytics.id" is not set.


### PR DESCRIPTION
By default, Docsy truncates lists in the navbar to 50 entries. Kf's CLI uses significantly more. Bumped up the number here to ensure the whole things shows.