### PR TITLE
Fix feature flag reconciler triggers.

### DIFF
--- a/pkg/reconciler/featureflag/controller.go
+++ b/pkg/reconciler/featureflag/controller.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
-	logger := reconciler.NewControllerLogger(ctx, "namespace")
+	logger := reconciler.NewControllerLogger(ctx, "featureflag")
 
 	namespaceInformer := namespaceinformer.Get(ctx)
 
@@ -58,7 +58,9 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 		&config.DefaultsConfig{},
 	}
 	resync := configmap.TypeFilter(configsToResync...)(func(string, interface{}) {
-		impl.GlobalResync(namespaceInformer.Informer())
+		impl.FilteredGlobalResync(
+			controller.FilterWithName(v1alpha1.KfNamespace),
+			namespaceInformer.Informer())
 	})
 	configStore := config.NewStore(logger.Named("kf-config-store"), resync)
 	configStore.WatchConfigs(cmw)

--- a/pkg/reconciler/featureflag/reconciler_test.go
+++ b/pkg/reconciler/featureflag/reconciler_test.go
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package featureflag
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/kf/v2/pkg/kf/testutil"
+)
+
+func TestValidateKfNamespaceName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		key  string
+		want error
+	}{
+		"nominal":           {key: "kf/", want: nil},
+		"invalid namespace": {key: "kf-system/", want: errors.New(`invalid namespace "kf-system" queued, expect only "kf"`)},
+		"invalid key":       {key: "foo/bar/bazz", want: errors.New(`unexpected key format: "foo/bar/bazz"`)},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			got := validateKfNamespaceName(tc.key)
+
+			testutil.AssertErrorsEqual(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
The Feature Flag reconciler previously was building too long of a queue by enqueueing _all_ namespaces when the config-defaults configmap changed.

While it appears there wasn't any harm due to the reconciler ignoring the keys, it was still leading to concerningly high queue depths and a huge amount of unnecessary work for the controllers.