### PR TITLE
Use faster kaniko snapshotting.

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -186,6 +186,11 @@ data:
     # system privileges.
     taskDisableVolumeMounts: "true"
 
+    # buildKanikoRobustSnapshot turns off fast snapshotting in Kaniko for v2 buildpacks.
+    # This causes significantly higher disk usage, but reduces the risk
+    # of producing incorrect images. Kf apps shoudln't typically need this on.
+    buildKanikoRobustSnapshot: "false"
+
     # The following images are used to execute builds. They SHOULD NOT be
     # modified except in rare circumstances.
     buildHelpersImage: "ko://github.com/google/kf/v2/cmd/build-helpers"
@@ -237,7 +242,8 @@ data:
       runImage: cloudfoundry/run:full-cnb@sha256:dbe17be507b1cc6ffae1e9edf02806fe0e28ffbbb89a6c7ef41f37b69156c3c2
   spaceDefaultToV3Stack: "false"
   routeServiceProxyImage: "ko://github.com/google/kf/v2/cmd/route-service-proxy"
-  buildKanikoExecutorImage: "gcr.io/kaniko-project/executor:v1.0.0"
+  buildKanikoExecutorImage: "gcr.io/kaniko-project/executor:v1.15.0"
+  buildKanikoRobustSnapshot: "false"
   buildInfoImage: "ko://github.com/google/kf/v2/cmd/setup-buildpack-build"
   buildTokenDownloadImage: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
   buildHelpersImage: "ko://github.com/google/kf/v2/cmd/build-helpers"

--- a/operator/pkg/apis/kfsystem/kf/defaults.go
+++ b/operator/pkg/apis/kfsystem/kf/defaults.go
@@ -36,6 +36,7 @@ const (
 	buildDisableIstioSidecarKey        = "buildDisableIstioSidecar"
 	buildPodResourcesKey               = "buildPodResources"
 	buildRetentionCountKey             = "buildRetentionCount"
+	buildKanikoRobustSnapshotKey       = "buildKanikoRobustSnapshot"
 	taskRetentionCountKey              = "taskRetentionCount"
 	buildTimeoutKey                    = "buildTimeout"
 	buildNodeSelectorsKey              = "buildNodeSelectors"
@@ -107,6 +108,11 @@ type DefaultsConfig struct {
 	// BuildDisableIstioSidecar when set to true, will prevent the Istio
 	// sidecar from being attached to the Build pods.
 	BuildDisableIstioSidecar bool `json:"buildDisableIstioSidecar,omitempty"`
+
+	// BuildKanikoRobustSnapshotKey turns off fast snapshotting in Kaniko for v2 buildpacks.
+	// This causes significantly higher disk usage, but reduces the risk
+	// of producing incorrect images. Kf apps shoudln't typically need this on.
+	BuildKanikoRobustSnapshot bool `json:"buildKanikoRobustSnapshot,omitempty"`
 
 	// BuildPodResources sets the Build pod resources field.
 	// NOTE: This is only applicable for built-in Tasks. For V2 builds, this
@@ -281,6 +287,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		buildRetentionCountKey:             &defaultsConfig.BuildRetentionCount,
 		taskRetentionCountKey:              &defaultsConfig.TaskRetentionCount,
 		buildNodeSelectorsKey:              &defaultsConfig.BuildNodeSelectors,
+		buildKanikoRobustSnapshotKey:       &defaultsConfig.BuildKanikoRobustSnapshot,
 		appCPUPerGBOfRAMKey:                &defaultsConfig.AppCPUPerGBOfRAM,
 		appCPUMinKey:                       &defaultsConfig.AppCPUMin,
 		appDisableStartCommandLookupKey:    &defaultsConfig.AppDisableStartCommandLookup,

--- a/pkg/apis/kf/config/defaults.go
+++ b/pkg/apis/kf/config/defaults.go
@@ -36,6 +36,7 @@ const (
 	buildDisableIstioSidecarKey        = "buildDisableIstioSidecar"
 	buildPodResourcesKey               = "buildPodResources"
 	buildRetentionCountKey             = "buildRetentionCount"
+	buildKanikoRobustSnapshotKey       = "buildKanikoRobustSnapshot"
 	taskRetentionCountKey              = "taskRetentionCount"
 	buildTimeoutKey                    = "buildTimeout"
 	buildNodeSelectorsKey              = "buildNodeSelectors"
@@ -118,6 +119,11 @@ type DefaultsConfig struct {
 	// BuildRetentionCount is the number of completed Builds each App will
 	// keep before garbage collecting.
 	BuildRetentionCount *uint `json:"buildRetentionCount,omitempty"`
+
+	// BuildKanikoRobustSnapshotKey turns off fast snapshotting in Kaniko for v2 buildpacks.
+	// This causes significantly higher disk usage, but reduces the risk
+	// of producing incorrect images. Kf apps shoudln't typically need this on.
+	BuildKanikoRobustSnapshot bool `json:"buildKanikoRobustSnapshot,omitempty"`
 
 	// TaskRetentionCount is the number of completed Tasks each App will
 	// keep before garbage collecting.
@@ -281,6 +287,7 @@ func (defaultsConfig *DefaultsConfig) getInterfaceValues(leaveEmpty bool) map[st
 		buildRetentionCountKey:             &defaultsConfig.BuildRetentionCount,
 		taskRetentionCountKey:              &defaultsConfig.TaskRetentionCount,
 		buildNodeSelectorsKey:              &defaultsConfig.BuildNodeSelectors,
+		buildKanikoRobustSnapshotKey:       &defaultsConfig.BuildKanikoRobustSnapshot,
 		appCPUPerGBOfRAMKey:                &defaultsConfig.AppCPUPerGBOfRAM,
 		appCPUMinKey:                       &defaultsConfig.AppCPUMin,
 		appDisableStartCommandLookupKey:    &defaultsConfig.AppDisableStartCommandLookup,

--- a/pkg/apis/kf/config/defaults_test.go
+++ b/pkg/apis/kf/config/defaults_test.go
@@ -43,6 +43,7 @@ func TestPatchConfigMap(t *testing.T) {
 		buildHelpersImageKey,
 		buildpacksV2LifecycleImageKey,
 		buildDisableIstioSidecarKey,
+		buildKanikoRobustSnapshotKey,
 		buildPodResourcesKey,
 		featureFlagsKey,
 		nopImageKey,

--- a/pkg/apis/kf/config/store_test.go
+++ b/pkg/apis/kf/config/store_test.go
@@ -50,6 +50,7 @@ func TestStoreLoadWithContext(t *testing.T) {
 		buildpacksV2LifecycleImageKey,
 		buildDisableIstioSidecarKey,
 		buildPodResourcesKey,
+		buildKanikoRobustSnapshotKey,
 		featureFlagsKey,
 		nopImageKey,
 		appCPUMinKey,

--- a/pkg/reconciler/build/resources/builtin_tasks.go
+++ b/pkg/reconciler/build/resources/builtin_tasks.go
@@ -72,6 +72,11 @@ func buildpackV2Task(cfg *config.DefaultsConfig) *tektonv1beta1.TaskSpec {
 		resources = *cfg.BuildPodResources
 	}
 
+	var optionalKanikoFlags []string
+	if !cfg.BuildKanikoRobustSnapshot {
+		optionalKanikoFlags = append(optionalKanikoFlags, "--snapshot-mode=redo")
+	}
+
 	return &tektonv1beta1.TaskSpec{
 		Params: []tektonv1beta1.ParamSpec{
 			tektonutil.DefaultStringParam("BUILD_NAME", "The name of the Build to push destination image for.", ""),
@@ -189,7 +194,7 @@ EOF
 				WorkingDir: "/workspace",
 				Command:    []string{"/kaniko/executor"},
 				Image:      cfg.BuildKanikoExecutorImage,
-				Args: []string{
+				Args: append([]string{
 					"--force",
 					"--dockerfile",
 					"/workspace/Dockerfile",
@@ -203,7 +208,7 @@ EOF
 					"--no-push",
 					"--tarPath",
 					"/workspace/image.tar",
-				},
+				}, optionalKanikoFlags...),
 				Resources: resources,
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "cache-dir", MountPath: "/cache"},


### PR DESCRIPTION
Tested using an app with 10,000 small files and builds are about 10 seconds faster. For some of the large Java apps we're seeing with 90MB of class files we should see a nice speedup.

## Proposed Changes

* Changed default Kaniko image to v1.15 from v1.0
* Added ability to pick a snapshot mode for v2 buildpacks.
* Changed default snapshot mode from robust to fast for Kaniko when used with v2 builds.

