### PR TITLE
Increased source package size limit to 3 GB

### DIFF
--- a/pkg/apis/kf/v1alpha1/source_package_validation.go
+++ b/pkg/apis/kf/v1alpha1/source_package_validation.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	minUploadSizeBytes = 1
-	maxUploadSizeBytes = 1 * 1024 * 1024 * 1024
+	maxUploadSizeBytes = 3 * 1024 * 1024 * 1024
 )
 
 // Validate checks for errors in the SourcePackage's spec or status fields.


### PR DESCRIPTION
## Proposed Changes
* Increase size limit for SourcePackage from 1 to 3 GB
## Release Notes
Changed size limit for SourcePackage from 1 to 3 GB
