### PR TITLE
Removed versions from vendor license.

### DIFF
--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -1,6 +1,6 @@
 
 ===========================================================
-Module: github.com/aws/smithy-go v1.11.0
+Module: github.com/aws/smithy-go
 
 
 
@@ -181,7 +181,7 @@ Module: github.com/aws/smithy-go v1.11.0
 
 
 ===========================================================
-Module: k8s.io/gengo v0.0.0-20220307231824-4627b89bbf1b
+Module: k8s.io/gengo
 
 
 
@@ -389,11 +389,11 @@ Module: k8s.io/gengo v0.0.0-20220307231824-4627b89bbf1b
 
 
 ===========================================================
-Module: github.com/google/go-containerregistry v0.8.1-0.20220216220642-00c59d91847c
-Module: github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220328141311-efc62d802606
-Module: github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220301182634-bfe2ffc6b6bd
-Module: go.opencensus.io v0.23.0
-Module: go.opencensus.io v0.23.0
+Module: github.com/google/go-containerregistry
+Module: github.com/google/go-containerregistry/pkg/authn/k8schain
+Module: github.com/google/go-containerregistry/pkg/authn/kubernetes
+Module: go.opencensus.io
+Module: go.opencensus.io
 
 
 
@@ -600,76 +600,76 @@ Module: go.opencensus.io v0.23.0
    limitations under the License.
 
 ===========================================================
-Module: cloud.google.com/go v0.100.2
-Module: cloud.google.com/go/compute v1.5.0
-Module: cloud.google.com/go/compute v1.5.0
-Module: cloud.google.com/go/logging v1.0.0
-Module: github.com/aws/aws-sdk-go-v2 v1.14.0
-Module: github.com/aws/aws-sdk-go-v2/config v1.14.0
-Module: github.com/aws/aws-sdk-go-v2/credentials v1.9.0
-Module: github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.11.0
-Module: github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.5
-Module: github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.3.0
-Module: github.com/aws/aws-sdk-go-v2/internal/ini v1.3.6
-Module: github.com/aws/aws-sdk-go-v2/service/ecr v1.15.0
-Module: github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.12.0
-Module: github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.8.0
-Module: github.com/aws/aws-sdk-go-v2/service/sso v1.10.0
-Module: github.com/aws/aws-sdk-go-v2/service/sts v1.15.0
-Module: github.com/census-instrumentation/opencensus-proto v0.3.0
-Module: github.com/census-instrumentation/opencensus-proto v0.3.0
-Module: github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
-Module: github.com/containerd/stargz-snapshotter/estargz v0.11.0
-Module: github.com/coreos/go-semver v0.3.0
-Module: github.com/go-openapi/jsonpointer v0.19.5
-Module: github.com/go-openapi/jsonreference v0.19.5
-Module: github.com/go-openapi/swag v0.19.15
-Module: github.com/golang/mock v1.6.0
-Module: github.com/golang/mock v1.6.0
-Module: github.com/google/btree v1.0.1
-Module: github.com/google/gofuzz v1.2.0
-Module: github.com/google/gofuzz v1.2.0
-Module: github.com/google/licenseclassifier v0.0.0-20190926221455-842c0d70d702
-Module: github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
-Module: github.com/google/subcommands v1.0.1
-Module: github.com/google/wire v0.4.0
-Module: github.com/moby/spdystream v0.2.0
-Module: github.com/tektoncd/pipeline v0.36.0 (imported as github.com/tektoncd/pipeline v0.36.0)
-Module: github.com/tektoncd/pipeline v0.36.0 (imported as github.com/tektoncd/pipeline )
-Module: go.etcd.io/etcd/api/v3 v3.5.0
-Module: go.etcd.io/etcd/client/pkg/v3 v3.5.0
-Module: go.etcd.io/etcd/client/v3 v3.5.0
-Module: google.golang.org/appengine v1.6.7
-Module: google.golang.org/appengine v1.6.7
-Module: google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf
-Module: google.golang.org/genproto v0.0.0-20220303160752-862486edd9cc
-Module: google.golang.org/grpc v1.44.0
-Module: google.golang.org/grpc v1.44.0
-Module: k8s.io/api v0.23.5
-Module: k8s.io/api v0.23.8
-Module: k8s.io/apiextensions-apiserver v0.23.4
-Module: k8s.io/apiextensions-apiserver v0.23.8
-Module: k8s.io/apimachinery v0.23.5
-Module: k8s.io/apimachinery v0.23.8
-Module: k8s.io/apiserver v0.23.5
-Module: k8s.io/cli-runtime v0.23.5
-Module: k8s.io/client-go v0.23.5
-Module: k8s.io/client-go v0.23.8
-Module: k8s.io/code-generator v0.23.5
-Module: k8s.io/component-base v0.23.5
-Module: k8s.io/kube-aggregator v0.23.5
-Module: k8s.io/kube-aggregator v0.23.5
-Module: k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
-Module: k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
-Module: k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-Module: k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-Module:  third_party/cloudfoundry-cli
-Module:  third_party/forked/cobra
-Module:  third_party/forked/gomod-collector
-Module:  third_party/forked/v2-buildpack-lifecycle
-Module:  third_party/k8s.io/kubectl
-Module:  third_party/mapfs
-Module:  third_party/tektoncd-cli
+Module: cloud.google.com/go
+Module: cloud.google.com/go/compute
+Module: cloud.google.com/go/compute
+Module: cloud.google.com/go/logging
+Module: github.com/aws/aws-sdk-go-v2
+Module: github.com/aws/aws-sdk-go-v2/config
+Module: github.com/aws/aws-sdk-go-v2/credentials
+Module: github.com/aws/aws-sdk-go-v2/feature/ec2/imds
+Module: github.com/aws/aws-sdk-go-v2/internal/configsources
+Module: github.com/aws/aws-sdk-go-v2/internal/endpoints/v2
+Module: github.com/aws/aws-sdk-go-v2/internal/ini
+Module: github.com/aws/aws-sdk-go-v2/service/ecr
+Module: github.com/aws/aws-sdk-go-v2/service/ecrpublic
+Module: github.com/aws/aws-sdk-go-v2/service/internal/presigned-url
+Module: github.com/aws/aws-sdk-go-v2/service/sso
+Module: github.com/aws/aws-sdk-go-v2/service/sts
+Module: github.com/census-instrumentation/opencensus-proto
+Module: github.com/census-instrumentation/opencensus-proto
+Module: github.com/chrismellard/docker-credential-acr-env
+Module: github.com/containerd/stargz-snapshotter/estargz
+Module: github.com/coreos/go-semver
+Module: github.com/go-openapi/jsonpointer
+Module: github.com/go-openapi/jsonreference
+Module: github.com/go-openapi/swag
+Module: github.com/golang/mock
+Module: github.com/golang/mock
+Module: github.com/google/btree
+Module: github.com/google/gofuzz
+Module: github.com/google/gofuzz
+Module: github.com/google/licenseclassifier
+Module: github.com/google/shlex
+Module: github.com/google/subcommands
+Module: github.com/google/wire
+Module: github.com/moby/spdystream
+Module: github.com/tektoncd/pipeline (imported as github.com/tektoncd/pipeline)
+Module: github.com/tektoncd/pipeline (imported as github.com/tektoncd/pipeline)
+Module: go.etcd.io/etcd/api/v3
+Module: go.etcd.io/etcd/client/pkg/v3
+Module: go.etcd.io/etcd/client/v3
+Module: google.golang.org/appengine
+Module: google.golang.org/appengine
+Module: google.golang.org/genproto
+Module: google.golang.org/genproto
+Module: google.golang.org/grpc
+Module: google.golang.org/grpc
+Module: k8s.io/api
+Module: k8s.io/api
+Module: k8s.io/apiextensions-apiserver
+Module: k8s.io/apiextensions-apiserver
+Module: k8s.io/apimachinery
+Module: k8s.io/apimachinery
+Module: k8s.io/apiserver
+Module: k8s.io/cli-runtime
+Module: k8s.io/client-go
+Module: k8s.io/client-go
+Module: k8s.io/code-generator
+Module: k8s.io/component-base
+Module: k8s.io/kube-aggregator
+Module: k8s.io/kube-aggregator
+Module: k8s.io/kube-openapi
+Module: k8s.io/kube-openapi
+Module: k8s.io/utils
+Module: k8s.io/utils
+Module: third_party/cloudfoundry-cli
+Module: third_party/forked/cobra
+Module: third_party/forked/gomod-collector
+Module: third_party/forked/v2-buildpack-lifecycle
+Module: third_party/k8s.io/kubectl
+Module: third_party/mapfs
+Module: third_party/tektoncd-cli
 
 
 
@@ -877,10 +877,10 @@ Module:  third_party/tektoncd-cli
 
 
 ===========================================================
-Module: github.com/googleapis/gnostic v0.5.5 (imported as github.com/googleapis/gnostic v0.5.5)
-Module: github.com/googleapis/gnostic v0.5.5 (imported as github.com/googleapis/gnostic )
-Module: github.com/googleapis/gnostic v0.5.5 (imported as github.com/googleapis/gnostic v0.5.5)
-Module: github.com/googleapis/gnostic v0.5.5 (imported as github.com/googleapis/gnostic )
+Module: github.com/googleapis/gnostic (imported as github.com/googleapis/gnostic)
+Module: github.com/googleapis/gnostic (imported as github.com/googleapis/gnostic)
+Module: github.com/googleapis/gnostic (imported as github.com/googleapis/gnostic)
+Module: github.com/googleapis/gnostic (imported as github.com/googleapis/gnostic)
 
 
 
@@ -1089,7 +1089,7 @@ Module: github.com/googleapis/gnostic v0.5.5 (imported as github.com/googleapis/
 
 
 ===========================================================
-Module: sigs.k8s.io/go-open-service-broker-client/v2 v2.0.0-20200911103215-9787cad28392
+Module: sigs.k8s.io/go-open-service-broker-client/v2
 
 
 
@@ -1286,14 +1286,14 @@ Module: sigs.k8s.io/go-open-service-broker-client/v2 v2.0.0-20200911103215-9787c
 
 
 ===========================================================
-Module: github.com/Azure/go-autorest v14.2.0+incompatible
-Module: github.com/Azure/go-autorest/autorest v0.11.24
-Module: github.com/Azure/go-autorest/autorest/adal v0.9.18
-Module: github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
-Module: github.com/Azure/go-autorest/autorest/azure/cli v0.4.5
-Module: github.com/Azure/go-autorest/autorest/date v0.3.0
-Module: github.com/Azure/go-autorest/logger v0.2.1
-Module: github.com/Azure/go-autorest/tracing v0.6.0
+Module: github.com/Azure/go-autorest
+Module: github.com/Azure/go-autorest/autorest
+Module: github.com/Azure/go-autorest/autorest/adal
+Module: github.com/Azure/go-autorest/autorest/azure/auth
+Module: github.com/Azure/go-autorest/autorest/azure/cli
+Module: github.com/Azure/go-autorest/autorest/date
+Module: github.com/Azure/go-autorest/logger
+Module: github.com/Azure/go-autorest/tracing
 
 
 
@@ -1490,7 +1490,7 @@ Module: github.com/Azure/go-autorest/tracing v0.6.0
 
 
 ===========================================================
-Module: github.com/opencontainers/image-spec v1.1.0-rc3
+Module: github.com/opencontainers/image-spec
 
 
 
@@ -1687,7 +1687,7 @@ Module: github.com/opencontainers/image-spec v1.1.0-rc3
 
 
 ===========================================================
-Module: github.com/docker/cli v20.10.12+incompatible
+Module: github.com/docker/cli
 
 
 
@@ -1884,8 +1884,8 @@ Module: github.com/docker/cli v20.10.12+incompatible
 
 
 ===========================================================
-Module: github.com/docker/docker v20.10.24+incompatible
-Module: github.com/moby/term v0.0.0-20210610120745-9d4ed1856297
+Module: github.com/docker/docker
+Module: github.com/moby/term
 
 
 
@@ -2082,8 +2082,8 @@ Module: github.com/moby/term v0.0.0-20210610120745-9d4ed1856297
 
 
 ===========================================================
-Module: github.com/opencontainers/go-digest v1.0.0
-Module: github.com/opencontainers/go-digest v1.0.0
+Module: github.com/opencontainers/go-digest
+Module: github.com/opencontainers/go-digest
 
 
 
@@ -2281,7 +2281,7 @@ Module: github.com/opencontainers/go-digest v1.0.0
 
 
 ===========================================================
-Module: github.com/containerd/containerd v1.5.18
+Module: github.com/containerd/containerd
 
 
 
@@ -2478,8 +2478,8 @@ Module: github.com/containerd/containerd v1.5.18
 
 
 ===========================================================
-Module: istio.io/api v0.0.0-20220602172134-34645c49f9d9 (imported as istio.io/api v0.0.0-20220602172134-34645c49f9d9)
-Module: istio.io/api v0.0.0-20220602172134-34645c49f9d9 (imported as istio.io/api )
+Module: istio.io/api (imported as istio.io/api)
+Module: istio.io/api (imported as istio.io/api)
 
 
 
@@ -2687,8 +2687,8 @@ Module: istio.io/api v0.0.0-20220602172134-34645c49f9d9 (imported as istio.io/ap
 
 
 ===========================================================
-Module: gopkg.in/yaml.v3 v3.0.1
-Module: gopkg.in/yaml.v3 v3.0.1
+Module: gopkg.in/yaml.v3
+Module: gopkg.in/yaml.v3
 
 
 
@@ -2744,7 +2744,7 @@ limitations under the License.
 
 
 ===========================================================
-Module: github.com/NYTimes/gziphandler v1.1.1
+Module: github.com/NYTimes/gziphandler
 
 
                                  Apache License
@@ -2951,44 +2951,44 @@ Module: github.com/NYTimes/gziphandler v1.1.1
 
 
 ===========================================================
-Module: ./third_party/forked/v2-buildpack-lifecycle  (imported as code.cloudfoundry.org/buildpackapplifecycle v0.0.0-00010101000000-000000000000)
-Module: ./third_party/forked/v2-buildpack-lifecycle  (imported as code.cloudfoundry.org/buildpackapplifecycle )
-Module: contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d
-Module: contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d
-Module: contrib.go.opencensus.io/exporter/prometheus v0.4.0
-Module: contrib.go.opencensus.io/exporter/prometheus v0.4.0
-Module: github.com/manifestival/client-go-client v0.5.0
-Module: github.com/manifestival/manifestival v0.7.1
-Module: github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
-Module: github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
-Module: github.com/modern-go/reflect2 v1.0.2
-Module: github.com/modern-go/reflect2 v1.0.2
-Module: github.com/prometheus/client_golang v1.11.1
-Module: github.com/prometheus/client_golang v1.11.1
-Module: github.com/prometheus/client_model v0.2.0
-Module: github.com/prometheus/client_model v0.2.0
-Module: github.com/prometheus/common v0.32.1
-Module: github.com/prometheus/common v0.32.1
-Module: github.com/prometheus/procfs v0.6.0
-Module: github.com/prometheus/procfs v0.6.0
-Module: github.com/prometheus/statsd_exporter v0.21.0
-Module: github.com/prometheus/statsd_exporter v0.21.0
-Module: go.opentelemetry.io/contrib v0.20.0
-Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0
-Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0
-Module: go.opentelemetry.io/otel v0.20.0
-Module: go.opentelemetry.io/otel/exporters/otlp v0.20.0
-Module: go.opentelemetry.io/otel/metric v0.20.0
-Module: go.opentelemetry.io/otel/sdk v0.20.0
-Module: go.opentelemetry.io/otel/sdk/export/metric v0.20.0
-Module: go.opentelemetry.io/otel/sdk/metric v0.20.0
-Module: go.opentelemetry.io/otel/trace v0.20.0
-Module: go.opentelemetry.io/proto/otlp v0.7.0
-Module: knative.dev/caching v0.0.0-20211206133228-c29dc56d8f03
-Module: knative.dev/operator v0.27.1-0.20211210172029-2f2c8b8fc83f
-Module: knative.dev/pkg v0.0.0-20220524202603-19adf798efb8 (imported as knative.dev/pkg v0.0.0-20220524202603-19adf798efb8)
-Module: knative.dev/pkg v0.0.0-20220524202603-19adf798efb8 (imported as knative.dev/pkg )
-Module: knative.dev/pkg v0.0.0-20220621173822-9c5a7317fa9d
+Module: ./third_party/forked/v2-buildpack-lifecycle (imported as code.cloudfoundry.org/buildpackapplifecycle)
+Module: ./third_party/forked/v2-buildpack-lifecycle (imported as code.cloudfoundry.org/buildpackapplifecycle)
+Module: contrib.go.opencensus.io/exporter/ocagent
+Module: contrib.go.opencensus.io/exporter/ocagent
+Module: contrib.go.opencensus.io/exporter/prometheus
+Module: contrib.go.opencensus.io/exporter/prometheus
+Module: github.com/manifestival/client-go-client
+Module: github.com/manifestival/manifestival
+Module: github.com/modern-go/concurrent
+Module: github.com/modern-go/concurrent
+Module: github.com/modern-go/reflect2
+Module: github.com/modern-go/reflect2
+Module: github.com/prometheus/client_golang
+Module: github.com/prometheus/client_golang
+Module: github.com/prometheus/client_model
+Module: github.com/prometheus/client_model
+Module: github.com/prometheus/common
+Module: github.com/prometheus/common
+Module: github.com/prometheus/procfs
+Module: github.com/prometheus/procfs
+Module: github.com/prometheus/statsd_exporter
+Module: github.com/prometheus/statsd_exporter
+Module: go.opentelemetry.io/contrib
+Module: go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
+Module: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
+Module: go.opentelemetry.io/otel
+Module: go.opentelemetry.io/otel/exporters/otlp
+Module: go.opentelemetry.io/otel/metric
+Module: go.opentelemetry.io/otel/sdk
+Module: go.opentelemetry.io/otel/sdk/export/metric
+Module: go.opentelemetry.io/otel/sdk/metric
+Module: go.opentelemetry.io/otel/trace
+Module: go.opentelemetry.io/proto/otlp
+Module: knative.dev/caching
+Module: knative.dev/operator
+Module: knative.dev/pkg (imported as knative.dev/pkg)
+Module: knative.dev/pkg (imported as knative.dev/pkg)
+Module: knative.dev/pkg
 
 
                                  Apache License
@@ -3195,7 +3195,7 @@ Module: knative.dev/pkg v0.0.0-20220621173822-9c5a7317fa9d
 
 
 ===========================================================
-Module: github.com/dimchansky/utfbom v1.1.1
+Module: github.com/dimchansky/utfbom
 
 
                                  Apache License
@@ -3402,21 +3402,21 @@ Module: github.com/dimchansky/utfbom v1.1.1
 
 
 ===========================================================
-Module: github.com/go-logr/logr v1.2.2
-Module: github.com/go-logr/logr v1.2.2
-Module: github.com/go-logr/zapr v1.2.2
-Module: github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
-Module: github.com/matttproud/golang_protobuf_extensions v1.0.4
-Module: gopkg.in/yaml.v2 v2.4.0
-Module: gopkg.in/yaml.v2 v2.4.0
-Module: sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30
-Module: sigs.k8s.io/controller-runtime v0.7.2
-Module: sigs.k8s.io/controller-runtime v0.8.0
-Module: sigs.k8s.io/controller-tools v0.6.2
-Module: sigs.k8s.io/kustomize/api v0.10.1
-Module: sigs.k8s.io/kustomize/kyaml v0.13.0
-Module: sigs.k8s.io/structured-merge-diff/v4 v4.2.1
-Module: sigs.k8s.io/structured-merge-diff/v4 v4.2.1
+Module: github.com/go-logr/logr
+Module: github.com/go-logr/logr
+Module: github.com/go-logr/zapr
+Module: github.com/matttproud/golang_protobuf_extensions
+Module: github.com/matttproud/golang_protobuf_extensions
+Module: gopkg.in/yaml.v2
+Module: gopkg.in/yaml.v2
+Module: sigs.k8s.io/apiserver-network-proxy/konnectivity-client
+Module: sigs.k8s.io/controller-runtime
+Module: sigs.k8s.io/controller-runtime
+Module: sigs.k8s.io/controller-tools
+Module: sigs.k8s.io/kustomize/api
+Module: sigs.k8s.io/kustomize/kyaml
+Module: sigs.k8s.io/structured-merge-diff/v4
+Module: sigs.k8s.io/structured-merge-diff/v4
 
 
                                  Apache License
@@ -3623,8 +3623,8 @@ Module: sigs.k8s.io/structured-merge-diff/v4 v4.2.1
 
 
 ===========================================================
-Module: gomodules.xyz/jsonpatch/v2 v2.2.0
-Module: gomodules.xyz/jsonpatch/v2 v2.2.0
+Module: gomodules.xyz/jsonpatch/v2
+Module: gomodules.xyz/jsonpatch/v2
 
 
                                  Apache License
@@ -3832,8 +3832,8 @@ Module: gomodules.xyz/jsonpatch/v2 v2.2.0
 
 
 ===========================================================
-Module: ./third_party/forked/cobra  (imported as github.com/spf13/cobra v1.3.0)
-Module: ./third_party/forked/cobra  (imported as github.com/spf13/cobra )
+Module: ./third_party/forked/cobra (imported as github.com/spf13/cobra)
+Module: ./third_party/forked/cobra (imported as github.com/spf13/cobra)
 
 
                                 Apache License
@@ -4013,7 +4013,7 @@ Module: ./third_party/forked/cobra  (imported as github.com/spf13/cobra )
 
 
 ===========================================================
-Module: github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+Module: github.com/grpc-ecosystem/go-grpc-prometheus
 
 
                  Apache License
@@ -4219,7 +4219,7 @@ Module: github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
    limitations under the License.
 
 ===========================================================
-Module: github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220228164355-396b2034c795
+Module: github.com/awslabs/amazon-ecr-credential-helper/ecr-login
 
 
 Apache License
@@ -4276,8 +4276,8 @@ Note: Other license terms may apply to certain, identified software files contai
 
 
 ===========================================================
-Module: github.com/docker/distribution v2.8.2+incompatible
-Module: github.com/docker/distribution v2.8.2+incompatible
+Module: github.com/docker/distribution
+Module: github.com/docker/distribution
 
 
 Apache License
@@ -4485,11 +4485,11 @@ Apache License
 
 
 ===========================================================
-Module: github.com/coreos/go-systemd/v22 v22.3.2
-Module: github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
-Module: github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
-Module: k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89
-Module: k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89
+Module: github.com/coreos/go-systemd/v22
+Module: github.com/golang/groupcache
+Module: github.com/golang/groupcache
+Module: k8s.io/klog/v2
+Module: k8s.io/klog/v2
 
 
 Apache License
@@ -4686,7 +4686,7 @@ third-party archives.
 
 
 ===========================================================
-Module: github.com/russross/blackfriday/v2 v2.1.0
+Module: github.com/russross/blackfriday/v2
 
 
 Blackfriday is distributed under the Simplified BSD License:
@@ -4721,7 +4721,7 @@ Blackfriday is distributed under the Simplified BSD License:
 
 
 ===========================================================
-Module: github.com/russross/blackfriday v1.6.0
+Module: github.com/russross/blackfriday
 
 
 Blackfriday is distributed under the Simplified BSD License:
@@ -4755,7 +4755,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/robfig/cron/v3 v3.0.1
+Module: github.com/robfig/cron/v3
 
 
 Copyright (C) 2012 Rob Figueiredo
@@ -4782,8 +4782,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/beorn7/perks v1.0.1
-Module: github.com/beorn7/perks v1.0.1
+Module: github.com/beorn7/perks
+Module: github.com/beorn7/perks
 
 
 Copyright (C) 2013 Blake Mizerany
@@ -4809,7 +4809,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/Masterminds/semver/v3 v3.0.3
+Module: github.com/Masterminds/semver/v3
 
 
 Copyright (C) 2014-2019, Matt Butcher and Matt Farina
@@ -4834,25 +4834,25 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
-Module: golang.org/x/crypto v0.1.0
-Module: golang.org/x/mod v0.5.1
-Module: golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4
-Module: golang.org/x/net v0.0.0-20220225172249-27dd8689420f
-Module: golang.org/x/net v0.7.0
-Module: golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
-Module: golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
-Module: golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-Module: golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
-Module: golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9
-Module: golang.org/x/sys v0.5.0
-Module: golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
-Module: golang.org/x/term v0.5.0
-Module: golang.org/x/text v0.3.7
-Module: golang.org/x/text v0.7.0
-Module: golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
-Module: golang.org/x/time v0.0.0-20220224211638-0e9765cccd65
-Module: golang.org/x/tools v0.1.12
+Module: github.com/liggitt/tabwriter
+Module: golang.org/x/crypto
+Module: golang.org/x/mod
+Module: golang.org/x/mod
+Module: golang.org/x/net
+Module: golang.org/x/net
+Module: golang.org/x/oauth2
+Module: golang.org/x/oauth2
+Module: golang.org/x/sync
+Module: golang.org/x/sync
+Module: golang.org/x/sys
+Module: golang.org/x/sys
+Module: golang.org/x/term
+Module: golang.org/x/term
+Module: golang.org/x/text
+Module: golang.org/x/text
+Module: golang.org/x/time
+Module: golang.org/x/time
+Module: golang.org/x/tools
 
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
@@ -4885,8 +4885,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/google/uuid v1.3.0
-Module: github.com/google/uuid v1.3.0
+Module: github.com/google/uuid
+Module: github.com/google/uuid
 
 
 Copyright (c) 2009,2014 Google Inc. All rights reserved.
@@ -4919,8 +4919,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: google.golang.org/api v0.70.0
-Module: google.golang.org/api v0.70.0
+Module: google.golang.org/api
+Module: google.golang.org/api
 
 
 Copyright (c) 2011 Google Inc. All rights reserved.
@@ -4953,7 +4953,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
+Module: github.com/munnerz/goautoneg
 
 
 Copyright (c) 2011, Open Knowledge Foundation Ltd.
@@ -4990,7 +4990,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/peterbourgon/diskv v2.0.1+incompatible
+Module: github.com/peterbourgon/diskv
 
 
 Copyright (c) 2011-2012 Peter Bourgon
@@ -5015,8 +5015,8 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/spf13/pflag v1.0.5
-Module: github.com/spf13/pflag v1.0.5
+Module: github.com/spf13/pflag
+Module: github.com/spf13/pflag
 
 
 Copyright (c) 2012 Alex Ogier. All rights reserved.
@@ -5050,7 +5050,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/golang-jwt/jwt/v4 v4.3.0
+Module: github.com/golang-jwt/jwt/v4
 
 
 Copyright (c) 2012 Dave Grijalva
@@ -5065,8 +5065,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Module: gopkg.in/inf.v0 v0.9.1
-Module: gopkg.in/inf.v0 v0.9.1
+Module: gopkg.in/inf.v0
+Module: gopkg.in/inf.v0
 
 
 Copyright (c) 2012 Péter Surányi. Portions Copyright (c) 2009 The Go
@@ -5100,7 +5100,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
+Module: github.com/PuerkitoBio/urlesc
 
 
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -5133,7 +5133,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/fsnotify/fsnotify v1.5.1
+Module: github.com/fsnotify/fsnotify
 
 
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -5167,7 +5167,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/klauspost/compress v1.14.4
+Module: github.com/klauspost/compress
 
 
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -5477,7 +5477,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Module: github.com/PuerkitoBio/purell v1.1.1
+Module: github.com/PuerkitoBio/purell
 
 
 Copyright (c) 2012, Martin Angers
@@ -5495,7 +5495,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 ===========================================================
-Module: github.com/emicklei/go-restful v2.16.0+incompatible
+Module: github.com/emicklei/go-restful
 
 
 Copyright (c) 2012,2013 Ernest Micklei
@@ -5522,7 +5522,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ===========================================================
-Module: github.com/sergi/go-diff v1.1.0
+Module: github.com/sergi/go-diff
 
 
 Copyright (c) 2012-2016 The go-diff Authors. All rights reserved.
@@ -5548,7 +5548,7 @@ DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/gorilla/mux v1.8.0
+Module: github.com/gorilla/mux
 
 
 Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
@@ -5581,8 +5581,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/imdario/mergo v0.3.12
-Module: github.com/imdario/mergo v0.3.12
+Module: github.com/imdario/mergo
+Module: github.com/imdario/mergo
 
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
@@ -5616,8 +5616,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/kelseyhightower/envconfig v1.4.0
-Module: github.com/kelseyhightower/envconfig v1.4.0
+Module: github.com/kelseyhightower/envconfig
+Module: github.com/kelseyhightower/envconfig
 
 
 Copyright (c) 2013 Kelsey Hightower
@@ -5642,7 +5642,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/pmezard/go-difflib v1.0.0
+Module: github.com/pmezard/go-difflib
 
 
 Copyright (c) 2013, Patrick Mezard
@@ -5675,8 +5675,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/gogo/protobuf v1.3.2
-Module: github.com/gogo/protobuf v1.3.2
+Module: github.com/gogo/protobuf
+Module: github.com/gogo/protobuf
 
 
 Copyright (c) 2013, The GoGo Authors. All rights reserved.
@@ -5717,10 +5717,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/evanphx/json-patch v4.12.0+incompatible
-Module: github.com/evanphx/json-patch v4.12.0+incompatible
-Module: github.com/evanphx/json-patch/v5 v5.6.0
-Module: github.com/evanphx/json-patch/v5 v5.6.0
+Module: github.com/evanphx/json-patch
+Module: github.com/evanphx/json-patch
+Module: github.com/evanphx/json-patch/v5
+Module: github.com/evanphx/json-patch/v5
 
 
 Copyright (c) 2014, Evan Phoenix
@@ -5751,7 +5751,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/go-errors/errors v1.0.1
+Module: github.com/go-errors/errors
 
 
 Copyright (c) 2015 Conrad Irwin <conrad@bugsnag.com>
@@ -5764,7 +5764,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Module: github.com/vbatts/tar-split v0.11.2
+Module: github.com/vbatts/tar-split
 
 
 Copyright (c) 2015 Vincent Batts, Raleigh, NC, USA
@@ -5798,8 +5798,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/pkg/errors v0.9.1
-Module: github.com/pkg/errors v0.9.1
+Module: github.com/pkg/errors
+Module: github.com/pkg/errors
 
 
 Copyright (c) 2015, Dave Cheney <dave@cheney.net>
@@ -5828,8 +5828,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/grpc-ecosystem/grpc-gateway v1.16.0
-Module: github.com/grpc-ecosystem/grpc-gateway v1.16.0
+Module: github.com/grpc-ecosystem/grpc-gateway
+Module: github.com/grpc-ecosystem/grpc-gateway
 
 
 Copyright (c) 2015, Gengo, Inc.
@@ -5862,7 +5862,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/gofrs/flock v0.8.1
+Module: github.com/gofrs/flock
 
 
 Copyright (c) 2015-2020, Tim Heckman
@@ -5895,8 +5895,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/cespare/xxhash/v2 v2.1.1
-Module: github.com/cespare/xxhash/v2 v2.1.2
+Module: github.com/cespare/xxhash/v2
+Module: github.com/cespare/xxhash/v2
 
 
 Copyright (c) 2016 Caleb Spare
@@ -5924,7 +5924,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/docker/docker-credential-helpers v0.6.4
+Module: github.com/docker/docker-credential-helpers
 
 
 Copyright (c) 2016 David Calavera
@@ -5950,7 +5950,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/felixge/httpsnoop v1.0.1
+Module: github.com/felixge/httpsnoop
 
 
 Copyright (c) 2016 Felix Geisendörfer (felix@debuggable.com)
@@ -5975,7 +5975,7 @@ Copyright (c) 2016 Felix Geisendörfer (felix@debuggable.com)
 
 
 ===========================================================
-Module: github.com/mailru/easyjson v0.7.7
+Module: github.com/mailru/easyjson
 
 
 Copyright (c) 2016 Mail.Ru Group
@@ -5988,8 +5988,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Module: go.uber.org/atomic v1.9.0
-Module: go.uber.org/atomic v1.9.0
+Module: go.uber.org/atomic
+Module: go.uber.org/atomic
 
 
 Copyright (c) 2016 Uber Technologies, Inc.
@@ -6014,8 +6014,8 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: go.uber.org/zap v1.19.1
-Module: go.uber.org/zap v1.19.1
+Module: go.uber.org/zap
+Module: go.uber.org/zap
 
 
 Copyright (c) 2016-2017 Uber Technologies, Inc.
@@ -6040,7 +6040,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5
+Module: go.starlark.net
 
 
 Copyright (c) 2017 The Bazel Authors.  All rights reserved.
@@ -6075,9 +6075,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/google/go-cmp v0.3.0 (imported as github.com/google/go-cmp v0.5.7)
-Module: github.com/google/go-cmp v0.3.0 (imported as github.com/google/go-cmp )
-Module: github.com/google/go-cmp v0.5.7
+Module: github.com/google/go-cmp (imported as github.com/google/go-cmp)
+Module: github.com/google/go-cmp (imported as github.com/google/go-cmp)
+Module: github.com/google/go-cmp
 
 
 Copyright (c) 2017 The Go Authors. All rights reserved.
@@ -6110,8 +6110,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: go.uber.org/automaxprocs v1.4.0
-Module: go.uber.org/automaxprocs v1.4.0
+Module: go.uber.org/automaxprocs
+Module: go.uber.org/automaxprocs
 
 
 Copyright (c) 2017 Uber Technologies, Inc.
@@ -6135,7 +6135,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ===========================================================
-Module: go.uber.org/multierr v1.6.0
+Module: go.uber.org/multierr
 
 
 Copyright (c) 2017 Uber Technologies, Inc.
@@ -6160,7 +6160,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: go.uber.org/multierr v1.7.0
+Module: go.uber.org/multierr
 
 
 Copyright (c) 2017-2021 Uber Technologies, Inc.
@@ -6185,8 +6185,8 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: google.golang.org/protobuf v1.27.1
-Module: google.golang.org/protobuf v1.28.0
+Module: google.golang.org/protobuf
+Module: google.golang.org/protobuf
 
 
 Copyright (c) 2018 The Go Authors. All rights reserved.
@@ -6219,7 +6219,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+Module: golang.org/x/xerrors
 
 
 Copyright (c) 2019 The Go Authors. All rights reserved.
@@ -6252,7 +6252,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/mattn/go-isatty v0.0.14
+Module: github.com/mattn/go-isatty
 
 
 Copyright (c) Yasuhiro MATSUMOTO <mattn.jp@gmail.com>
@@ -6267,8 +6267,8 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 ===========================================================
-Module: github.com/golang/protobuf v1.5.2
-Module: github.com/golang/protobuf v1.5.2
+Module: github.com/golang/protobuf
+Module: github.com/golang/protobuf
 
 
 Copyright 2010 The Go Authors.  All rights reserved.
@@ -6302,7 +6302,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/inconshreveable/mousetrap v1.0.0
+Module: github.com/inconshreveable/mousetrap
 
 
 Copyright 2014 Alan Shreve
@@ -6321,7 +6321,7 @@ limitations under the License.
 
 
 ===========================================================
-Module: github.com/jmespath/go-jmespath v0.4.0
+Module: github.com/jmespath/go-jmespath
 
 
 Copyright 2015 James Saryerwinnie
@@ -6340,7 +6340,7 @@ limitations under the License.
 
 
 ===========================================================
-Module: github.com/googleapis/gax-go/v2 v2.1.1
+Module: github.com/googleapis/gax-go/v2
 
 
 Copyright 2016, Google Inc.
@@ -6373,7 +6373,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
+Module: github.com/gregjones/httpcache
 
 
 Copyright © 2012 Greg Jones (greg.jones@gmail.com)
@@ -6385,8 +6385,8 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ===========================================================
-Module: sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6
-Module: sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
+Module: sigs.k8s.io/json
+Module: sigs.k8s.io/json
 
 
 Files other than internal/golang/* licensed under:
@@ -6630,8 +6630,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/davecgh/go-spew v1.1.1
-Module: github.com/davecgh/go-spew v1.1.1
+Module: github.com/davecgh/go-spew
+Module: github.com/davecgh/go-spew
 
 
 ISC License
@@ -6652,8 +6652,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ===========================================================
-Module: github.com/blendle/zapdriver v1.3.1
-Module: github.com/blendle/zapdriver v1.3.1
+Module: github.com/blendle/zapdriver
+Module: github.com/blendle/zapdriver
 
 
 ISC License
@@ -6674,7 +6674,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 
 ===========================================================
-Module: github.com/stretchr/testify v1.7.0
+Module: github.com/stretchr/testify
 
 
 MIT License
@@ -6701,8 +6701,8 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/json-iterator/go v1.1.12
-Module: github.com/json-iterator/go v1.1.12
+Module: github.com/json-iterator/go
+Module: github.com/json-iterator/go
 
 
 MIT License
@@ -6729,7 +6729,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/segmentio/textio v1.2.0
+Module: github.com/segmentio/textio
 
 
 MIT License
@@ -6756,7 +6756,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/josharian/intern v1.0.0
+Module: github.com/josharian/intern
 
 
 MIT License
@@ -6783,8 +6783,8 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/go-kit/log v0.1.0
-Module: github.com/go-kit/log v0.1.0
+Module: github.com/go-kit/log
+Module: github.com/go-kit/log
 
 
 MIT License
@@ -6811,8 +6811,8 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/hashicorp/golang-lru v0.5.4
-Module: github.com/hashicorp/golang-lru v0.5.4
+Module: github.com/hashicorp/golang-lru
+Module: github.com/hashicorp/golang-lru
 
 
 Mozilla Public License, version 2.0
@@ -7180,8 +7180,8 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 
 ===========================================================
-Module: github.com/hashicorp/go-multierror v1.1.1
-Module: github.com/hashicorp/go-multierror v1.1.1
+Module: github.com/hashicorp/go-multierror
+Module: github.com/hashicorp/go-multierror
 
 
 Mozilla Public License, version 2.0
@@ -7540,9 +7540,9 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 
 
 ===========================================================
-Module: github.com/hashicorp/errwrap v1.0.0
-Module: github.com/hashicorp/errwrap v1.0.0
-Module: github.com/hashicorp/go-version v1.3.0
+Module: github.com/hashicorp/errwrap
+Module: github.com/hashicorp/errwrap
+Module: github.com/hashicorp/go-version
 
 
 Mozilla Public License, version 2.0
@@ -7902,9 +7902,9 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 
 
 ===========================================================
-Module: github.com/blang/semver v3.5.1+incompatible
-Module: github.com/blang/semver/v4 v4.0.0
-Module: github.com/blang/semver/v4 v4.0.0
+Module: github.com/blang/semver
+Module: github.com/blang/semver/v4
+Module: github.com/blang/semver/v4
 
 
 The MIT License
@@ -7932,7 +7932,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/fatih/color v1.13.0
+Module: github.com/fatih/color
 
 
 The MIT License (MIT)
@@ -7958,7 +7958,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/mitchellh/go-homedir v1.1.0
+Module: github.com/mitchellh/go-homedir
 
 
 The MIT License (MIT)
@@ -7985,7 +7985,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/mitchellh/go-wordwrap v1.0.0
+Module: github.com/mitchellh/go-wordwrap
 
 
 The MIT License (MIT)
@@ -8012,7 +8012,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: gopkg.in/natefinch/lumberjack.v2 v2.0.0
+Module: gopkg.in/natefinch/lumberjack.v2
 
 
 The MIT License (MIT)
@@ -8038,8 +8038,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ===========================================================
-Module: sigs.k8s.io/yaml v1.3.0
-Module: sigs.k8s.io/yaml v1.3.0
+Module: sigs.k8s.io/yaml
+Module: sigs.k8s.io/yaml
 
 
 The MIT License (MIT)
@@ -8095,7 +8095,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
-Module: github.com/sirupsen/logrus v1.8.1
+Module: github.com/sirupsen/logrus
 
 
 The MIT License (MIT)
@@ -8122,7 +8122,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/MakeNowJust/heredoc v0.0.0-20171113091838-e9091a26100e
+Module: github.com/MakeNowJust/heredoc
 
 
 The MIT License (MIT)
@@ -8149,7 +8149,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1
+Module: github.com/Azure/go-ansiterm
 
 
 The MIT License (MIT)
@@ -8176,7 +8176,7 @@ THE SOFTWARE.
 
 
 ===========================================================
-Module: github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
+Module: github.com/sabhiram/go-gitignore
 
 
 The MIT License (MIT)
@@ -8204,8 +8204,8 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/go-logfmt/logfmt v0.5.0
-Module: github.com/go-logfmt/logfmt v0.5.0
+Module: github.com/go-logfmt/logfmt
+Module: github.com/go-logfmt/logfmt
 
 
 The MIT License (MIT)
@@ -8233,7 +8233,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/alessio/shellescape v1.4.1
+Module: github.com/alessio/shellescape
 
 
 The MIT License (MIT)
@@ -8260,7 +8260,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/mattn/go-colorable v0.1.11
+Module: github.com/mattn/go-colorable
 
 
 The MIT License (MIT)
@@ -8287,7 +8287,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/gobuffalo/flect v0.2.4
+Module: github.com/gobuffalo/flect
 
 
 The MIT License (MIT)
@@ -8314,7 +8314,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/Azure/azure-sdk-for-go v63.3.0+incompatible
+Module: github.com/Azure/azure-sdk-for-go
 
 
 The MIT License (MIT)
@@ -8341,7 +8341,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00
+Module: github.com/monochromegane/go-gitignore
 
 
 The MIT License (MIT)
@@ -8368,7 +8368,7 @@ SOFTWARE.
 
 
 ===========================================================
-Module: github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca
+Module: github.com/xlab/treeprint
 
 
 The MIT License (MIT)

--- a/third_party/forked/gomod-collector/licenses.go
+++ b/third_party/forked/gomod-collector/licenses.go
@@ -174,7 +174,19 @@ func (lc LicenseCollection) GroupedEntries() (string, error) {
 		fmt.Fprintln(w, "===========================================================")
 
 		for _, license := range licenses {
-			fmt.Fprintln(w, "Module:", license.Mod.Description())
+			modText := ""
+			switch {
+			case license.Mod.Module == "":
+				modText = license.Mod.ModuleVersion
+
+			case license.Mod.Replace != "":
+				modText = fmt.Sprintf("%s (imported as %s)", license.Mod.Replace, license.Mod.Module)
+
+			default:
+				modText = license.Mod.Module
+			}
+
+			fmt.Fprintln(w, "Module:", modText)
 		}
 		fmt.Fprintln(w)
 		fmt.Fprintln(w)

--- a/third_party/forked/gomod-collector/modules.go
+++ b/third_party/forked/gomod-collector/modules.go
@@ -64,7 +64,7 @@ func (m *Module) Source() string {
 
 func (a *Module) IsLessThan(b Module) bool {
 	return a.RealModule() < b.RealModule() ||
-	a.RealModule() == b.RealModule() && a.RealVersion() < b.RealVersion()
+		a.RealModule() == b.RealModule() && a.RealVersion() < b.RealVersion()
 }
 
 func CollectVendoredModules(projectDirectories []string) ([]Module, error) {


### PR DESCRIPTION
These versions are preventing dependabot from working correctly and with Kf being fully OSS the licenses can be pulled from the source releases.
