### PR TITLE
Added "M" suffix to MEMORY_LIMIT environment variable.

### DIFF
--- a/pkg/reconciler/app/resources/env.go
+++ b/pkg/reconciler/app/resources/env.go
@@ -199,7 +199,7 @@ func getRuntimeEnvVars(runtime EnvRuntime) runtimeEnvVars {
 			runtime:     CFRunning,
 		},
 		{
-			name:        "MEMORY_LIMIT",
+			name:        "MEMORY_LIMIT_IN_MB",
 			description: "The maximum amount of memory in MB the App can consume.",
 			compute: func(app *v1alpha1.App) corev1.EnvVar {
 				return corev1.EnvVar{
@@ -245,7 +245,7 @@ func getRuntimeEnvVars(runtime EnvRuntime) runtimeEnvVars {
 				// add values that can only be computed at runtime
 				appValues["limits"] = limits{
 					Disk:   "$(DISK_LIMIT)",
-					Memory: "$(MEMORY_LIMIT)",
+					Memory: "$(MEMORY_LIMIT_IN_MB)",
 				}
 
 				valueBytes, _ := json.Marshal(appValues)
@@ -254,7 +254,7 @@ func getRuntimeEnvVars(runtime EnvRuntime) runtimeEnvVars {
 				// Replace limit values with unquoted env vars.
 				// This ensures that disk and mem on the "limits" field are correctly represented in the JSON
 				// as ints instead of strings.
-				jsonWithInts := strings.ReplaceAll(jsonStr, `"$(MEMORY_LIMIT)"`, "$(MEMORY_LIMIT)")
+				jsonWithInts := strings.ReplaceAll(jsonStr, `"$(MEMORY_LIMIT_IN_MB)"`, "$(MEMORY_LIMIT_IN_MB)")
 				jsonWithInts = strings.ReplaceAll(jsonWithInts, `"$(DISK_LIMIT)"`, "$(DISK_LIMIT)")
 				return corev1.EnvVar{
 					Value: string(jsonWithInts),
@@ -273,6 +273,12 @@ func getRuntimeEnvVars(runtime EnvRuntime) runtimeEnvVars {
 			description: "The first URI found in a VCAP_SERVICES credential.",
 			compute:     injectedSecretRef(cfutil.DatabaseURLEnvVarName, true),
 			runtime:     CFRunning | CFTask,
+		},
+		{
+			name:        "MEMORY_LIMIT",
+			description: "The maximum amount of memory the App can consume.",
+			compute:     staticValue("$(MEMORY_LIMIT_IN_MB)M"),
+			runtime:     CFRunning | CFStaging | CFTask,
 		},
 	}
 

--- a/pkg/reconciler/app/resources/env_test.go
+++ b/pkg/reconciler/app/resources/env_test.go
@@ -113,7 +113,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
-                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
+				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 		"staging app": {
@@ -154,7 +154,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(false),
 					},
 				}},
-                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
+				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 		"task app": {
@@ -211,7 +211,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
-                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
+				{Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 	}

--- a/pkg/reconciler/app/resources/env_test.go
+++ b/pkg/reconciler/app/resources/env_test.go
@@ -80,7 +80,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				{Name: "INSTANCE_GUID", Value: "$(CF_INSTANCE_GUID)"},
 				{Name: "CF_INSTANCE_INDEX", Value: "0"},
 				{Name: "INSTANCE_INDEX", Value: "$(CF_INSTANCE_INDEX)"},
-				{Name: "MEMORY_LIMIT", ValueFrom: &corev1.EnvVarSource{
+				{Name: "MEMORY_LIMIT_IN_MB", ValueFrom: &corev1.EnvVarSource{
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						Divisor:  memoryDivisor,
 						Resource: "limits.memory",
@@ -94,7 +94,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				}},
 				{Name: "LANG", Value: "en_US.UTF-8"},
 				// json.Marshal writes values in sorted key order
-				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
+				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT_IN_MB)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
 				{Name: "VCAP_SERVICES", ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						Key: "VCAP_SERVICES",
@@ -113,6 +113,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
+                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 		"staging app": {
@@ -129,7 +130,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				{Name: "VCAP_APP_HOST", Value: "$(CF_INSTANCE_IP)"},
 				{Name: "CF_INSTANCE_PORT", Value: "9999"},
 				{Name: "CF_INSTANCE_ADDR", Value: "$(CF_INSTANCE_IP):$(CF_INSTANCE_PORT)"},
-				{Name: "MEMORY_LIMIT", ValueFrom: &corev1.EnvVarSource{
+				{Name: "MEMORY_LIMIT_IN_MB", ValueFrom: &corev1.EnvVarSource{
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						Divisor:  memoryDivisor,
 						Resource: "limits.memory",
@@ -143,7 +144,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				}},
 				{Name: "LANG", Value: "en_US.UTF-8"},
 				// json.Marshal writes values in sorted key order
-				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
+				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT_IN_MB)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
 				{Name: "VCAP_SERVICES", ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						Key: "VCAP_SERVICES",
@@ -153,6 +154,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(false),
 					},
 				}},
+                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 		"task app": {
@@ -176,7 +178,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 					},
 				}},
 				{Name: "INSTANCE_GUID", Value: "$(CF_INSTANCE_GUID)"},
-				{Name: "MEMORY_LIMIT", ValueFrom: &corev1.EnvVarSource{
+				{Name: "MEMORY_LIMIT_IN_MB", ValueFrom: &corev1.EnvVarSource{
 					ResourceFieldRef: &corev1.ResourceFieldSelector{
 						Divisor:  memoryDivisor,
 						Resource: "limits.memory",
@@ -190,7 +192,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 				}},
 				{Name: "LANG", Value: "en_US.UTF-8"},
 				// json.Marshal writes values in sorted key order
-				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
+				{Name: "VCAP_APPLICATION", Value: `{"application_id":"12345","application_name":"my-app","application_uris":["my-app.example.com"],"limits":{"disk":$(DISK_LIMIT),"mem":$(MEMORY_LIMIT_IN_MB)},"name":"my-app","process_id":"12345","process_type":"web","space_name":"my-ns","uris":["my-app.example.com"]}`},
 				{Name: "VCAP_SERVICES", ValueFrom: &corev1.EnvVarSource{
 					SecretKeyRef: &corev1.SecretKeySelector{
 						Key: "VCAP_SERVICES",
@@ -209,6 +211,7 @@ func TestBuildRuntimeEnvVars(t *testing.T) {
 						Optional: ptr.Bool(true),
 					},
 				}},
+                                {Name: "MEMORY_LIMIT", Value: "$(MEMORY_LIMIT_IN_MB)M"},
 			},
 		},
 	}

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_buildpack_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_buildpack_build.golden
@@ -103,7 +103,7 @@
                 "value": "$(CF_INSTANCE_IP):$(CF_INSTANCE_PORT)"
             },
             {
-                "name": "MEMORY_LIMIT",
+                "name": "MEMORY_LIMIT_IN_MB",
                 "valueFrom": {
                     "resourceFieldRef": {
                         "resource": "limits.memory",
@@ -126,7 +126,7 @@
             },
             {
                 "name": "VCAP_APPLICATION",
-                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
+                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
             },
             {
                 "name": "VCAP_SERVICES",
@@ -137,6 +137,10 @@
                         "optional": false
                     }
                 }
+            },
+            {
+                "name": "MEMORY_LIMIT",
+                "value": "$(MEMORY_LIMIT_IN_MB)M"
             },
             {
                 "name": "some-env-var",

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_cascading_env_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_cascading_env_build.golden
@@ -108,7 +108,7 @@
                 "value": "$(CF_INSTANCE_IP):$(CF_INSTANCE_PORT)"
             },
             {
-                "name": "MEMORY_LIMIT",
+                "name": "MEMORY_LIMIT_IN_MB",
                 "valueFrom": {
                     "resourceFieldRef": {
                         "resource": "limits.memory",
@@ -131,7 +131,7 @@
             },
             {
                 "name": "VCAP_APPLICATION",
-                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
+                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
             },
             {
                 "name": "VCAP_SERVICES",
@@ -142,6 +142,10 @@
                         "optional": false
                     }
                 }
+            },
+            {
+                "name": "MEMORY_LIMIT",
+                "value": "$(MEMORY_LIMIT_IN_MB)M"
             },
             {
                 "name": "CASCADE",

--- a/pkg/reconciler/app/resources/testdata/golden/testmakesource_empty_app_and_space_build.golden
+++ b/pkg/reconciler/app/resources/testdata/golden/testmakesource_empty_app_and_space_build.golden
@@ -89,7 +89,7 @@
                 "value": "$(CF_INSTANCE_IP):$(CF_INSTANCE_PORT)"
             },
             {
-                "name": "MEMORY_LIMIT",
+                "name": "MEMORY_LIMIT_IN_MB",
                 "valueFrom": {
                     "resourceFieldRef": {
                         "resource": "limits.memory",
@@ -112,7 +112,7 @@
             },
             {
                 "name": "VCAP_APPLICATION",
-                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
+                "value": "{\"application_id\":\"\",\"application_name\":\"mybuildpackapp\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"mybuildpackapp\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"myspace\",\"uris\":[]}"
             },
             {
                 "name": "VCAP_SERVICES",
@@ -123,6 +123,10 @@
                         "optional": false
                     }
                 }
+            },
+            {
+                "name": "MEMORY_LIMIT",
+                "value": "$(MEMORY_LIMIT_IN_MB)M"
             }
         ]
     },

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_empty_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_empty_taskrun.golden
@@ -114,7 +114,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -137,7 +137,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -158,6 +158,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_disabled_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_disabled_taskrun.golden
@@ -123,7 +123,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -146,7 +146,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -167,6 +167,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_start_command_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_start_command_taskrun.golden
@@ -127,7 +127,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -150,7 +150,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -171,6 +171,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {},

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_nfs_volumes_enabled_taskrun.golden
@@ -126,7 +126,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -149,7 +149,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -170,6 +170,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {},

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_timeout_taskrun.golden
@@ -115,7 +115,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -138,7 +138,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -159,6 +159,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unlimited_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unlimited_timeout_taskrun.golden
@@ -115,7 +115,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -138,7 +138,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -159,6 +159,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {}

--- a/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unset_timeout_taskrun.golden
+++ b/pkg/reconciler/task/resources/testdata/golden/testmaketaskrun_unset_timeout_taskrun.golden
@@ -114,7 +114,7 @@
                             "value": "$(CF_INSTANCE_GUID)"
                         },
                         {
-                            "name": "MEMORY_LIMIT",
+                            "name": "MEMORY_LIMIT_IN_MB",
                             "valueFrom": {
                                 "resourceFieldRef": {
                                     "resource": "limits.memory",
@@ -137,7 +137,7 @@
                         },
                         {
                             "name": "VCAP_APPLICATION",
-                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
+                            "value": "{\"application_id\":\"\",\"application_name\":\"\",\"application_uris\":[],\"limits\":{\"disk\":$(DISK_LIMIT),\"mem\":$(MEMORY_LIMIT_IN_MB)},\"name\":\"\",\"process_id\":\"\",\"process_type\":\"web\",\"space_name\":\"\",\"uris\":[]}"
                         },
                         {
                             "name": "VCAP_SERVICES",
@@ -158,6 +158,10 @@
                                     "optional": true
                                 }
                             }
+                        },
+                        {
+                            "name": "MEMORY_LIMIT",
+                            "value": "$(MEMORY_LIMIT_IN_MB)M"
                         }
                     ],
                     "resources": {}


### PR DESCRIPTION
## Proposed Changes
* Restore "M" suffix of MEMORY_LIMIT variable value deleted by #1053

## Release Notes
```release-note
Fixes: issue with missing "M" suffix in MEMORY_LIMIT variable value
```
