### PR TITLE
Revert PR: https://github.com/google/kf/pull/1049

### DIFF
--- a/pkg/kf/commands/apps/set_env.go
+++ b/pkg/kf/commands/apps/set_env.go
@@ -17,7 +17,6 @@ package apps
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	v1alpha1 "github.com/google/kf/v2/pkg/apis/kf/v1alpha1"
@@ -65,7 +64,7 @@ func NewSetEnvCommand(p *config.KfParams, client apps.Client) *cobra.Command {
 			value := args[2]
 
 			toSet := []corev1.EnvVar{
-				{Name: strings.ToUpper(name), Value: value},
+				{Name: name, Value: value},
 			}
 
 			app, err := client.Transform(cmd.Context(), p.Space, appName, func(app *v1alpha1.App) error {


### PR DESCRIPTION
PR: https://github.com/google/kf/pull/1049 is breaking .net Core applications, where lower case environment variables are expected. Proposing this change, before better fix is available

<!-- Include the issue number below -->
Fixes #

## Proposed Changes

*
*
*

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note

```
