### PR TITLE
Set version of php-buildpack to v4.6.23 to address git clone error in run-lifecycle task

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -219,7 +219,7 @@ data:
     - name: python_buildpack
       url: https://github.com/cloudfoundry/python-buildpack
     - name: php_buildpack
-      url: https://github.com/cloudfoundry/php-buildpack
+      url: https://github.com/cloudfoundry/php-buildpack/#v4.6.23
     - name: binary_buildpack
       url: https://github.com/cloudfoundry/binary-buildpack
     - name: nginx_buildpack


### PR DESCRIPTION
## Release Notes

```release-note
Changed version of php-buildpack used from latest to v4.6.23 as a workaround to github.com/cloudfoundry/php-buildpack/issues/1110
```
