### PR TITLE
fix: set-env may behave incorrectly if variables provided are lowercase

### DIFF
--- a/pkg/kf/commands/apps/set_env.go
+++ b/pkg/kf/commands/apps/set_env.go
@@ -17,6 +17,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	v1alpha1 "github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
@@ -64,7 +65,7 @@ func NewSetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
 			value := args[2]
 
 			toSet := []corev1.EnvVar{
-				{Name: name, Value: value},
+				{Name: strings.ToUpper(name), Value: value},
 			}
 
 			app, err := client.Transform(cmd.Context(), p.Space, appName, func(app *v1alpha1.App) error {


### PR DESCRIPTION
e.g. `kf set-env FOO` followed by `kf set-env foo` may add both to the environment even though they will be interpreted as the same var by kubernetes.