### PR TITLE
Enqueue apps on the slow queue when spaces are updated.

### DIFF
--- a/pkg/reconciler/app/controller.go
+++ b/pkg/reconciler/app/controller.go
@@ -116,7 +116,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	// Watch for Space changes and enqueue all Apps in the evented Space
 	spaceInformer.Informer().AddEventHandler(&cache.ResourceEventHandlerFuncs{
 		AddFunc:    nil,
-		UpdateFunc: controller.PassNew(reconciler.LogEnqueueError(logger, enqueueAppsOfSpace(impl.Enqueue, appLister))),
+		UpdateFunc: controller.PassNew(reconciler.LogEnqueueError(logger, enqueueAppsOfSpace(impl.EnqueueSlow, appLister))),
 		DeleteFunc: nil,
 	})
 


### PR DESCRIPTION
These changes should take lower priority than live updates impacting the app itself, like pushes.

This should decrease latency for pushes during cluster changes.