### PR TITLE
Ignore SysctlChanged condition when using `kf doctor`

### DIFF
--- a/pkg/kf/doctor/cluster.go
+++ b/pkg/kf/doctor/cluster.go
@@ -422,6 +422,11 @@ func diagnoseDaemonSets(ctx context.Context, d *Diagnostic, kubernetes kubernete
 	}
 }
 
+func conditionShouldBeIgnored(condition corev1.NodeCondition) bool {
+	shouldIgnore := condition.Type == "SysctlChanged" && condition.Status != corev1.ConditionFalse && condition.Message == "{\"unmanaged\": {\"kernel.cad_pid\": \"1\"}}"
+	return shouldIgnore
+}
+
 func diagnoseNodes(ctx context.Context, d *Diagnostic, kubernetes kubernetes.Interface) {
 	nodesList, err := kubernetes.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	switch {
@@ -500,21 +505,10 @@ func diagnoseNodes(ctx context.Context, d *Diagnostic, kubernetes kubernetes.Int
 									cond.Message,
 								)
 							}
-						case cond.Type == "SysctlChanged":
-							if cond.Status != corev1.ConditionFalse {
-								if cond.Message != "{\"unmanaged\": {\"kernel.cad_pid\": \"1\"}}" {
-									d.Errorf(
-										"Condition %s is not healthy, current status is %q with message %q",
-										cond.Type,
-										cond.Status,
-										cond.Message,
-									)
-								}
-							}
 						default:
-							// Other conditions on the node should be false because they
-							// indicate specific failure conditions when set to true.
-							if cond.Status != corev1.ConditionFalse {
+							// Other conditions on the node should be false (unless known issue)
+							// because they indicate specific failure conditions when set to true.
+							if cond.Status != corev1.ConditionFalse && !conditionShouldBeIgnored(cond) {
 								d.Errorf(
 									"Condition %s is not healthy, current status is %q with message %q",
 									cond.Type,

--- a/pkg/kf/doctor/cluster.go
+++ b/pkg/kf/doctor/cluster.go
@@ -500,6 +500,17 @@ func diagnoseNodes(ctx context.Context, d *Diagnostic, kubernetes kubernetes.Int
 									cond.Message,
 								)
 							}
+						case cond.Type == "SysctlChanged":
+							if cond.Status != corev1.ConditionFalse {
+								if cond.Message != "{\"unmanaged\": {\"kernel.cad_pid\": \"1\"}}" {
+									d.Errorf(
+										"Condition %s is not healthy, current status is %q with message %q",
+										cond.Type,
+										cond.Status,
+										cond.Message,
+									)
+								}
+							}
 						default:
 							// Other conditions on the node should be false because they
 							// indicate specific failure conditions when set to true.


### PR DESCRIPTION
<!-- Include the issue number below -->

## Fixes

Current pipelines that fail for no reason, see #1105 

## Proposed Changes

* Fixes `kf doctor` reporting status `FAIL` when diagnosing perfectly fine nodes by ignoring specific `SysctlChanged` condition.

## Release Notes

<!-- kf follows the Keep A Changelog standard for release notes.

https://keepachangelog.com/en/1.0.0/

Changelog entries should be one per line and start with one of the following
words:

`Added` for new features.
`Changed` for changes in existing functionality.
`Deprecated` for soon-to-be removed features.
`Removed` for now removed features.
`Fixed` for any bug fixes.
`Security` in case of vulnerabilities.

If one of the changes is breaking include that as a second word e.g.

  Removed BREAKING support for manifests v1
-->

```release-note
`Fixed` `kf doctor` reporting FAIL on node conditions despite node being healthly
```
