### PR TITLE
Update package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,24 +1,38 @@
 {
-  "name": "tech-doc-hugo",
-  "version": "0.0.1",
-  "description": "Hugo theme for technical documentation.",
-  "main": "none.js",
+  "name": "docsy-example-site",
+  "version": "0.7.1",
+  "description": "Example site that uses Docsy theme for technical documentation.",
+  "repository": "github:google/docsy-example",
+  "homepage": "https://example.docsy.dev",
+  "author": "Docsy Authors",
+  "license": "Apache-2.0",
+  "bugs": "https://github.com/google/docsy-example/issues",
+  "spelling": "cSpell:ignore HTMLTEST precheck postbuild -",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "_build": "npm run _hugo-dev",
+    "_check:links": "echo IMPLEMENTATION PENDING for check-links; echo",
+    "_hugo": "hugo --cleanDestinationDir",
+    "_hugo-dev": "npm run _hugo -- -e dev -DFE",
+    "_serve": "npm run _hugo-dev -- --minify serve",
+    "build:preview": "npm run _hugo-dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
+    "build:production": "npm run _hugo -- --minify",
+    "build": "npm run _build",
+    "check:links:all": "HTMLTEST_ARGS= npm run _check:links",
+    "check:links": "npm run _check:links",
+    "clean": "rm -Rf public/* resources",
+    "make:public": "git init -b main public",
+    "precheck:links:all": "npm run build",
+    "precheck:links": "npm run build",
+    "postbuild:preview": "npm run _check:links",
+    "postbuild:production": "npm run _check:links",
+    "serve": "npm run _serve",
+    "test": "npm run check:links",
+    "update:pkg:dep": "npm install --save-dev autoprefixer@latest postcss-cli@latest",
+    "update:pkg:hugo": "npm install --save-dev --save-exact hugo-extended@latest"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/google/docsy-example.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/google/docsy-example/issues"
-  },
-  "homepage": "https://github.com/google/docsy-example#readme",
   "devDependencies": {
-    "autoprefixer": "^10.4.0",
-    "postcss": "^8.3.7",
-    "postcss-cli": "^9.1.0"
+    "autoprefixer": "^10.4.14",
+    "hugo-extended": "0.117.0",
+    "postcss-cli": "^10.1.0"
   }
 }


### PR DESCRIPTION
Remove old "tech-doc-hugo" name which was triggering Snyk vulnerability scans. Replaced it with currenty docsy contents.

This was from an older version of docsy: https://github.com/google/docsy-example/issues/45

Looks like this name was taken over at one point: https://security.snyk.io/vuln/SNYK-JS-TECHDOCHUGO-5870392. The scan is triggering even though the name is just the same (even if we aren't and never were using that package).