### PR TITLE
Updated Tekton dependency to the newest patch for current LTS version

### DIFF
--- a/pkg/kf/commands/dependencies/dependencies.go
+++ b/pkg/kf/commands/dependencies/dependencies.go
@@ -108,7 +108,7 @@ func newDependencies() []dependency {
 			// dep matrix right now is fairly impossible. To ensure we still
 			// testing against the right version though, we are going to hard
 			// code this.
-			ResolveVersion: staticVersionResolver("v0.53.2"),
+			ResolveVersion: staticVersionResolver("v0.53.3"),
 			ResolveURL: func(version string) (string, error) {
 				const URL = "https://github.com/tektoncd/pipeline/releases/download/%s/release.yaml"
 				return fmt.Sprintf(URL, version), nil


### PR DESCRIPTION
## Proposed Changes

* Updated Tekton Pipelines dependency to the newest patch for current LTS version - v0.53.3

## Release Notes

Changed version of Tekton Pipelines dependency

