### PR TITLE
Do not include binaries in third_party image - just source code

### DIFF
--- a/cmd/generate-release/cloudbuild.yaml
+++ b/cmd/generate-release/cloudbuild.yaml
@@ -138,6 +138,8 @@ steps:
     for TAG in "$${TAGS[@]}"; do
       IMAGES+=("-t" "gcr.io/${PROJECT_ID}/kf-thirdparty:$${TAG}")
     done
+    
+    echo "third_party/forked/v2-buildpack-lifecycle/installer/kodata" > .dockerignore
     docker build \
       -f ./cmd/generate-release/scripts/Dockerfile.thirdparty \
       "$${IMAGES[@]}" .

--- a/cmd/generate-release/cloudbuild.yaml
+++ b/cmd/generate-release/cloudbuild.yaml
@@ -98,6 +98,8 @@ steps:
 
     GIT_SHA="$(</workspace/substitutions/git_sha)"
 
+    echo "Cleaning workspace..."
+    git clean -fd -e "substitutions/" -e "build-log.txt"
     echo "Checking out $${GIT_SHA}..."
     git checkout "$${GIT_SHA}"
 
@@ -138,8 +140,6 @@ steps:
     for TAG in "$${TAGS[@]}"; do
       IMAGES+=("-t" "gcr.io/${PROJECT_ID}/kf-thirdparty:$${TAG}")
     done
-    
-    echo "third_party/forked/v2-buildpack-lifecycle/installer/kodata" > .dockerignore
     docker build \
       -f ./cmd/generate-release/scripts/Dockerfile.thirdparty \
       "$${IMAGES[@]}" .


### PR DESCRIPTION
## Proposed Changes

* `Changed` `kf_thirdparty` container image no longer contains `kodata` folder for installer. This image is used as a base image for all Kf components.
