### PR TITLE
Make kf doctor recognize arm64 K8s platform as valid

### DIFF
--- a/pkg/kf/doctor/cluster.go
+++ b/pkg/kf/doctor/cluster.go
@@ -105,7 +105,7 @@ func diagnoseKubernetesVersion(ctx context.Context, d *Diagnostic, vc discovery.
 
 	testutil.AssertNil(d, "server version error", err)
 	testutil.AssertEqual(d, "major version", "1", k8sVersion.Major)
-	testutil.AssertEqual(d, "platform", "linux/amd64", k8sVersion.Platform)
+	testutil.AssertRegexp(d, "platform", "^linux/(amd64|arm64)$", k8sVersion.Platform)
 }
 
 // diagnoseComponents checks that the Kubernetes instance has all


### PR DESCRIPTION
<!-- Include the issue number below -->
## Proposed Changes
* `kf doctor` should not report a failure if GKE platform string includes arm64. `amd64` and `arm64` are acceptable values.
