### PR TITLE
Removed duplicate MEMORY_LIMIT entry from App reconciler.

### DIFF
--- a/pkg/reconciler/app/resources/env.go
+++ b/pkg/reconciler/app/resources/env.go
@@ -274,12 +274,6 @@ func getRuntimeEnvVars(runtime EnvRuntime) runtimeEnvVars {
 			compute:     injectedSecretRef(cfutil.DatabaseURLEnvVarName, true),
 			runtime:     CFRunning | CFTask,
 		},
-		{
-			name:        "MEMORY_LIMIT",
-			description: "The maximum amount of memory in MB the App can consume.",
-			compute:     staticValue("$(MEMORY_LIMIT)M"),
-			runtime:     CFRunning | CFStaging | CFTask,
-		},
 	}
 
 	var out []runtimeEnvVar

--- a/pkg/reconciler/app/resources/env_test.go
+++ b/pkg/reconciler/app/resources/env_test.go
@@ -113,7 +113,6 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
-				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT)M"},
 			},
 		},
 		"staging app": {
@@ -154,7 +153,6 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(false),
 					},
 				}},
-				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT)M"},
 			},
 		},
 		"task app": {
@@ -211,7 +209,6 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
-				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT)M"},
 			},
 		},
 	}

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_buildpack_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_buildpack_build.golden
@@ -139,10 +139,6 @@
                 }
             },
             {
-                "name": "MEMORY_LIMIT",
-                "value": "$(MEMORY_LIMIT)M"
-            },
-            {
                 "name": "some-env-var",
                 "value": "cool-env-value"
             }

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_cascading_env_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_cascading_env_build.golden
@@ -144,10 +144,6 @@
                 }
             },
             {
-                "name": "MEMORY_LIMIT",
-                "value": "$(MEMORY_LIMIT)M"
-            },
-            {
                 "name": "CASCADE",
                 "value": "build"
             }

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_empty_app_and_space_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_empty_app_and_space_build.golden
@@ -123,10 +123,6 @@
                         "optional": false
                     }
                 }
-            },
-            {
-                "name": "MEMORY_LIMIT",
-                "value": "$(MEMORY_LIMIT)M"
             }
         ]
     },

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_empty_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_empty_taskrun.golden
@@ -158,10 +158,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_disabled_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_disabled_taskrun.golden
@@ -167,10 +167,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_start_command_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_start_command_taskrun.golden
@@ -171,10 +171,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {},

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_taskrun.golden
@@ -170,10 +170,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {},

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_timeout_taskrun.golden
@@ -159,10 +159,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unlimited_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unlimited_timeout_taskrun.golden
@@ -159,10 +159,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unset_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unset_timeout_taskrun.golden
@@ -158,10 +158,6 @@
                                     "optional": true
                                 }
                             }
-                        },
-                        {
-                            "name": "MEMORY_LIMIT",
-                            "value": "$(MEMORY_LIMIT)M"
                         }
                     ],
                     "resources": {}


### PR DESCRIPTION

<!-- Include the issue number below -->

## Proposed Changes
* Remove the second entry for `MEMORY_LIMIT` created for container environment variables by App's reconciler.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Fixed: issue with duplicate entries produced for MEMORY_LIMIT environment variable in App's reconciler.

```
