### PR TITLE
Upgraded Golang version and unpinned CloudSDK image for integration tests

### DIFF
--- a/ci/cloudbuild/release-and-test.yaml
+++ b/ci/cloudbuild/release-and-test.yaml
@@ -24,7 +24,7 @@ options:
   machineType: "N1_HIGHCPU_8"
 
 substitutions:
-  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:417.0.1-alpine"
+  _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
   _RELEASE_BUCKET: ""
   _EXPORT_BUCKET: ""
   _EXPORT_JOB_NAME: ""

--- a/ci/cloudbuild/test.yaml
+++ b/ci/cloudbuild/test.yaml
@@ -103,7 +103,7 @@ substitutions:
 
   _KO_IMAGE: 'gcr.io/kf-releases/ko:latest'
   _CLOUDSDK_IMAGE: "gcr.io/google.com/cloudsdktool/cloud-sdk:alpine"
-  _GOLANG_IMAGE: 'golang:1.20'
+  _GOLANG_IMAGE: 'golang:1.22'
 
 steps:
 - id: check substitutions

--- a/ci/cloudbuild/unit-test.yaml
+++ b/ci/cloudbuild/unit-test.yaml
@@ -24,7 +24,7 @@ timeout: 7200s
 options:
   machineType: "E2_HIGHCPU_8"
 substitutions:
-  _GOLANG_IMAGE: "golang:1.20"
+  _GOLANG_IMAGE: "golang:1.22"
 
 steps:
   - id: verify build

--- a/cmd/generate-release/cloudbuild.yaml
+++ b/cmd/generate-release/cloudbuild.yaml
@@ -31,7 +31,7 @@ substitutions:
   _RELEASE_BUCKET: '' # Required
   _RELEASE_FOLDER: '' # Defaults to _VERSION
   _CLOUDSDK_IMAGE: 'gcr.io/google.com/cloudsdktool/cloud-sdk:alpine'
-  _GOLANG_IMAGE: 'golang:1.20'
+  _GOLANG_IMAGE: 'golang:1.22'
   _BUILDPACK_WRAPPER_GOLANG_IMAGE: 'golang:1.15'
   _KO_VERSION: 'github.com/google/ko@latest'
 

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.appstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.appstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.buildstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.buildstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.commonservicebrokerstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.commonservicebrokerstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.routestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.routestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancebindingstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancebindingstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.serviceinstancestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.sourcepackagestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.sourcepackagestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.spacestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.spacestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskschedulestatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskschedulestatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskstatus.go
+++ b/pkg/apis/kf/v1alpha1/zz_generated.conditions.taskstatus.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/apps/push_options.go
+++ b/pkg/kf/apps/push_options.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/apps/zz_generated.client.go
+++ b/pkg/kf/apps/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/builds/zz_generated.client.go
+++ b/pkg/kf/builds/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/configmaps/zz_generated.client.go
+++ b/pkg/kf/configmaps/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/internal/genericcli/zz_generated_options.go
+++ b/pkg/kf/internal/genericcli/zz_generated_options.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
+++ b/pkg/kf/internal/tools/clientgen/gentest/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/logs/options.go
+++ b/pkg/kf/logs/options.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/networkpolicies/zz_generated.client.go
+++ b/pkg/kf/networkpolicies/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/routes/zz_generated.client.go
+++ b/pkg/kf/routes/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/secrets/zz_generated.client.go
+++ b/pkg/kf/secrets/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/service-brokers/cluster/zz_generated.client.go
+++ b/pkg/kf/service-brokers/cluster/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/service-brokers/namespaced/zz_generated.client.go
+++ b/pkg/kf/service-brokers/namespaced/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/serviceinstancebindings/zz_generated.client.go
+++ b/pkg/kf/serviceinstancebindings/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/serviceinstances/zz_generated.client.go
+++ b/pkg/kf/serviceinstances/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/sourcepackages/zz_generated.client.go
+++ b/pkg/kf/sourcepackages/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/spaces/zz_generated.client.go
+++ b/pkg/kf/spaces/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/kf/tasks/zz_generated.client.go
+++ b/pkg/kf/tasks/zz_generated.client.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reconciler/apiservercerts/zz_generated.fakelister.apiservice_test.go
+++ b/pkg/reconciler/apiservercerts/zz_generated.fakelister.apiservice_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/reconciler/apiservercerts/zz_generated.fakelister.secret_test.go
+++ b/pkg/reconciler/apiservercerts/zz_generated.fakelister.secret_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2024 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION

## Proposed Changes

* Change GoLang version to 1.22 - to match the version required by Ko
* Unpin Cloud SDK image - to allow it to pick upgrades to Cloud SDK


## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
Changed GoLang version used for building and testing the software to 1.22
Changed version selection for Cloud SDK Docker image (unpinning)
```
