### PR TITLE
Pinning go-buildpack version to avoid https://github.com/cloudfoundry…

### DIFF
--- a/config/config-defaults.yaml
+++ b/config/config-defaults.yaml
@@ -215,7 +215,7 @@ data:
     - name: nodejs_buildpack
       url: https://github.com/cloudfoundry/nodejs-buildpack
     - name: go_buildpack
-      url: https://github.com/cloudfoundry/go-buildpack
+      url: https://github.com/cloudfoundry/go-buildpack/#v1.10.42
     - name: python_buildpack
       url: https://github.com/cloudfoundry/python-buildpack
     - name: php_buildpack


### PR DESCRIPTION

<!-- Include the issue number below -->
Workaround for […/go-buildpack/issues/556](https://github.com/cloudfoundry/go-buildpack/issues/556)

## Proposed Changes
* Temporarily use fixed version of go-buildpack instead of the latest one.
