### PR TITLE
Upgraded server-side dependencies: Tekton, ASM, Config Connector

### DIFF
--- a/cmd/generate-release/scripts/install-asm.bash
+++ b/cmd/generate-release/scripts/install-asm.bash
@@ -33,7 +33,7 @@ else
     echo "gcloud CLI is already available, skipping installation"
 fi
 
-curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_1.17 >asmcli
+curl https://storage.googleapis.com/csm-artifacts/asm/asmcli_1.19 >asmcli
 chmod +x asmcli
 
 gcloud container clusters get-credentials "${CLUSTER_NAME}" \
@@ -67,5 +67,5 @@ else
     kubectl label namespace asm-gateways istio-injection- istio.io/rev="$REVISION" --overwrite
 fi
 
-# https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/tree/release-1.17/samples/gateways/istio-ingressgateway
+# https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/tree/release-1.19/samples/gateways/istio-ingressgateway
 kubectl apply -n asm-gateways -f out/samples/gateways/istio-ingressgateway/

--- a/pkg/kf/commands/dependencies/dependencies.go
+++ b/pkg/kf/commands/dependencies/dependencies.go
@@ -108,7 +108,7 @@ func newDependencies() []dependency {
 			// dep matrix right now is fairly impossible. To ensure we still
 			// testing against the right version though, we are going to hard
 			// code this.
-			ResolveVersion: staticVersionResolver("v0.47.1"),
+			ResolveVersion: staticVersionResolver("v0.53.2"),
 			ResolveURL: func(version string) (string, error) {
 				const URL = "https://github.com/tektoncd/pipeline/releases/download/%s/release.yaml"
 				return fmt.Sprintf(URL, version), nil
@@ -120,7 +120,7 @@ func newDependencies() []dependency {
 			InfoURL:    "https://cloud.google.com/service-mesh/docs/gke-install-overview",
 			// This version is fetched from the asmcli script. It needs to be
 			// updated by hand until we have a programtic way to fetch it.
-			ResolveVersion: staticVersionResolver("1.17.4-asm.2+config1"),
+			ResolveVersion: staticVersionResolver("1.19.3-asm.4+config1"),
 			ResolveURL: func(version string) (string, error) {
 				const URL = "https://github.com/GoogleCloudPlatform/anthos-service-mesh-packages/releases/tag/%s"
 				return fmt.Sprintf(URL, version), nil
@@ -132,7 +132,7 @@ func newDependencies() []dependency {
 			InfoURL:    "https://cloud.google.com//config-connector/docs/how-to/advanced-install",
 			// This version needs to be updated by hand until we have a
 			// programtic way to fetch it.
-			ResolveVersion: staticVersionResolver("1.105.0"),
+			ResolveVersion: staticVersionResolver("1.111.0"),
 			ResolveURL: func(version string) (string, error) {
 				const URL = "gs://configconnector-operator/%s/release-bundle.tar.gz"
 				return fmt.Sprintf(URL, version), nil


### PR DESCRIPTION
<!-- Include the issue number below -->
## Proposed Changes
* Upgraded dependencies - Tekton to 0.53.2, ASM to 1.19 and Config Connector to 1.111

## Release Notes
```release-note
CHANGED Server-side dependencies - Tekton to 0.53.2, ASM to 1.19 and Config Connector to 1.111
```
